### PR TITLE
Fix nextjs error for viewport metatag

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -13,6 +13,7 @@ function MyApp({ Component, pageProps }: AppProps) {
   return (
     <>
       <Head>
+        <meta name="viewport" content="initial-scale=1.0, width=device-width" />
         <title key="title">{metaTags.title}</title>
         <meta
           name="description"

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -24,10 +24,6 @@ class MyDocument extends Document {
           />
           <link rel="manifest" href="/site.webmanifest" />
           <meta name="theme-color" content="#200133" />
-          <meta
-            name="viewport"
-            content="initial-scale=1.0, width=device-width"
-          />
           <script
             async
             src={`https://www.googletagmanager.com/gtag/js?id=${process.env.NEXT_PUBLIC_GA_ID}`}


### PR DESCRIPTION
I moved this last night, apparently not the correct place to put it

![image](https://user-images.githubusercontent.com/1582152/139195028-b9bdad26-d15b-4cf8-9570-a236ab9e0259.png)

https://nextjs.org/docs/messages/no-document-viewport-meta