### PR TITLE
Moves globals.css -> globals.scss & updates @tailwind directives

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,6 @@
 import type { AppProps } from "next/app";
 import Head from "next/head";
-import "../styles/globals.css";
+import "../styles/globals.scss";
 import "../styles/main.scss";
 
 const metaTags = {

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -1,6 +1,6 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss/base";
+@import "tailwindcss/components";
+@import "tailwindcss/utilities";
 
 * {
   -webkit-tap-highlight-color: transparent;
@@ -9,6 +9,7 @@
 body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  font-family: Rubik, Helvetica, Arial, sans-serif;
 }
 
 @keyframes fade-in {

--- a/styles/main.scss
+++ b/styles/main.scss
@@ -3,7 +3,6 @@
 
 body {
   background: var(--background-tint-2);
-  font-family: "Rubik", Helvetica, Arial, sans-serif;
 }
 
 .background-shape {


### PR DESCRIPTION
Because we actually use a setup that allows the @import syntax, we can make globals scss & avoid pesky IDE errors

While there, I've moved font definition to globals - seems to fit there more correctly