### PR TITLE
Refactor styles - allowing us to import files where needed

### DIFF
--- a/app/components/DosesDescriptionList/DosesDescriptionList.module.scss
+++ b/app/components/DosesDescriptionList/DosesDescriptionList.module.scss
@@ -1,3 +1,5 @@
+@import "../../styles/vars.scss";
+
 .description-definition {
   display: flex;
   flex-direction: row;
@@ -31,7 +33,7 @@
   justify-content: center;
   color: var(--progress-complete);
   background: var(--complete-background);
-  border-radius: 99999px;
+  border-radius: $radius-full;
   margin-right: 0.5rem;
 
   & svg {

--- a/app/styles/animations.scss
+++ b/app/styles/animations.scss
@@ -1,19 +1,3 @@
-@import "tailwindcss/base";
-@import "tailwindcss/components";
-@import "tailwindcss/utilities";
-
-@import "animations";
-
-* {
-  -webkit-tap-highlight-color: transparent;
-}
-
-body {
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  font-family: Rubik, Helvetica, Arial, sans-serif;
-}
-
 @keyframes fade-in {
   0% {
     opacity: 0%;

--- a/app/styles/colors.scss
+++ b/app/styles/colors.scss
@@ -46,37 +46,3 @@ $dark--background-tint-1: $purple-xdark;
 $dark--background-tint-2: $purple-dark;
 $dark--dark-mode-toggle: $white-95;
 $dark--dark-mode-toggle-hover: $purple-base;
-
-:root {
-  --text-primary: #{$dark--text-primary};
-  --text-secondary: #{$dark--text-secondary};
-  --text-positive: #{$dark--text-positive};
-  --progress-goal: #{$dark--progress-goal};
-  --progress-complete: #{$dark--progress-complete};
-  --progress--total: #{$dark--progress--total};
-  --progress--first: #{$dark--progress--first};
-  --progress--second: #{$dark--progress--second};
-  --complete-background: #{$dark--complete-background};
-  --background-base: #{$dark--background-base};
-  --background-tint-1: #{$dark--background-tint-1};
-  --background-tint-2: #{$dark--background-tint-2};
-  --dark-mode-toggle: #{$dark--dark-mode-toggle};
-  --dark-mode-toggle-hover: #{$dark--dark-mode-toggle-hover};
-}
-
-.light {
-  --text-primary: #{$light--text-primary};
-  --text-secondary: #{$light--text-secondary};
-  --text-positive: #{$light--text-positive};
-  --progress-goal: #{$light--progress--goal};
-  --progress-complete: #{$light--progress--complete};
-  --progress--total: #{$light--progress--total};
-  --progress--first: #{$light--progress--first};
-  --progress--second: #{$light--progress--second};
-  --complete-background: #{$light--complete--background};
-  --background-base: #{$light--background--base};
-  --background-tint-1: #{$light--background--tint-1};
-  --background-tint-2: #{$light--background--tint-2};
-  --dark-mode-toggle: #{$light--dark-mode-toggle};
-  --dark-mode-toggle-hover: #{$light--dark-mode-toggle-hover};
-}

--- a/app/styles/globals.scss
+++ b/app/styles/globals.scss
@@ -2,7 +2,12 @@
 @import "tailwindcss/components";
 @import "tailwindcss/utilities";
 
+@import "colors";
+@import "styles";
 @import "animations";
+
+// Font
+@import url("https://fonts.googleapis.com/css2?family=Rubik:wght@300;400;500;700&display=swap");
 
 * {
   -webkit-tap-highlight-color: transparent;
@@ -12,36 +17,54 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-family: Rubik, Helvetica, Arial, sans-serif;
+  background: var(--background-tint-2);
 }
 
-@keyframes fade-in {
-  0% {
-    opacity: 0%;
-  }
-  100% {
-    opacity: 100%;
-  }
+.background-shape {
+  position: absolute;
+  z-index: -1;
+  width: 100%;
+  height: 80vh;
+  background-color: var(--background-base);
+  clip-path: ellipse(85% 100% at 50% 0%);
 }
 
-@keyframes grow-width {
-  0% {
-    opacity: 0%;
-    width: 0%;
-  }
-  30% {
-    opacity: 100%;
-  }
-  100% {
-    opacity: 100%;
-    width: 100%;
-  }
+.container-data {
+  background: var(--background-tint-1);
 }
 
-.animate-fade-in {
-  animation: fade-in 0.3s ease-in-out forwards;
+// Themes
+
+:root {
+  --text-primary: #{$dark--text-primary};
+  --text-secondary: #{$dark--text-secondary};
+  --text-positive: #{$dark--text-positive};
+  --progress-goal: #{$dark--progress-goal};
+  --progress-complete: #{$dark--progress-complete};
+  --progress--total: #{$dark--progress--total};
+  --progress--first: #{$dark--progress--first};
+  --progress--second: #{$dark--progress--second};
+  --complete-background: #{$dark--complete-background};
+  --background-base: #{$dark--background-base};
+  --background-tint-1: #{$dark--background-tint-1};
+  --background-tint-2: #{$dark--background-tint-2};
+  --dark-mode-toggle: #{$dark--dark-mode-toggle};
+  --dark-mode-toggle-hover: #{$dark--dark-mode-toggle-hover};
 }
 
-.animate-grow-width {
-  opacity: 0%;
-  animation: grow-width 1s ease-in-out 0.5s forwards;
+.light {
+  --text-primary: #{$light--text-primary};
+  --text-secondary: #{$light--text-secondary};
+  --text-positive: #{$light--text-positive};
+  --progress-goal: #{$light--progress--goal};
+  --progress-complete: #{$light--progress--complete};
+  --progress--total: #{$light--progress--total};
+  --progress--first: #{$light--progress--first};
+  --progress--second: #{$light--progress--second};
+  --complete-background: #{$light--complete--background};
+  --background-base: #{$light--background--base};
+  --background-tint-1: #{$light--background--tint-1};
+  --background-tint-2: #{$light--background--tint-2};
+  --dark-mode-toggle: #{$light--dark-mode-toggle};
+  --dark-mode-toggle-hover: #{$light--dark-mode-toggle-hover};
 }

--- a/app/styles/globals.scss
+++ b/app/styles/globals.scss
@@ -3,7 +3,7 @@
 @import "tailwindcss/utilities";
 
 @import "colors";
-@import "styles";
+@import "typography";
 @import "animations";
 
 // Font

--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -1,52 +1,6 @@
 @import "colors";
 @import "styles";
 
-body {
-  background: var(--background-tint-2);
-}
-
-.background-shape {
-  position: absolute;
-  z-index: -1;
-  width: 100%;
-  height: 80vh;
-  background-color: var(--background-base);
-  clip-path: ellipse(85% 100% at 50% 0%);
-}
-
-.container-data {
-  background: var(--background-tint-1);
-}
-
-.heading-1 {
-  @include h1;
-  color: var(--text-primary);
-}
-
-.heading-2 {
-  @include h2;
-  color: var(--text-primary);
-}
-
-.heading-3 {
-  @include h3;
-  color: var(--text-primary);
-}
-
-.data-text {
-  @include h4;
-  color: var(--text-secondary);
-}
-
-.footnote {
-  @include footnote;
-  color: var(--text-secondary);
-}
-
-.data-text-complete {
-  color: var(--text-positive);
-}
-
 // Progress bars
 
 .progress-bar {

--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -1,5 +1,5 @@
 @import "colors";
-@import "styles";
+@import "vars";
 
 // Progress bars
 

--- a/app/styles/styles.scss
+++ b/app/styles/styles.scss
@@ -1,6 +1,3 @@
-// Font
-@import url("https://fonts.googleapis.com/css2?family=Rubik:wght@300;400;500;700&display=swap");
-
 // Radius
 
 $radius: 4px;
@@ -34,4 +31,33 @@ $radius-full: 9999px;
   font-size: 0.875rem;
   line-height: 1.25rem;
   font-weight: 400;
+}
+
+.heading-1 {
+  @include h1;
+  color: var(--text-primary);
+}
+
+.heading-2 {
+  @include h2;
+  color: var(--text-primary);
+}
+
+.heading-3 {
+  @include h3;
+  color: var(--text-primary);
+}
+
+.data-text {
+  @include h4;
+  color: var(--text-secondary);
+}
+
+.footnote {
+  @include footnote;
+  color: var(--text-secondary);
+}
+
+.data-text-complete {
+  color: var(--text-positive);
 }

--- a/app/styles/typography.scss
+++ b/app/styles/typography.scss
@@ -1,9 +1,3 @@
-// Radius
-
-$radius: 4px;
-$radius-large: 8px;
-$radius-full: 9999px;
-
 // Typography
 
 @mixin h1 {

--- a/app/styles/vars.scss
+++ b/app/styles/vars.scss
@@ -1,0 +1,5 @@
+// Radius
+
+$radius: 4px;
+$radius-large: 8px;
+$radius-full: 9999px;


### PR DESCRIPTION
## Motivation

Since we're using css modules, we don't _really_ need so many different "main" css files. This PR removes those files and makes them more generic.

## Changes

1. Extracts animations to their own file. Not sure if these should just live with Progress bar?
2. Moves theming (light & dark) to globals
3. Moves font import to globals
4. `main.scss` - this is pretty much all progress bar stuff now will move in next PR
5. Renames styles -> typography (contains all heading & text classnames)
6. Creates a vars file to have basic variables radius for now - could have spacing in here too?
7. Updates all imports to come through globals