### PR TITLE
Adds space x & y - uses in doses description list

### DIFF
--- a/app/components/DosesDescriptionList/DosesDescriptionList.module.scss
+++ b/app/components/DosesDescriptionList/DosesDescriptionList.module.scss
@@ -34,7 +34,6 @@
   color: var(--progress-complete);
   background: var(--complete-background);
   border-radius: $radius-full;
-  margin-right: 0.5rem;
 
   & svg {
     width: 0.875rem;

--- a/app/components/DosesDescriptionList/DosesDescriptionList.tsx
+++ b/app/components/DosesDescriptionList/DosesDescriptionList.tsx
@@ -23,7 +23,7 @@ export const DosesDescription = ({
   children = null,
 }: DosesDescriptionProps) => (
   <div className={styles["description-definition"]}>
-    <dt className={styles["term"]}>
+    <dt className={cx(styles["term"], "space-x-xs")}>
       {hasMetTarget && (
         <div className={styles["check"]}>
           <CheckIcon />

--- a/app/components/Progress/Progress.module.scss
+++ b/app/components/Progress/Progress.module.scss
@@ -13,17 +13,17 @@
 }
 
 .progress-total-xsmall {
-  height: 0.75rem;
+  height: $space-s;
   border-radius: $radius;
 }
 
 .progress-total-small {
-  height: 1.5rem;
+  height: $space-xl;
   border-radius: $radius;
 }
 
 .progress-total-large {
-  height: 2.5rem;
+  height: $space-3xl;
   border-radius: $radius-large;
 }
 

--- a/app/styles/spacing.scss
+++ b/app/styles/spacing.scss
@@ -72,4 +72,16 @@ $space-map: (
   .width-#{$size} {
     width: $space;
   }
+
+  // Space
+  .space-y-#{$size} {
+    & > :not([hidden]) ~ :not([hidden]) {
+      margin-top: $space;
+    }
+  }
+  .space-x-#{$size} {
+    & > :not([hidden]) ~ :not([hidden]) {
+      margin-left: $space;
+    }
+  }
 }


### PR DESCRIPTION
Adds `space-x-` - still not sure on naming :( `gap` seems perfect, but gap is already a css property (for grid) and I don't want to overload that meaning. Some other chandidates:

- `child-space-` or `child-gap-`
- `slot-`
- `spread-`

I kind of like "spread" actually 