### PR TITLE
Adds a resets scss file - imports in globals

### DIFF
--- a/app/styles/globals.scss
+++ b/app/styles/globals.scss
@@ -2,6 +2,8 @@
 @import "tailwindcss/components";
 @import "tailwindcss/utilities";
 
+@import "resets";
+
 @import "vars";
 @import "colors";
 @import "typography";

--- a/app/styles/resets.scss
+++ b/app/styles/resets.scss
@@ -1,0 +1,85 @@
+body,
+blockquote,
+dl,
+dd,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+hr,
+figure,
+p,
+pre {
+  margin: 0;
+}
+
+ol,
+ul {
+  margin: 0;
+  padding: 0;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-size: inherit;
+  font-weight: inherit;
+}
+
+*,
+::before,
+::after {
+  border-width: 0;
+  border-style: solid;
+}
+
+button,
+input,
+optgroup,
+select,
+textarea {
+  font-family: inherit;
+  font-size: 100%;
+  line-height: 1.15;
+  margin: 0;
+  padding: 0;
+  line-height: inherit;
+  color: inherit;
+}
+
+button,
+select {
+  text-transform: none;
+}
+
+button {
+  background-color: transparent;
+  background-image: none;
+}
+
+[type="button"],
+[type="reset"],
+[type="submit"],
+button {
+  -webkit-appearance: button;
+}
+
+[role="button"],
+button,
+a {
+  cursor: pointer;
+}
+
+a {
+  color: inherit;
+  text-decoration: inherit;
+}
+
+[hidden] {
+  display: none;
+}


### PR DESCRIPTION
Tailwind applies css resets to remove default browser styling - when we remove tailwind, we'll need to remove the resets too 🙏 I took a look at their resets and pulled some of the ones we'll need off the bat.

Question: This is pretty common (we do it at work etc) - are there any resets I've missed / any you wouldn't have in here?