### PR TITLE
Allowing fetchy to be trigger by a repo dispatch event

### DIFF
--- a/.github/workflows/fetchy.yml
+++ b/.github/workflows/fetchy.yml
@@ -1,19 +1,18 @@
 name: Run Fetchy Fetch Boi
 on:
+  # will be removed soon
   schedule:
     # This will run fetchy every 5 mins with an offset of 3 min
     - cron: "3-59/5 * * * *"
   pull_request:
-  push:
-    branches:
-      - main
+  repository_dispatch:
   workflow_dispatch:
     branches:
       - main
 
 jobs:
   fetchy:
-    name: Run
+    name: Run Fetchy
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -32,7 +31,7 @@ jobs:
       - name: Run Fetchy
         run: npm run fetch-boi
       - uses: EndBug/add-and-commit@v7
-        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch'
         with:
           default_author: github_actions
           message: "Adding/Updating the latest MoH Data"


### PR DESCRIPTION
Adding in this new event for when we want to create an endpoint in netlify to trigger this workflow
![image](https://user-images.githubusercontent.com/5621207/139564579-487683e8-dbf0-4c73-8e5a-bafd8c688bce.png)


Also removed the push event since we don't really need it to run once its been merged into the main branch. It would have gone through a PR already. (also when I use the github API to check when the last run was, I don't want the push events included so this would remove them)


P.S. Promise this is the last rename of the fetchy workflow