### PR TITLE
Replaces 'a' with 'ā' in Tairāwhiti

### DIFF
--- a/app/utilities/dhbDisplayName.ts
+++ b/app/utilities/dhbDisplayName.ts
@@ -13,7 +13,7 @@ const nameMap: Record<string, string> = {
   Northland: "Northland",
   "South Canterbury": "South Canterbury",
   Southern: "Southern",
-  Tairawhiti: "Tairawhiti",
+  Tairawhiti: "Tairāwhiti",
   Taranaki: "Taranaki",
   Waikato: "Waikato",
   Wairarapa: "Wairarapa",


### PR DESCRIPTION
As per request from Gareth Cronin