### PR TITLE
Adds specific text style mixins

### DIFF
--- a/app/components/DosesDescriptionList/DosesDescriptionList.module.scss
+++ b/app/components/DosesDescriptionList/DosesDescriptionList.module.scss
@@ -1,4 +1,5 @@
 @import "../../styles/vars.scss";
+@import "../../styles/typography.scss";
 
 .description-definition {
   display: flex;
@@ -8,6 +9,7 @@
 }
 
 .term {
+  @include dose-label;
   width: 7rem;
   display: flex;
   flex-direction: row;
@@ -16,6 +18,7 @@
 }
 
 .definition-primary {
+  @include percentage-label;
   width: 2rem;
   text-align: right;
 }

--- a/app/components/DosesDescriptionList/DosesDescriptionList.module.scss
+++ b/app/components/DosesDescriptionList/DosesDescriptionList.module.scss
@@ -56,7 +56,7 @@
     line-height: 1rem; // 16px
   }
 }
-.percentage-label {
+.percentage-value {
   font-size: 1.125rem; // 18px
   line-height: 1.5rem; // 24px
   font-weight: 500;

--- a/app/components/DosesDescriptionList/DosesDescriptionList.module.scss
+++ b/app/components/DosesDescriptionList/DosesDescriptionList.module.scss
@@ -1,5 +1,4 @@
 @import "../../styles/vars.scss";
-@import "../../styles/typography.scss";
 
 .description-definition {
   display: flex;
@@ -9,7 +8,6 @@
 }
 
 .term {
-  @include dose-label;
   width: 7rem;
   display: flex;
   flex-direction: row;
@@ -18,7 +16,6 @@
 }
 
 .definition-primary {
-  @include percentage-label;
   width: 2rem;
   text-align: right;
 }
@@ -36,5 +33,44 @@
   & svg {
     width: $space-s;
     height: $space-s;
+  }
+}
+
+.card-title {
+  font-size: 1.125rem; // 18px
+  line-height: 1.5rem; // 24px
+  font-weight: 500;
+  @media (min-width: $breakpoint-s) {
+    font-size: 1.25rem; // 20px
+    line-height: 1.625rem; // 26px
+  }
+}
+.dose-label {
+  font-size: 0.625rem; // 10px
+  line-height: 0.875rem; // 14px
+  font-weight: 400;
+  text-transform: uppercase;
+  letter-spacing: 0.05rem;
+  @media (min-width: $breakpoint-s) {
+    font-size: 0.75rem; // 12px
+    line-height: 1rem; // 16px
+  }
+}
+.percentage-label {
+  font-size: 1.125rem; // 18px
+  line-height: 1.5rem; // 24px
+  font-weight: 500;
+  @media (min-width: $breakpoint-s) {
+    font-size: 1.25rem; // 20px
+    line-height: 1.75rem; // 28px
+  }
+}
+.vaccine-count {
+  font-size: 0.75rem; // 12px
+  line-height: 1rem; // 16px
+  font-weight: 400;
+  @media (min-width: $breakpoint-s) {
+    font-size: 0.875rem; // 14px
+    line-height: 1.125rem; // 18px
   }
 }

--- a/app/styles/typography.scss
+++ b/app/styles/typography.scss
@@ -101,7 +101,6 @@
 }
 
 .data-text {
-  // @include h4;
   color: var(--text-secondary);
 }
 

--- a/app/styles/typography.scss
+++ b/app/styles/typography.scss
@@ -34,45 +34,6 @@
   font-weight: 500;
 }
 
-@mixin card-title {
-  font-size: 1.125rem; // 18px
-  line-height: 1.5rem; // 24px
-  font-weight: 500;
-  @media (min-width: $breakpoint-s) {
-    font-size: 1.25rem; // 20px
-    line-height: 1.625rem; // 26px
-  }
-}
-@mixin dose-label {
-  font-size: 0.625rem; // 10px
-  line-height: 0.875rem; // 14px
-  font-weight: 400;
-  text-transform: uppercase;
-  letter-spacing: 0.05rem;
-  @media (min-width: $breakpoint-s) {
-    font-size: 0.75rem; // 12px
-    line-height: 1rem; // 16px
-  }
-}
-@mixin percentage-label {
-  font-size: 1.125rem; // 18px
-  line-height: 1.5rem; // 24px
-  font-weight: 500;
-  @media (min-width: $breakpoint-s) {
-    font-size: 1.25rem; // 20px
-    line-height: 1.75rem; // 28px
-  }
-}
-@mixin vaccine-count {
-  font-size: 0.75rem; // 12px
-  line-height: 1rem; // 16px
-  font-weight: 400;
-  @media (min-width: $breakpoint-s) {
-    font-size: 0.875rem; // 14px
-    line-height: 1.125rem; // 18px
-  }
-}
-
 @mixin control {
   font-size: 1.25rem;
   line-height: 1.5rem;
@@ -101,6 +62,7 @@
 }
 
 .data-text {
+  @include h4;
   color: var(--text-secondary);
 }
 

--- a/app/styles/typography.scss
+++ b/app/styles/typography.scss
@@ -34,6 +34,45 @@
   font-weight: 500;
 }
 
+@mixin card-title {
+  font-size: 1.125rem; // 18px
+  line-height: 1.5rem; // 24px
+  font-weight: 500;
+  @media (min-width: $breakpoint-s) {
+    font-size: 1.25rem; // 20px
+    line-height: 1.625rem; // 26px
+  }
+}
+@mixin dose-label {
+  font-size: 0.625rem; // 10px
+  line-height: 0.875rem; // 14px
+  font-weight: 400;
+  text-transform: uppercase;
+  letter-spacing: 0.05rem;
+  @media (min-width: $breakpoint-s) {
+    font-size: 0.75rem; // 12px
+    line-height: 1rem; // 16px
+  }
+}
+@mixin percentage-label {
+  font-size: 1.125rem; // 18px
+  line-height: 1.5rem; // 24px
+  font-weight: 500;
+  @media (min-width: $breakpoint-s) {
+    font-size: 1.25rem; // 20px
+    line-height: 1.75rem; // 28px
+  }
+}
+@mixin vaccine-count {
+  font-size: 0.75rem; // 12px
+  line-height: 1rem; // 16px
+  font-weight: 400;
+  @media (min-width: $breakpoint-s) {
+    font-size: 0.875rem; // 14px
+    line-height: 1.125rem; // 18px
+  }
+}
+
 @mixin control {
   font-size: 1.25rem;
   line-height: 1.5rem;
@@ -62,7 +101,7 @@
 }
 
 .data-text {
-  @include h4;
+  // @include h4;
   color: var(--text-secondary);
 }
 


### PR DESCRIPTION
cc @andycarrell 

- Adds mixins for card text. Moved away from h3, h4 etc because it's not really following the structure properly anyways. 
- Swapped some styling over but realised that you're probably changing the structure quite a bit so happy to remove these changes from this PR

Could maybe even remove the h3 and h4 heading mixins if they aren't being used - Just keep h1 and h2?