### PR TITLE
Added older raw vaccine site data

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -19,3 +19,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# data html files
+data/rawSite/*

--- a/data/rawSite/2021-10-22.html
+++ b/data/rawSite/2021-10-22.html
@@ -1,0 +1,2510 @@
+
+<!DOCTYPE html>
+<html lang="en" dir="ltr" prefix="" class="no-js">
+<head><script src="//archive.org/includes/analytics.js?v=cf34f82" type="text/javascript"></script>
+<script type="text/javascript">window.addEventListener('DOMContentLoaded',function(){var v=archive_analytics.values;v.service='wb';v.server_name='wwwb-app211.us.archive.org';v.server_ms=249;archive_analytics.send_pageview({});});</script>
+<script type="text/javascript" src="/_static/js/bundle-playback.js?v=UfTkgsKx" charset="utf-8"></script>
+<script type="text/javascript" src="/_static/js/wombat.js?v=UHAOicsW" charset="utf-8"></script>
+<script type="text/javascript">
+  __wm.init("https://web.archive.org/web");
+  __wm.wombat("https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data","20211023081356","https://web.archive.org/","web","/_static/",
+	      "1634976836");
+</script>
+<link rel="stylesheet" type="text/css" href="/_static/css/banner-styles.css?v=omkqRugM" />
+<link rel="stylesheet" type="text/css" href="/_static/css/iconochive.css?v=qtvMKcIJ" />
+<!-- End Wayback Rewrite JS Include -->
+
+  <!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta name="format-detection" content="telephone=no"/>
+  <link rel="profile" href="http://www.w3.org/1999/xhtml/vocab"/>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+<link rel="shortcut icon" href="https://web.archive.org/web/20211023081356im_/https://www.health.govt.nz/sites/all/themes/mohpub_bootstrap/favicon.ico" type="image/vnd.microsoft.icon"/>
+<meta name="description" content="Dashboard of data and statistics about the rollout of COVID-19 vaccines in New Zealand"/>
+<meta name="generator" content="Drupal 7 (https://www.drupal.org)"/>
+<link rel="canonical" href="https://web.archive.org/web/20211023081356/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data"/>
+<link rel="shortlink" href="https://web.archive.org/web/20211023081356/https://www.health.govt.nz/node/12052"/>
+<meta property="og:site_name" content="Ministry of Health NZ"/>
+<meta property="og:type" content="article"/>
+<meta property="og:url" content="https://web.archive.org/web/20211023081356/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data"/>
+<meta property="og:title" content="COVID-19: Vaccine data"/>
+<meta property="og:description" content="Dashboard of data and statistics about the rollout of COVID-19 vaccines in New Zealand"/>
+  <title>COVID-19: Vaccine data | Ministry of Health NZ</title>
+  <link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211023081356cs_/https://www.health.govt.nz/sites/default/files/css/css_lQaZfjVpwP_oGNqdtWCSpJT1EMqXdMiU84ekLLxQnc4.css" media="all"/>
+<link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211023081356cs_/https://www.health.govt.nz/sites/default/files/css/css_jqUBpWfMaxMiP7LismdZVlyVv8azUJSE2yaH58nj0cE.css" media="all"/>
+<link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211023081356cs_/https://www.health.govt.nz/sites/default/files/css/css_Rb1wqFBC8VXCJC-BuNY53cvjjlj6UADGvqzo_f-1yN0.css" media="all"/>
+<link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211023081356cs_/https://www.health.govt.nz/sites/default/files/css/css_38_K1lHKg-98m4KKRfv57JBK0gvlKscexGt9MKoi0DE.css" media="all"/>
+<link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211023081356cs_/https://www.health.govt.nz/sites/default/files/css/css_r7NPyvpdYfAyZmk9zkK8OaFKEFj6er5ZJnam2H644DM.css" media="print"/>
+  <link rel="alternate stylesheet" type="text/css" href="/web/20211023081356cs_/https://www.health.govt.nz/sites/all/themes/mohpub_bootstrap/css/high-contrast.css" media="screen" title="High Contrast"/>
+  <script src="https://web.archive.org/web/20211023081356js_/https://www.health.govt.nz/sites/default/files/js/js_zS-CmNFGyegtLYJmqFRpxQvvQrfPIFrOMq_3T3C8sZE.js"></script>
+<script src="https://web.archive.org/web/20211023081356js_/https://www.health.govt.nz/sites/default/files/js/js_fNgZ4Okisfr70Q0yvAYsATgB0o_jD3-srhQQ-VHmlXE.js"></script>
+<script src="https://web.archive.org/web/20211023081356js_/https://www.health.govt.nz/sites/default/files/js/js_YAdPZfg12M1m7ROp3_gVJPS5sArqL0kYQgNRPoicvHE.js"></script>
+<script>(function(i,s,o,g,r,a,m){i["GoogleAnalyticsObject"]=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,"script","https://web.archive.org/web/20211023081356/https://www.google-analytics.com/analytics.js","ga");ga("create", "UA-3573389-24", {"cookieDomain":".www.health.govt.nz","siteSpeedSampleRate":15});ga("send", "pageview");</script>
+<script src="https://web.archive.org/web/20211023081356js_/https://www.health.govt.nz/sites/default/files/js/js_QAXZNPwLISRLHqyNpT4Vvr_iqD9foD6GTbEjlhIIjeo.js"></script>
+<script src="https://web.archive.org/web/20211023081356js_/https://www.health.govt.nz/sites/default/files/js/js_4VW9edmu3V8VjGJxFfXGAwkXeW2cJIa5h-6y7SgwVrk.js"></script>
+<script>    (function(h,o,t,j,a,r){
+        h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
+        h._hjSettings={hjid:930919,hjsv:6};
+        a=o.getElementsByTagName('head')[0];
+        r=o.createElement('script');r.async=1;
+        r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+        a.appendChild(r);
+    })(window,document,'https://web.archive.org/web/20211023081356/https://static.hotjar.com/c/hotjar-','.js?sv=');
+</script>
+<script>jQuery.extend(Drupal.settings, {"basePath":"\/","pathPrefix":"","ajaxPageState":{"theme":"mohpub_bootstrap","theme_token":"Lt8zcu4V3Ny6UZZ1-FGadvqvwO9NU0-5l08CA1iolNc","js":{"sites\/all\/modules\/custom\/table_d3chart\/js\/table_d3chart.js":1,"sites\/all\/modules\/custom\/moh_d3\/moh_d3.js":1,"sites\/all\/modules\/contrib\/jquery_update\/replace\/jquery\/1.7\/jquery.min.js":1,"misc\/jquery-extend-3.4.0.js":1,"misc\/jquery-html-prefilter-3.5.0-backport.js":1,"misc\/jquery.once.js":1,"misc\/drupal.js":1,"sites\/all\/modules\/contrib\/ckeditor_accordion\/js\/ckeditor-accordion.js":1,"sites\/all\/modules\/contrib\/extlink\/extlink.js":1,"modules\/field\/modules\/text\/text.js":1,"sites\/all\/modules\/contrib\/field_group\/field_group.js":1,"sites\/all\/modules\/contrib\/google_analytics\/googleanalytics.js":1,"0":1,"sites\/all\/libraries\/c3\/c3.js":1,"sites\/all\/libraries\/d3\/d3.min.js":1,"sites\/all\/modules\/contrib\/d3\/js\/d3.js":1,"sites\/all\/libraries\/d3.helpers\/d3.helpers.js":1,"sites\/all\/libraries\/d3.c3\/d3-c3.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/assets\/ios-fix.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/affix.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/alert.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/button.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/carousel.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/collapse.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/dropdown.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/modal.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/tooltip.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/popover.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/scrollspy.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/tab.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/transition.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/jquery.cookie.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/jquery.moh.announcement.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/svgeezy.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/fitvids.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/bootstrap-tabcollapse.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/jquery.scrollTo.min.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/script.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/jquery.google_analytics.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/bootstrap-accessibility.min.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/style-switcher.js":1,"1":1},"css":{"modules\/system\/system.base.css":1,"sites\/all\/modules\/contrib\/calendar\/css\/calendar_multiday.css":1,"sites\/all\/modules\/contrib\/ckeditor_accordion\/css\/ckeditor-accordion.css":1,"modules\/field\/theme\/field.css":1,"modules\/node\/node.css":1,"sites\/all\/modules\/contrib\/extlink\/extlink.css":1,"sites\/all\/modules\/contrib\/views\/css\/views.css":1,"sites\/all\/modules\/contrib\/ckeditor\/css\/ckeditor.css":1,"sites\/all\/modules\/contrib\/ctools\/css\/ctools.css":1,"sites\/all\/modules\/contrib\/panels\/css\/panels.css":1,"sites\/all\/libraries\/c3\/c3.css":1,"sites\/all\/libraries\/d3.c3\/d3-c3.css":1,"sites\/all\/themes\/mohpub_bootstrap\/fontawesome\/css\/fontawesome.min.css":1,"sites\/all\/themes\/mohpub_bootstrap\/fontawesome\/css\/solid.min.css":1,"sites\/all\/themes\/mohpub_bootstrap\/fontawesome\/css\/brands.min.css":1,"sites\/all\/modules\/features\/site_profile\/css\/fix-rubik-multiselect-height.css":1,"sites\/all\/themes\/mohpub_bootstrap\/css\/style.css":1,"sites\/all\/themes\/mohpub_bootstrap\/css\/responsive-tables.css":1,"sites\/all\/themes\/mohpub_bootstrap\/css\/print.css":1}},"field_group":{"div":"full"},"ckeditor_accordion":{"collapseAll":1},"extlink":{"extTarget":0,"extClass":"ext","extLabel":"(link is external)","extImgClass":0,"extIconPlacement":"append","extSubdomains":0,"extExclude":"","extInclude":"","extCssExclude":"","extCssExplicit":"","extAlert":0,"extAlertText":"This link will take you to an external web site. We are not responsible for their content.","mailtoClass":"mailto","mailtoLabel":"(link sends e-mail)"},"googleanalytics":{"trackOutbound":1,"trackMailto":1,"trackDownload":1,"trackDownloadExtensions":"7z|aac|arc|arj|asf|asx|avi|bin|csv|doc|exe|flv|gif|gz|gzip|hqx|jar|jpe?g|js|mp(2|3|4|e?g)|mov(ie)?|msi|msp|pdf|phps|png|ppt|qtm?|ra(m|r)?|sea|sit|tar|tgz|torrent|txt|wav|wma|wmv|wpd|xls|xml|z|zip|docx|xlsx|pptx|pptm|ppsx|ppsm|epub"},"mohD3":{"C3Types":["line","spline","step","area","area-spline","area-step","bar","scatter","pie","donut","gauge"],"graphRender":"line","graphLegend":true,"graphDefaultColors":"#2b8cbe, #abdda4, #7f7f7f, #92cddc, #dc8b0c","graphDefaultGroupedTooltip":0,"graphDefaultGridX":0,"graphDefaultGridY":0,"graphDefaultLegendPosition":"top-right","graphDefaultTooltip":1,"graphDefaultDataLabel":0,"graphLegendStep":"5","graphInteraction":true,"graphTypes":"","graphXaxisShow":true,"graphXaxisLabel":"","graphYaxisLabel":"","graphXaxisType":"category","graphXaxisCentered":false,"graphXaxisRotation":"","graphXaxisHeight":"","graphYaxisShow":true,"graphYaxisMax":"","graphYaxisMin":"","graphYaxisInverted":false,"graphYaxisCenter":"","graphYaxisPrefix":"","graphYaxisSuffix":"","graphYaxisPosition":"","graphY2axisShow":false,"graphY2axisSource":"","graphY2axisMax":"","graphY2axisMin":"","graphGroups":"","graphRotated":false,"graphIgnoreEmpty":false,"graphLineDot":true,"graphBarRatio":"0.9","graphDot":true,"graphDotR":"2.5","graphFocus":false},"tableD3":{"show":"View table data source","hide":"Hide table data source"},"urlIsAjaxTrusted":{"\/our-work\/diseases-and-conditions\/covid-19-novel-coronavirus\/covid-19-data-and-statistics\/covid-19-vaccine-data":true},"bootstrap":{"anchorsFix":1,"anchorsSmoothScrolling":1,"formHasError":1,"popoverEnabled":1,"popoverOptions":{"animation":1,"html":0,"placement":"right","selector":"","trigger":"click","triggerAutoclose":1,"title":"","content":"","delay":0,"container":"body"},"tooltipEnabled":1,"tooltipOptions":{"animation":1,"html":0,"placement":"auto left","selector":"","trigger":"hover focus","delay":0,"container":"body"}}});</script>
+  <!-- HTML5 element support for IE6-8 -->
+  <!--[if lt IE 9]>
+    <script src="/sites/all/themes/mohpub_bootstrap/js/assets/html5shiv.js"></script>
+    <script src="/sites/all/themes/mohpub_bootstrap/js/assets/respond.min.js"></script>
+  <![endif]-->
+</head>
+<body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-12052 node-type-page node-has-intro"><!-- BEGIN WAYBACK TOOLBAR INSERT -->
+<style type="text/css">
+body {
+  margin-top:0 !important;
+  padding-top:0 !important;
+  /*min-width:800px !important;*/
+}
+</style>
+<script>__wm.rw(0);</script>
+<div id="wm-ipp-base" lang="en" style="display:none;direction:ltr;">
+<div id="wm-ipp" style="position:fixed;left:0;top:0;right:0;">
+<div id="wm-ipp-inside">
+  <div style="position:relative;">
+    <div id="wm-logo" style="float:left;width:110px;padding-top:12px;">
+      <a href="/web/" title="Wayback Machine home page"><img src="/_static/images/toolbar/wayback-toolbar-logo-200.png" srcset="/_static/images/toolbar/wayback-toolbar-logo-100.png, /_static/images/toolbar/wayback-toolbar-logo-150.png 1.5x, /_static/images/toolbar/wayback-toolbar-logo-200.png 2x" alt="Wayback Machine" style="width:100px" border="0" /></a>
+    </div>
+    <div class="r" style="float:right;">
+      <div id="wm-btns" style="text-align:right;height:25px;">
+                  <div id="wm-save-snapshot-success">success</div>
+          <div id="wm-save-snapshot-fail">fail</div>
+          <a id="wm-save-snapshot-open" href="#"
+	     title="Share via My Web Archive" >
+            <span class="iconochive-web"></span>
+          </a>
+          <a href="https://archive.org/account/login.php"
+             title="Sign In"
+             id="wm-sign-in"
+          >
+            <span class="iconochive-person"></span>
+          </a>
+          <span id="wm-save-snapshot-in-progress" class="iconochive-web"></span>
+        	<a href="http://faq.web.archive.org/" title="Get some help using the Wayback Machine" style="top:-6px;"><span class="iconochive-question" style="color:rgb(87,186,244);font-size:160%;"></span></a>
+	<a id="wm-tb-close" href="#close" onclick="__wm.h(event);return false;" style="top:-2px;" title="Close the toolbar"><span class="iconochive-remove-circle" style="color:#888888;font-size:240%;"></span></a>
+      </div>
+      <div id="wm-share">
+          <a href="/web/20211023081356/http://web.archive.org/screenshot/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data"
+             id="wm-screenshot"
+             title="screenshot">
+            <span class="wm-icon-screen-shot"></span>
+          </a>
+          <a href="#"
+            id="wm-video"
+            title="video">
+            <span class="iconochive-movies"></span>
+          </a>
+	<a id="wm-share-facebook" href="#" data-url="https://web.archive.org/web/20211023081356/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="Share on Facebook" style="margin-right:5px;" target="_blank"><span class="iconochive-facebook" style="color:#3b5998;font-size:160%;"></span></a>
+	<a id="wm-share-twitter" href="#" data-url="https://web.archive.org/web/20211023081356/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="Share on Twitter" style="margin-right:5px;" target="_blank"><span class="iconochive-twitter" style="color:#1dcaff;font-size:160%;"></span></a>
+      </div>
+    </div>
+    <table class="c" style="">
+      <tbody>
+	<tr>
+	  <td class="u" colspan="2">
+	    <form target="_top" method="get" action="/web/submit" name="wmtb" id="wmtb"><input type="text" name="url" id="wmtbURL" value="https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" onfocus="this.focus();this.select();" /><input type="hidden" name="type" value="replay" /><input type="hidden" name="date" value="20211023081356" /><input type="submit" value="Go" /></form>
+	  </td>
+	  <td class="n" rowspan="2" style="width:110px;">
+	    <table>
+	      <tbody>
+		<!-- NEXT/PREV MONTH NAV AND MONTH INDICATOR -->
+		<tr class="m">
+		  <td class="b" nowrap="nowrap"><a href="https://web.archive.org/web/20210923034317/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="23 Sep 2021"><strong>Sep</strong></a></td>
+		  <td class="c" id="displayMonthEl" title="You are here: 08:13:56 Oct 23, 2021">OCT</td>
+		  <td class="f" nowrap="nowrap">Nov</td>
+		</tr>
+		<!-- NEXT/PREV CAPTURE NAV AND DAY OF MONTH INDICATOR -->
+		<tr class="d">
+		  <td class="b" nowrap="nowrap"><a href="https://web.archive.org/web/20211022013706/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="01:37:06 Oct 22, 2021"><img src="/_static/images/toolbar/wm_tb_prv_on.png" alt="Previous capture" width="14" height="16" border="0" /></a></td>
+		  <td class="c" id="displayDayEl" style="width:34px;font-size:24px;white-space:nowrap;" title="You are here: 08:13:56 Oct 23, 2021">23</td>
+		  <td class="f" nowrap="nowrap"><a href="https://web.archive.org/web/20211025010905/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="01:09:05 Oct 25, 2021"><img src="/_static/images/toolbar/wm_tb_nxt_on.png" alt="Next capture" width="14" height="16" border="0" /></a></td>
+		</tr>
+		<!-- NEXT/PREV YEAR NAV AND YEAR INDICATOR -->
+		<tr class="y">
+		  <td class="b" nowrap="nowrap">2020</td>
+		  <td class="c" id="displayYearEl" title="You are here: 08:13:56 Oct 23, 2021">2021</td>
+		  <td class="f" nowrap="nowrap">2022</td>
+		</tr>
+	      </tbody>
+	    </table>
+	  </td>
+	</tr>
+	<tr>
+	  <td class="s">
+	    	    <div id="wm-nav-captures">
+	      	      <a class="t" href="/web/20211023081356*/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="See a list of every capture for this URL">682 captures</a>
+	      <div class="r" title="Timespan for captures of this URL">07 Apr 2021 - 06 Nov 2021</div>
+	      </div>
+	  </td>
+	  <td class="k">
+	    <a href="" id="wm-graph-anchor">
+	      <div id="wm-ipp-sparkline" title="Explore captures for this URL" style="position: relative">
+		<canvas id="wm-sparkline-canvas" width="650" height="27" border="0"></canvas>
+	      </div>
+	    </a>
+	  </td>
+	</tr>
+      </tbody>
+    </table>
+    <div style="position:absolute;bottom:0;right:2px;text-align:right;">
+      <a id="wm-expand" class="wm-btn wm-closed" href="#expand" onclick="__wm.ex(event);return false;"><span id="wm-expand-icon" class="iconochive-down-solid"></span> <span style="font-size:80%">About this capture</span></a>
+    </div>
+  </div>
+    <div id="wm-capinfo" style="border-top:1px solid #777;display:none; overflow: hidden">
+                    <div id="wm-capinfo-collected-by">
+    <div style="background-color:#666;color:#fff;font-weight:bold;text-align:center">COLLECTED BY</div>
+    <div style="padding:3px;position:relative" id="wm-collected-by-content">
+      <div style="display:inline-block;vertical-align:top;width:49%;">
+			<span class="c-logo" style="background-image:url(https://archive.org/services/img/save-page-now)"></span>
+		<div>Collection: <a style="color:#33f;" href="https://archive.org/details/save-page-now" target="_new"><span class="wm-title">Save Page Now</span></a></div>
+	      </div>
+    </div>
+    </div>
+    <div id="wm-capinfo-timestamps">
+    <div style="background-color:#666;color:#fff;font-weight:bold;text-align:center" title="Timestamps for the elements of this page">TIMESTAMPS</div>
+    <div>
+      <div id="wm-capresources" style="margin:0 5px 5px 5px;max-height:250px;overflow-y:scroll !important"></div>
+      <div id="wm-capresources-loading" style="text-align:left;margin:0 20px 5px 5px;display:none"><img src="/_static/images/loading.gif" alt="loading" /></div>
+    </div>
+    </div>
+  </div></div></div></div><div id="wm-ipp-print">The Wayback Machine - https://web.archive.org/web/20211023081356/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data</div>
+<div id="donato" style="position:relative;width:100%;">
+  <div id="donato-base">
+    <iframe id="donato-if" src="https://archive.org/includes/donate.php?as_page=1&amp;platform=wb&amp;referer=https%3A//web.archive.org/web/20211023081356/https%3A//www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data"
+	    scrolling="no" frameborder="0" style="width:100%; height:100%">
+    </iframe>
+  </div>
+</div><script type="text/javascript">
+__wm.bt(650,27,25,2,"web","https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data","20211023081356",1996,"/_static/",["/_static/css/banner-styles.css?v=omkqRugM","/_static/css/iconochive.css?v=qtvMKcIJ"], "False");
+  __wm.rw(1);
+</script>
+<!-- END WAYBACK TOOLBAR INSERT -->
+<!--googleoff: all-->
+  <div id="skip-link">
+    <a href="#skip-content" id="skipper" class="element-invisible element-focusable">Skip to main content</a>
+  </div>
+    <div id="page">
+  <header id="navbar" role="banner" class="navbar container navbar-default">
+          <ul class="menu nav navbar-nav secondary"><li class="first leaf jobs depth-1"><a href="https://web.archive.org/web/20211023081356/https://careers.health.govt.nz/" title="">Jobs</a></li>
+<li class="leaf news depth-1"><a href="/web/20211023081356/https://www.health.govt.nz/news-media" data-is-top-level="0" title="">News</a></li>
+<li class="leaf contact-us depth-1"><a href="/web/20211023081356/https://www.health.govt.nz/about-ministry/contact-us" title="">Contact us</a></li>
+<li class="leaf facebook depth-1"><a href="https://web.archive.org/web/20211023081356/https://www.facebook.com/minhealthnz/">Facebook</a></li>
+<li class="leaf twitter depth-1"><a href="https://web.archive.org/web/20211023081356/https://twitter.com/minhealthnz" data-is-top-level="0" title="">Twitter</a></li>
+<li class="last leaf youtube depth-1"><a href="https://web.archive.org/web/20211023081356/https://www.youtube.com/user/minhealthnz" data-is-top-level="0" title="">Youtube</a></li>
+</ul>        <div class="container">
+      <div class="navbar-header">
+                <a class="logo navbar-btn pull-left" href="/web/20211023081356/https://www.health.govt.nz/" title="Home">
+          <img src="/web/20211023081356im_/https://www.health.govt.nz/sites/all/themes/mohpub_bootstrap/images/mohlogo.svg" alt="Ministry of Health"/>
+        </a>
+                  <div class="region region-header-top">
+    <section id="block-apachesolr-panels-search-form" class="block block-apachesolr-panels clearfix">
+
+
+  <form action="/web/20211023081356/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" method="post" id="apachesolr-panels-search-block" accept-charset="UTF-8"><div><div class="form-item form-item-apachesolr-panels-search-form form-type-textfield form-group"> <label class="control-label" for="edit-apachesolr-panels-search-form">Search</label>
+<input title="Enter the terms you wish to search for." class="form-control form-text" type="text" id="edit-apachesolr-panels-search-form" name="apachesolr_panels_search_form" value="" size="15" maxlength="128"/></div><input type="hidden" name="form_build_id" value="form-wCes83f8R3x6wI9C37tTxAuFYVHsnpZgmRvsUNX9jmU"/>
+<input type="hidden" name="form_id" value="apachesolr_panels_search_block"/>
+<div class="form-actions form-wrapper form-group" id="edit-actions"><button type="submit" id="edit-submit" name="op" value="Search" class="btn btn-primary form-submit">Search</button>
+</div></div></form>
+</section>
+  </div>
+        <!-- .btn-navbar is used as the toggle for collapsed navbar content -->
+        <button aria-expanded="false" aria-controls="megamenu" type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+                    <span class="menu-text">Menu</span><span class="sr-only">Toggle navigation</span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+
+        </button>
+      </div>
+
+              <div class="navbar-collapse collapse">
+          <nav id="megamenu" role="navigation">
+                          <h2 class="element-invisible">Main menu</h2><ul id="main-menu" class="menu nav navbar-nav yamm navbar"><li class="first dropdown"><a href="/web/20211023081356/https://www.health.govt.nz/your-health" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="megamenu-dropdown-780">Your health <b class="caret"></b></a>
+    <div id="megamenu-dropdown-780" class="dropdown-menu">
+    <div class="yamm-content">
+      <div class="row">
+                            <div class="col">
+            <h3><a href="/web/20211023081356/https://www.health.govt.nz/your-health/conditions-and-treatments?mega=Your%20health&amp;title=Conditions%20%26%20treatments" class="menu-header">Conditions &amp; treatments</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211023081356/https://www.health.govt.nz/your-health/conditions-and-treatments/mental-health/depression?mega=Your%20health&amp;title=Depression">Depression</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/diabetes?mega=Your%20health&amp;title=Diabetes">Diabetes</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/influenza?mega=Your%20health&amp;title=Influenza">Influenza</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/measles?mega=Your%20health&amp;title=Measles">Measles</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/meningococcal-disease-including-meningitis?mega=Your%20health&amp;title=Meningococcal%20disease">Meningococcal disease</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/mumps?mega=Your%20health&amp;title=Mumps">Mumps</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/respiratory-syncytial-virus-rsv?mega=Your%20health&amp;title=RSV">RSV</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/sore-throat?mega=Your%20health&amp;title=Sore%20throat">Sore throat</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/your-health/conditions-and-treatments?mega=Your%20health&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211023081356/https://www.health.govt.nz/your-health/healthy-living?mega=Your%20health&amp;title=Healthy%20living" class="menu-header">Healthy living</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211023081356/https://www.health.govt.nz/your-health/healthy-living/drinking-water?mega=Your%20health&amp;title=Drinking-water">Drinking-water</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/your-health/healthy-living/food-activity-and-sleep/green-prescriptions?mega=Your%20health&amp;title=Green%20Prescriptions">Green Prescriptions</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/your-health/healthy-living/food-activity-and-sleep/healthy-eating?mega=Your%20health&amp;title=Healthy%20eating">Healthy eating</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/your-health/healthy-living/immunisation?mega=Your%20health&amp;title=Immunisation">Immunisation</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/your-health/healthy-living/food-activity-and-sleep/physical-activity?mega=Your%20health&amp;title=Physical%20activity">Physical activity</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/your-health/healthy-living/addictions/quitting-smoking?mega=Your%20health&amp;title=Smoking">Smoking</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/your-health/healthy-living/teeth-and-gums?mega=Your%20health&amp;title=Teeth%20and%20gums">Teeth and gums</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/your-health/healthy-living?mega=Your%20health&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211023081356/https://www.health.govt.nz/your-health/pregnancy-and-kids?mega=Your%20health&amp;title=Pregnancy%20and%20kids" class="menu-header">Pregnancy and kids</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211023081356/https://www.health.govt.nz/your-health/pregnancy-and-kids/birth-and-afterwards?mega=Your%20health&amp;title=Birth%20and%20afterwards">Birth and afterwards</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/your-health/pregnancy-and-kids/first-year/helpful-advice-during-first-year/breastfeeding-perfect-you-and-your-baby?mega=Your%20health&amp;title=Breastfeeding">Breastfeeding</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/your-health/pregnancy-and-kids/pregnancy?mega=Your%20health&amp;title=Pregnancy">Pregnancy</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/your-health/pregnancy-and-kids/services-and-support-during-pregnancy?mega=Your%20health&amp;title=Services%20and%20support%20during%20pregnancy">Services and support during pregnancy</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/your-health/pregnancy-and-kids/services-and-support-you-and-your-child?mega=Your%20health&amp;title=Services%20and%20support%20for%20you%20and%20your%20child">Services and support for you and your child</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/your-health/pregnancy-and-kids/first-year?mega=Your%20health&amp;title=The%20first%20year">The first year</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/your-health/pregnancy-and-kids/under-fives?mega=Your%20health&amp;title=Under%20fives">Under fives</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/your-health/pregnancy-and-kids?mega=Your%20health&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211023081356/https://www.health.govt.nz/your-health/services-and-support?mega=Your%20health&amp;title=Services%20and%20support" class="menu-header">Services &amp; support</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211023081356/https://www.health.govt.nz/your-health/services-and-support/health-care-services/help-alcohol-and-drug-problems?mega=Your%20health&amp;title=Alcohol%20and%20drugs">Alcohol and drugs</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/your-health/services-and-support/disability-services?mega=Your%20health&amp;title=Disability%20services">Disability services</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/your-health/services-and-support/health-care-services/earthquake-support-line?mega=Your%20health&amp;title=Earthquake%20Support%20Line">Earthquake Support Line</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/your-health/services-and-support/health-care-services/healthline?mega=Your%20health&amp;title=Healthline">Healthline</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/your-health/services-and-support/health-care-services/mental-health-services?mega=Your%20health&amp;title=Mental%20health%20services">Mental health services</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/your-health/services-and-support/health-care-services/maori-health-provider-directory?mega=Your%20health&amp;title=M%C4%81ori%20health%20providers">Māori health providers</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/your-health/services-and-support/health-care-services/services-older-people/rest-home-certification-and-audits?mega=Your%20health&amp;title=Rest%20home%20certification">Rest home certification</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/your-health/services-and-support/health-care-services/hospitals-and-specialist-services/travel-assistance?mega=Your%20health&amp;title=Travel%20assistance">Travel assistance</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/your-health/services-and-support?mega=Your%20health&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                        </div>
+    </div>
+    <div class="feature-links">
+      <h3 class="sr-only">Other related resources</h3>
+      <a href="/web/20211023081356/https://www.health.govt.nz/your-health/full-a-z?mega=Your%20health&amp;title=A-Z">View the full A-Z</a>    </div>
+  </div>
+</li>
+<li class="dropdown"><a href="/web/20211023081356/https://www.health.govt.nz/new-zealand-health-system" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="megamenu-dropdown-6076">NZ health system <b class="caret"></b></a>
+    <div id="megamenu-dropdown-6076" class="dropdown-menu">
+    <div class="yamm-content">
+      <div class="row">
+                            <div class="col">
+            <h3><a href="/web/20211023081356/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people?mega=NZ%20health%20system&amp;title=Key%20organisations" class="menu-header">Key organisations</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211023081356/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/crown-entities-and-statutory-boards?mega=NZ%20health%20system&amp;title=Crown%20entities%20%26%20agencies">Crown entities &amp; agencies</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/district-health-boards?mega=NZ%20health%20system&amp;title=District%20health%20boards">District health boards</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/non-governmental-organisations?mega=NZ%20health%20system&amp;title=Non-governmental%20organisations">Non-governmental organisations</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/primary-health-organisations?mega=NZ%20health%20system&amp;title=Primary%20health%20organisations">Primary health organisations</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/public-health-units?mega=NZ%20health%20system&amp;title=Public%20health%20units">Public health units</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people?mega=NZ%20health%20system&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211023081356/https://www.health.govt.nz/new-zealand-health-system/health-system-indicators-framework?mega=NZ%20health%20system&amp;title=Health%20System%20Indicators%20framework" class="menu-header">Health System Indicators framework</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211023081356/https://www.health.govt.nz/new-zealand-health-system/health-system-indicators-framework?mega=NZ%20health%20system&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211023081356/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services?mega=NZ%20health%20system&amp;title=Eligibility%20for%20public%20health%20services" class="menu-header">Eligibility for public health services</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211023081356/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services/guide-eligibility-publicly-funded-health-services?mega=NZ%20health%20system&amp;title=Guide%20to%20eligibility">Guide to eligibility</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services/eligibility-questions-and-answers-consumers?mega=NZ%20health%20system&amp;title=Q%26A%20for%20consumers">Q&amp;A for consumers</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services/eligibility-questions-and-answers-service-providers?mega=NZ%20health%20system&amp;title=Q%26A%20for%20service%20providers">Q&amp;A for service providers</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services/reciprocal-health-agreements?mega=NZ%20health%20system&amp;title=Reciprocal%20health%20agreements">Reciprocal health agreements</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services?mega=NZ%20health%20system&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211023081356/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements?mega=NZ%20health%20system&amp;title=Claims%2C%20provider%20payments%20and%20entitlements" class="menu-header">Claims &amp; provider payments</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211023081356/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/carer-support-claims?mega=NZ%20health%20system&amp;title=Carer%20Support">Carer Support</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/high-use-health-card-payments?mega=NZ%20health%20system&amp;title=High%20Use%20Health%20Card%20payments">High Use Health Card payments</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/between-travel-settlement?mega=NZ%20health%20system&amp;title=In-Between%20Travel%20Settlement">In-Between Travel Settlement</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/maternity-claim-forms?mega=NZ%20health%20system&amp;title=Maternity%20claim%20forms">Maternity claim forms</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/national-travel-assistance?mega=NZ%20health%20system&amp;title=National%20travel%20assistance%20claims">National travel assistance claims</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements?mega=NZ%20health%20system&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                        </div>
+    </div>
+    <div class="feature-links">
+      <h3 class="sr-only">Other related resources</h3>
+      <a href="/web/20211023081356/https://www.health.govt.nz/new-zealand-health-system/overview-health-system?mega=NZ%20health%20system&amp;title=Overview">Overview of the health system</a>  <a href="/web/20211023081356/https://www.health.govt.nz/new-zealand-health-system/my-dhb?mega=NZ%20health%20system&amp;title=Mydhb">My DHB</a> <a href="/web/20211023081356/https://www.health.govt.nz/new-zealand-health-system/system-level-measures-framework?mega=NZ%20health%20system&amp;title=SLM">System level measures</a>  <a href="/web/20211023081356/https://www.health.govt.nz/publication/new-zealand-health-strategy-2016?mega=NZ%20health%20system&amp;title=HealthStrategy">NZ Health Strategy</a>    </div>
+  </div>
+</li>
+<li class="dropdown"><a href="/web/20211023081356/https://www.health.govt.nz/our-work" class="dropdown-toggle active-trail" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="megamenu-dropdown-776">Our work <b class="caret"></b></a>
+  <div id="megamenu-dropdown-776" class="dropdown-menu">
+    <div class="yamm-content">
+      <div class="row">
+                            <ul class="col list-unstyled no-menu-header">
+                                                                                <li>
+                <a href="/web/20211023081356/https://www.health.govt.nz/our-work/diseases-and-conditions/antimicrobial-resistance?mega=Our%20work&amp;title=Antimicrobial%20resistance" class="menu-header">Antimicrobial resistance</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211023081356/https://www.health.govt.nz/our-work/populations/asian-and-migrant-health?mega=Our%20work&amp;title=Asian%20and%20migrant%20health" class="menu-header">Asian and migrant health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211023081356/https://www.health.govt.nz/our-work/border-health?mega=Our%20work&amp;title=Border%20health" class="menu-header">Border health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211023081356/https://www.health.govt.nz/our-work/life-stages/breastfeeding?mega=Our%20work&amp;title=Breastfeeding" class="menu-header">Breastfeeding</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211023081356/https://www.health.govt.nz/our-work/diseases-and-conditions/cancer?mega=Our%20work&amp;title=Cancer" class="menu-header">Cancer</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211023081356/https://www.health.govt.nz/our-work/regulation-health-and-disability-system/certification-health-care-services?mega=Our%20work&amp;title=Certification%20of%20health%20care%20services" class="menu-header">Certification of health care services</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211023081356/https://www.health.govt.nz/our-work/life-stages/child-health?mega=Our%20work&amp;title=Child%20health" class="menu-header">Child health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211023081356/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus?mega=Our%20work&amp;title=COVID-19" class="menu-header">COVID-19 (novel coronavirus)</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211023081356/https://www.health.govt.nz/our-work/diseases-and-conditions/diabetes?mega=Our%20work&amp;title=Diabetes" class="menu-header">Diabetes</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211023081356/https://www.health.govt.nz/our-work/digital-health?mega=Our%20work&amp;title=Digital%20health" class="menu-header">Digital health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211023081356/https://www.health.govt.nz/our-work/disability-services?mega=Our%20work&amp;title=Disability%20services" class="menu-header">Disability services</a>                              </li>
+                                                                </ul>
+                            <ul class="col list-unstyled no-menu-header">
+                                                                                <li>
+                <a href="/web/20211023081356/https://www.health.govt.nz/our-work/diseases-and-conditions?mega=Our%20work&amp;title=Diseases%20and%20conditions" class="menu-header">Diseases and conditions</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211023081356/https://www.health.govt.nz/our-work/hospitals-and-specialist-care/emergency-departments?mega=Our%20work&amp;title=Emergency%20departments" class="menu-header">Emergency departments</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211023081356/https://www.health.govt.nz/our-work/emergency-management?mega=Our%20work&amp;title=Emergency%20management" class="menu-header">Emergency management</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211023081356/https://www.health.govt.nz/our-work/environmental-health?mega=Our%20work&amp;title=Environmental%20health" class="menu-header">Environmental health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211023081356/https://www.health.govt.nz/our-work/preventative-health-wellness/family-violence?mega=Our%20work&amp;title=Family%20violence" class="menu-header">Family violence</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211023081356/https://www.health.govt.nz/our-work/preventative-health-wellness/fluoride-and-oral-health?mega=Our%20work&amp;title=Fluoride%20and%20oral%20health" class="menu-header">Fluoride and oral health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211023081356/https://www.health.govt.nz/our-work/health-identity?mega=Our%20work&amp;title=Health%20identity" class="menu-header">Health identity</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211023081356/https://www.health.govt.nz/our-work/digital-health/digital-health-sector-architecture-standards-and-governance/health-information-standards-0?mega=Our%20work&amp;title=Health%20information%20standards" class="menu-header">Health information standards</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211023081356/https://www.health.govt.nz/our-work/life-stages/health-older-people?mega=Our%20work&amp;title=Health%20of%20older%20people" class="menu-header">Health of older people</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211023081356/https://www.health.govt.nz/our-work/health-workforce?mega=Our%20work&amp;title=Health%20workforce" class="menu-header">Health workforce</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211023081356/https://www.health.govt.nz/our-work/hospitals-and-specialist-care?mega=Our%20work&amp;title=Hospitals%20and%20specialist%20care" class="menu-header">Hospitals and specialist care</a>                              </li>
+                                                                </ul>
+                            <ul class="col list-unstyled no-menu-header">
+                                                                                <li>
+                <a href="/web/20211023081356/https://www.health.govt.nz/our-work/preventative-health-wellness/immunisation?mega=Our%20work&amp;title=Immunisation" class="menu-header">Immunisation</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211023081356/https://www.health.govt.nz/our-work/ionising-radiation-safety?mega=Our%20work&amp;title=Ionising%20radiation%20safety" class="menu-header">Ionising radiation safety</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211023081356/https://www.health.govt.nz/our-work/populations/maori-health?mega=Our%20work&amp;title=M%C4%81ori%20health" class="menu-header">Māori health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211023081356/https://www.health.govt.nz/our-work/life-stages/maternity-services?mega=Our%20work&amp;title=Maternity" class="menu-header">Maternity</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211023081356/https://www.health.govt.nz/our-work/regulation-health-and-disability-system/medicinal-cannabis-agency?mega=Our%20work&amp;title=Medicinal%20Cannabis%20Agency" class="menu-header">Medicinal cannabis</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211023081356/https://www.health.govt.nz/our-work/regulation-health-and-disability-system/medicines-control?mega=Our%20work&amp;title=Medicines%20control" class="menu-header">Medicines control</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211023081356/https://www.health.govt.nz/our-work/mental-health-and-addiction?mega=Our%20work&amp;title=Mental%20health%20and%20addiction" class="menu-header">Mental health and addiction</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211023081356/https://www.health.govt.nz/our-work/nursing?mega=Our%20work&amp;title=Nursing" class="menu-header">Nursing</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211023081356/https://www.health.govt.nz/our-work/preventative-health-wellness/nutrition?mega=Our%20work&amp;title=Nutrition" class="menu-header">Nutrition</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211023081356/https://www.health.govt.nz/our-work/preventative-health-wellness/oral-health?mega=Our%20work&amp;title=Oral%20health" class="menu-header">Oral health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211023081356/https://www.health.govt.nz/our-work/hospitals-and-specialist-care/organ-donation-and-transplantation?mega=Our%20work&amp;title=Organ%20donation%20and%20transplantation" class="menu-header">Organ donation and transplantation</a>                              </li>
+                                                                </ul>
+                            <ul class="col list-unstyled no-menu-header">
+                                                                                <li>
+                <a href="/web/20211023081356/https://www.health.govt.nz/our-work/populations/pacific-health?mega=Our%20work&amp;title=Pacific%20health" class="menu-header">Pacific health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211023081356/https://www.health.govt.nz/new-zealand-health-system/pay-equity-settlements?mega=Our%20work&amp;title=Pay%20equity%20settlements" class="menu-header">Pay equity</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211023081356/https://www.health.govt.nz/our-work/preventative-health-wellness/physical-activity?mega=Our%20work&amp;title=Physical%20activity" class="menu-header">Physical activity</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211023081356/https://www.health.govt.nz/our-work/hospitals-and-specialist-care/planned-care-services?mega=Our%20work&amp;title=Planned%20Care%20services" class="menu-header">Planned Care services</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211023081356/https://www.health.govt.nz/our-work/preventative-health-wellness?mega=Our%20work&amp;title=Preventative%20health/wellness" class="menu-header">Preventative health/wellness</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211023081356/https://www.health.govt.nz/our-work/primary-health-care?mega=Our%20work&amp;title=Primary%20health%20care" class="menu-header">Primary health care</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211023081356/https://www.health.govt.nz/our-work/public-health-workforce-development?mega=Our%20work&amp;title=Public%20health%20workforce%20development" class="menu-header">Public health workforce</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211023081356/https://www.health.govt.nz/our-work/regulation-health-and-disability-system?mega=Our%20work&amp;title=Regulation" class="menu-header">Regulation</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211023081356/https://www.health.govt.nz/our-work/preventative-health-wellness/tobacco-control?mega=Our%20work&amp;title=Tobacco%20control" class="menu-header">Tobacco control</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211023081356/https://www.health.govt.nz/our-work/regulation-health-and-disability-system/regulation-vaping-and-smokeless-tobacco-products?mega=Our%20work&amp;title=Vaping%20and%20smokeless%20tobacco%20products" class="menu-header">Vaping &amp; smokeless tobacco</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211023081356/https://www.health.govt.nz/our-work/who-code-nz?mega=Our%20work&amp;title=WHO%20Code%20in%20NZ" class="menu-header">WHO Code in NZ</a>                              </li>
+                      </ul>
+              </div>
+    </div>
+    <div class="feature-links">
+      <a href="/web/20211023081356/https://www.health.govt.nz/our-work?mega=Our%20work&amp;title=A-Z">View the full A-Z</a>    </div>
+  </div>
+</li>
+<li class="dropdown"><a href="/web/20211023081356/https://www.health.govt.nz/nz-health-statistics" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="megamenu-dropdown-778">Health statistics <b class="caret"></b></a>
+    <div id="megamenu-dropdown-778" class="dropdown-menu">
+    <div class="yamm-content">
+      <div class="row">
+                            <div class="col">
+            <h3><a href="/web/20211023081356/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets?mega=Health%20statistics&amp;title=Health%20statistics%20and%20data%20sets" class="menu-header">Statistics by topic</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211023081356/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/cancer-data-and-stats?mega=Health%20statistics&amp;title=Cancer">Cancer</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/diabetes-data-and-stats?mega=Health%20statistics&amp;title=Diabetes">Diabetes</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/mental-health-data-and-stats?mega=Health%20statistics&amp;title=Mental%20health">Mental health</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/maori-health-data-and-stats?mega=Health%20statistics&amp;title=M%C4%81ori%20health">Māori health</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/obesity-statistics?mega=Health%20statistics&amp;title=Obesity">Obesity</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/suicide-data-and-stats?mega=Health%20statistics&amp;title=Suicide">Suicide</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/tobacco-data-and-stats?mega=Health%20statistics&amp;title=Tobacco">Tobacco</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets?mega=Health%20statistics&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211023081356/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys?mega=Health%20statistics&amp;title=National%20collections%20and%20surveys" class="menu-header">About our surveys &amp; data collections</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211023081356/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/surveys/past-surveys/alcohol-and-drug-use-survey?mega=Health%20statistics&amp;title=Alcohol%20%26%20Drug%20Use%20Survey">Alcohol &amp; Drug Use Survey</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/national-collections-annual-maintenance-project?mega=Health%20statistics&amp;title=NCAMP">NCAMP</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/collections/new-zealand-cancer-registry-nzcr?mega=Health%20statistics&amp;title=NZ%20Cancer%20Registry">NZ Cancer Registry</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/surveys/new-zealand-health-survey?mega=Health%20statistics&amp;title=NZ%20Health%20Survey">NZ Health Survey</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/surveys/past-surveys/nutrition-survey?mega=Health%20statistics&amp;title=Nutrition%20Survey">Nutrition Survey</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/collections/primhd-mental-health-data?mega=Health%20statistics&amp;title=PRIMHD">PRIMHD</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys?mega=Health%20statistics&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211023081356/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology?mega=Health%20statistics&amp;title=Classification%20and%20Terminology" class="menu-header">Classification &amp; terminology</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211023081356/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology/using-icd-10-am-achi-acs/coding-queries/coding-query-database?mega=Health%20statistics&amp;title=Coding%20query%20database">Coding query database</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology/using-icd-10-am-achi-acs/courses-clinical-coding?mega=Health%20statistics&amp;title=Courses%20on%20clinical%20coding">Courses on clinical coding</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology/new-zealand-snomed-ct-national-release-centre?mega=Health%20statistics&amp;title=SNOMED%20CT">SNOMED CT</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology/using-icd-10-am-achi-acs?mega=Health%20statistics&amp;title=Using%20ICD-10-AM/ACHI/ACS">Using ICD-10-AM/ACHI/ACS</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology?mega=Health%20statistics&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211023081356/https://www.health.govt.nz/nz-health-statistics/data-references?mega=Health%20statistics&amp;title=Data%20references" class="menu-header">Data references</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211023081356/https://www.health.govt.nz/nz-health-statistics/data-references/code-tables?mega=Health%20statistics&amp;title=Code%20tables">Code tables</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/nz-health-statistics/data-references/data-dictionaries?mega=Health%20statistics&amp;title=Data%20dictionaries">Data dictionaries</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/nz-health-statistics/data-references/diagnosis-related-groups?mega=Health%20statistics&amp;title=Diagnosis-related%20groups">Diagnosis-related groups</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/nz-health-statistics/data-references/code-tables/common-code-tables/domicile-code-table?mega=Health%20statistics&amp;title=Domicile%20code%20table">Domicile code table</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/nz-health-statistics/data-references/mapping-tools?mega=Health%20statistics&amp;title=ICD%20mapping%20tools">ICD mapping tools</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/nz-health-statistics/data-references/weighted-inlier-equivalent-separations?mega=Health%20statistics&amp;title=Weighted%20Inlier%20Equivalent%20Separations">Weighted Inlier Equivalent Separations</a></li>
+                                  <li><a href="/web/20211023081356/https://www.health.govt.nz/nz-health-statistics/data-references?mega=Health%20statistics&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                        </div>
+    </div>
+    <div class="feature-links">
+      <h3 class="sr-only">Other related resources</h3>
+      <a href="/web/20211023081356/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/tier-1-health-statistics-release-calendar?mega=Health%20statistics&amp;title=Tier%201%20calendar">Release calendar for our Tier 1 statistics</a> <a href="/web/20211023081356/https://www.health.govt.nz/nz-health-statistics/about-data-collection?mega=Health%20statistics&amp;title=Enquiries">Data and survey enquiries</a>    </div>
+  </div>
+</li>
+<li class=""><a href="/web/20211023081356/https://www.health.govt.nz/publications" aria-haspopup="false">Publications</a></li>
+<li class=""><a href="/web/20211023081356/https://www.health.govt.nz/about-ministry" aria-haspopup="false">About us</a></li>
+<li class="visible-xs"><a href="/web/20211023081356/https://www.health.govt.nz/contactus" aria-haspopup="false">Contact us</a></li>
+</ul>
+                                  </nav>
+        </div>
+          </div>
+  </header>
+
+  <div class="main-container container">
+    <!-- announcement -->
+        <!-- /announcement -->
+
+    <header role="banner" id="page-header">
+
+          </header> <!-- /#page-header -->
+
+    <div class="row">
+
+      <section class="col-sm-12">
+                        <a id="main-content"></a>
+                                                                            <div class="breadcrumbs">
+            <ul><li><a href="/web/20211023081356/https://www.health.govt.nz/">Home</a></li><li><a href="/web/20211023081356/https://www.health.govt.nz/our-work">Our work</a></li><li><a href="/web/20211023081356/https://www.health.govt.nz/our-work/diseases-and-conditions">Diseases and conditions</a></li><li><a href="/web/20211023081356/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished" data-is-top-level="1" title="">COVID-19</a></li><li><a href="/web/20211023081356/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics" class="menu-node-unpublished menu-node-unpublished">Data and statistics</a></li><li><span class="current-breadcrumb">Vaccine data</span></li></ul>          </div>
+
+
+
+          <div class="region region-content">
+    <section id="block-system-main" class="block block-system clearfix">
+
+
+  <div class="bootstrap-threecol-stacked">
+
+      <div class="row"> <!-- @TODO: Add extra classes -->
+      <div class="panel-panel left col-xs-12 col-md-3 col-lg-3"><div class="panel-pane pane-block pane-menu-block-1 odd pane-top-link">
+
+        <span class="top-link"><a href="/web/20211023081356/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished active-trail" data-is-top-level="1">COVID-19</a></span>
+
+
+  <div class="pane-content">
+        <div class="menu-block-wrapper menu-block-1 menu-name-main-menu parent-mlid-1445 menu-level-2">
+  <ul class="menu nav"><li class="first collapsed menu-mlid-10163 health-advice depth-4"><a href="/web/20211023081356/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-health-advice-public" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished">Health advice</a></li>
+<li class="collapsed menu-mlid-10630 covid-19-vaccines- depth-4 section-overview hide-children"><a href="/web/20211023081356/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-vaccines" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished" data-is-top-level="1" title="">COVID-19 vaccines </a></li>
+<li class="collapsed menu-mlid-9997 health-professionals depth-4"><a href="/web/20211023081356/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-information-health-professionals" class="menu-node-unpublished menu-node-unpublished">Health professionals</a></li>
+<li class="collapsed menu-mlid-10019 specific-audiences depth-4"><a href="/web/20211023081356/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-information-specific-audiences" class="menu-node-unpublished">Specific audiences</a></li>
+<li class="expanded active-trail menu-mlid-10096 data-and-statistics depth-4"><a href="/web/20211023081356/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics" class="menu-node-unpublished menu-node-unpublished active-trail">Data and statistics</a><ul class="menu nav"><li class="first leaf menu-mlid-10062 current-cases depth-5 same-level-as-node"><a href="/web/20211023081356/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-current-cases" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Current cases</a></li>
+<li class="leaf menu-mlid-10146 case-demographics depth-5 same-level-as-node"><a href="/web/20211023081356/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-case-demographics">Case demographics</a></li>
+<li class="leaf menu-mlid-10097 source-of-cases depth-5 same-level-as-node"><a href="/web/20211023081356/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-source-cases" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Source of cases</a></li>
+<li class="leaf menu-mlid-10119 testing-for-covid-19 depth-5 same-level-as-node"><a href="/web/20211023081356/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/testing-covid-19" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Testing for COVID-19</a></li>
+<li class="leaf menu-mlid-10371 nz-covid-tracer-app-data depth-5 same-level-as-node"><a href="/web/20211023081356/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-nz-covid-tracer-app-data" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">NZ COVID Tracer app data</a></li>
+<li class="expanded active-trail active menu-mlid-10584 active vaccine-data depth-5 same-level-as-node"><a href="/web/20211023081356/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished active-trail active">Vaccine data</a><ul class="menu nav"><li class="first leaf menu-mlid-10867 covid-19-vaccination-uptake-rates-across-nz depth-6"><a href="/web/20211023081356/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-across-nz" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">COVID-19 Vaccination uptake rates across NZ</a></li>
+<li class="leaf menu-mlid-10868 covid-19-vaccination-uptake-rates---māori depth-6"><a href="/web/20211023081356/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-maori-communities-across-nz" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">COVID-19 Vaccination uptake rates - Māori</a></li>
+<li class="last leaf menu-mlid-10869 covid-19-vaccination-uptake-rates---pacific depth-6"><a href="/web/20211023081356/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-pacific-communities-across-nz" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">COVID-19 Vaccination uptake rates - Pacific</a></li>
+</ul></li>
+<li class="last leaf menu-mlid-10404 data-resources depth-5 same-level-as-node"><a href="/web/20211023081356/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-data-resources" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Data resources</a></li>
+</ul></li>
+<li class="collapsed menu-mlid-10369 response-planning depth-4"><a href="/web/20211023081356/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-response-planning" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Response planning</a></li>
+<li class="collapsed menu-mlid-10015 resources-and-tools depth-4"><a href="/web/20211023081356/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-resources-and-tools" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Resources and tools</a></li>
+<li class="last leaf menu-mlid-10004 news-and-media depth-4 section-overview hide-children"><a href="/web/20211023081356/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-news-and-media-updates" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">News and media</a></li>
+</ul></div>
+  </div>
+
+
+  </div>
+</div>      <div class="panel-panel middle col-xs-12 col-md-9 col-lg-9"><div class="panel-pane pane-page-title even">
+
+
+
+  <div class="pane-content">
+    <span id="skip-content" tabindex="-1"></span>    <h1>COVID-19: Vaccine data</h1>
+  </div>
+
+
+  </div>
+<div class="panel-pane pane-node-content odd">
+
+
+
+  <div class="pane-content">
+        <article id="node-12052" class="node node-page node-sticky view-mode-full clearfix" about="/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" typeof="sioc:Item foaf:Document">
+    <header>
+            <span property="dc:title" content="COVID-19: Vaccine data" class="rdf-meta element-hidden"></span>      </header>
+    <div class="field field-name-field-intro-text field-type-text-long field-label-hidden"><div class="field-items"><div class="field-item even"><p class="intro-text">Data and statistics about the rollout of COVID-19 vaccines in New Zealand.</p></div></div></div><div class="field field-name-body field-type-text-with-summary field-label-hidden"><div class="field-items"><div class="field-item even" property="content:encoded"><p>On this page:</p>
+
+<ul>
+	<li><a href="#daily">Daily updates</a>
+
+	<ul>
+		<li><a href="#total-vaccinations">Total vaccinations</a></li>
+		<li><a href="#ethnicity">Vaccinations by ethnicity</a></li>
+	</ul>
+	</li>
+	<li><a href="#weekly-updates">Weekly updates</a>
+	<ul>
+		<li><a href="#model">Vaccinations against plan</a></li>
+		<li><a href="#uptake">Vaccinations uptake</a></li>
+		<li><a href="#by-day">Vaccinations by day</a></li>
+		<li><a href="#location">Vaccinations by DHB</a></li>
+		<li><a href="#group">Vaccinations by group</a></li>
+		<li><a href="#by_soh">Stock on hand</a></li>
+		<li><a href="#age">Vaccinations by age</a></li>
+		<li><a href="#workforce">Trained vaccinator and active vaccinator</a></li>
+		<li><a href="#group">Vaccinations by group</a></li>
+		<li><a href="#download">Details of vaccination&nbsp;data</a></li>
+	</ul>
+	</li>
+	<li><a href="#adverse-events">Adverse events from immunisations</a></li>
+</ul>
+
+<hr/><!--daily-->
+<h2><a id="daily" name="daily"></a>COVID-19 vaccinations: daily updates</h2>
+
+<div class="well well-sm">
+<p style="margin-top: 0"><strong>Data in this section is as at 11:59pm 22 October 2021 and is updated daily.</strong></p>
+</div>
+
+<h3><a id="total-vaccinations" name="total-vaccinations"></a>Total Vaccinations</h3>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">&nbsp;</th>
+			<th scope="col" style="text-align:right">Vaccinations yesterday</th>
+			<th scope="col" style="text-align:right">Cumulative total</th>
+			<th scope="col" style="text-align:right">Eligible population vaccinated %</th>
+			<th scope="col" style="text-align:right">Total population vaccinated %</th>
+			<th scope="col" style="text-align:right">Vaccinated or booked</th>
+			<th scope="col" style="text-align:right">Eligible vaccinated or booked %</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">First dose</th>
+			<td style="text-align:right">11,368</td>
+			<td style="text-align:right">3,626,019</td>
+			<td style="text-align:right">86%</td>
+			<td style="text-align:right">73%</td>
+			<td style="text-align:right">3,647,971</td>
+			<td style="text-align:right">87%</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Second dose</th>
+			<td style="text-align:right">33,382</td>
+			<td style="text-align:right">2,935,712</td>
+			<td style="text-align:right">70%</td>
+			<td style="text-align:right">59%</td>
+			<td style="text-align:right">3,303,450</td>
+			<td style="text-align:right">78%</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total doses</strong></th>
+			<td style="text-align:right"><strong>44,750</strong></td>
+			<td style="text-align:right"><strong>6,561,731</strong></td>
+		</tr>
+	</tbody>
+</table>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Total vaccinations" class="img-responsive" height="900" src="/web/20211023081356im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_summary_11_0.png" width="5340"/></figure>
+
+<h5>Definitions</h5>
+
+<ul>
+	<li><strong>Cumulative total:</strong>&nbsp;All vaccinations that have been administered and entered into the COVID-19 Immunisation Register up until midnight of the night before the data is published.</li>
+	<li><strong>Eligible population vaccinated %:</strong>&nbsp;Vaccinations administered divided by HSU population estimates for the eligible population (12+).</li>
+	<li><strong>Total population vaccinated %:</strong>&nbsp;Vaccinations administered divided by HSU population estimates for the total population (0+).</li>
+	<li><strong>Vaccinated or booked:</strong>&nbsp;Count of individuals who have either received their vaccination or have booked via Book My Vaccine to receive a vaccination.</li>
+	<li><strong>Eligible vaccinated or booked %:</strong>&nbsp;Count of individuals who have either received their vaccination or have booked via Book My Vaccine to receive a vaccination divided by HSU population estimates for the eligible population (12+).</li>
+</ul>
+
+<p>HSU population estimates are available in the downloadable spreadsheet at the bottom of the page. Throughout the rest of this sheet doses per 1,000 are based on eligible (12+) population.</p>
+
+<p>Bookings are only counted if the site is using Book My Vaccine. Bookings made through other Patient Management Systems are not counted.</p>
+
+<hr/>
+<h3><a id="by_eth" name="ethnicity"></a>Cumulative vaccinations by ethnicity</h3>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">Ethnicity *</th>
+			<th scope="col" style="text-align:right">First dose administered</th>
+			<th scope="col" style="text-align:right">First doses per 1,000 people</th>
+			<th scope="col" style="text-align:right">Second dose administered</th>
+			<th scope="col" style="text-align:right">Second doses per 1,000 people</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">Māori</th>
+			<td style="text-align:right">389,884</td>
+			<td style="text-align:right">683</td>
+			<td style="text-align:right">272,446</td>
+			<td style="text-align:right">477</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Pacific Peoples</th>
+			<td style="text-align:right">235,267</td>
+			<td style="text-align:right">821</td>
+			<td style="text-align:right">179,554</td>
+			<td style="text-align:right">626</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Asian</th>
+			<td style="text-align:right">600,042</td>
+			<td style="text-align:right">&gt;950</td>
+			<td style="text-align:right">504,944</td>
+			<td style="text-align:right">844</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">European / Other</th>
+			<td style="text-align:right">2,367,493</td>
+			<td style="text-align:right">867</td>
+			<td style="text-align:right">1,952,528</td>
+			<td style="text-align:right">715</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Unknown</th>
+			<td style="text-align:right">33,333</td>
+			<td style="text-align:right">-</td>
+			<td style="text-align:right">26,240</td>
+			<td style="text-align:right">-</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total</strong></th>
+			<td style="text-align:right"><strong>3,626,019</strong></td>
+			<td style="text-align:right"><strong>861</strong></td>
+			<td style="text-align:right"><strong>2,935,712</strong></td>
+			<td style="text-align:right"><strong>697</strong></td>
+		</tr>
+	</tbody>
+</table>
+
+<p><strong>*</strong> The prioritised ethnicity classification system allocates each person to a single ethnic group, based on the ethnic groups they identify with. Where people identify with more than one group, they are assigned in this order of priority: Māori, Pacific Peoples, Asian, and European/Other. So, if a person identifies as being Māori and New Zealand European, the person is counted as Māori. See <a href="/web/20211023081356/https://www.health.govt.nz/publication/hiso-100012017-ethnicity-data-protocols">Ethnicity Data Protocols</a> for further information.</p>
+
+<p>Ethnicity breakdown by DHB of residence is available in the downloadable spreadsheet at the bottom of the page.</p>
+
+<hr/>
+<h3><a id="90pct" name="90pct"></a>Vaccinations to 90% by DHB</h3>
+
+<h4><a id="90pct all ethnicities" name="90pct all ethnicities"></a>All Ethnicities</h4>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">&nbsp;</th>
+			<th scope="col" style="text-align:right">First doses</th>
+			<th scope="col" style="text-align:right">First doses %</th>
+			<th scope="col" style="text-align:right">First doses to 90%</th>
+			<th scope="col" style="text-align:right">Second doses</th>
+			<th scope="col" style="text-align:right">Second doses %</th>
+			<th scope="col" style="text-align:right">Second doses to 90%</th>
+			<th scope="col" style="text-align:right">Population</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">Northland</th>
+			<td style="text-align:right">124,581</td>
+			<td style="text-align:right">77%</td>
+			<td style="text-align:right">20,607</td>
+			<td style="text-align:right">98,596</td>
+			<td style="text-align:right">61%</td>
+			<td style="text-align:right">46,592</td>
+			<td style="text-align:right">161,320</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waitemata</th>
+			<td style="text-align:right">472,845</td>
+			<td style="text-align:right">90%</td>
+			<td style="text-align:right">633</td>
+			<td style="text-align:right">393,932</td>
+			<td style="text-align:right">75%</td>
+			<td style="text-align:right">79,546</td>
+			<td style="text-align:right">526,087</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Auckland</th>
+			<td style="text-align:right">393,369</td>
+			<td style="text-align:right">93%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">337,329</td>
+			<td style="text-align:right">80%</td>
+			<td style="text-align:right">44,233</td>
+			<td style="text-align:right">423,958</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Counties Manukau</th>
+			<td style="text-align:right">420,059</td>
+			<td style="text-align:right">87%</td>
+			<td style="text-align:right">14,437</td>
+			<td style="text-align:right">347,137</td>
+			<td style="text-align:right">72%</td>
+			<td style="text-align:right">87,359</td>
+			<td style="text-align:right">482,773</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waikato</th>
+			<td style="text-align:right">302,169</td>
+			<td style="text-align:right">85%</td>
+			<td style="text-align:right">19,289</td>
+			<td style="text-align:right">241,318</td>
+			<td style="text-align:right">68%</td>
+			<td style="text-align:right">80,140</td>
+			<td style="text-align:right">357,176</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Lakes</th>
+			<td style="text-align:right">73,975</td>
+			<td style="text-align:right">78%</td>
+			<td style="text-align:right">11,002</td>
+			<td style="text-align:right">57,433</td>
+			<td style="text-align:right">61%</td>
+			<td style="text-align:right">27,544</td>
+			<td style="text-align:right">94,419</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Bay of Plenty</th>
+			<td style="text-align:right">176,124</td>
+			<td style="text-align:right">81%</td>
+			<td style="text-align:right">19,123</td>
+			<td style="text-align:right">133,220</td>
+			<td style="text-align:right">61%</td>
+			<td style="text-align:right">62,027</td>
+			<td style="text-align:right">216,941</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Tairawhiti</th>
+			<td style="text-align:right">31,756</td>
+			<td style="text-align:right">76%</td>
+			<td style="text-align:right">6,012</td>
+			<td style="text-align:right">25,265</td>
+			<td style="text-align:right">60%</td>
+			<td style="text-align:right">12,504</td>
+			<td style="text-align:right">41,965</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Taranaki</th>
+			<td style="text-align:right">83,776</td>
+			<td style="text-align:right">82%</td>
+			<td style="text-align:right">8,156</td>
+			<td style="text-align:right">62,349</td>
+			<td style="text-align:right">61%</td>
+			<td style="text-align:right">29,583</td>
+			<td style="text-align:right">102,147</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hawkes Bay</th>
+			<td style="text-align:right">120,053</td>
+			<td style="text-align:right">82%</td>
+			<td style="text-align:right">10,961</td>
+			<td style="text-align:right">97,596</td>
+			<td style="text-align:right">67%</td>
+			<td style="text-align:right">33,418</td>
+			<td style="text-align:right">145,571</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">MidCentral</th>
+			<td style="text-align:right">128,334</td>
+			<td style="text-align:right">84%</td>
+			<td style="text-align:right">8,738</td>
+			<td style="text-align:right">103,512</td>
+			<td style="text-align:right">68%</td>
+			<td style="text-align:right">33,560</td>
+			<td style="text-align:right">152,302</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Whanganui</th>
+			<td style="text-align:right">44,985</td>
+			<td style="text-align:right">79%</td>
+			<td style="text-align:right">6,537</td>
+			<td style="text-align:right">37,155</td>
+			<td style="text-align:right">65%</td>
+			<td style="text-align:right">14,367</td>
+			<td style="text-align:right">57,247</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Capital and Coast</th>
+			<td style="text-align:right">246,756</td>
+			<td style="text-align:right">91%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">203,157</td>
+			<td style="text-align:right">75%</td>
+			<td style="text-align:right">40,900</td>
+			<td style="text-align:right">271,174</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hutt Valley</th>
+			<td style="text-align:right">112,335</td>
+			<td style="text-align:right">86%</td>
+			<td style="text-align:right">4,880</td>
+			<td style="text-align:right">89,431</td>
+			<td style="text-align:right">69%</td>
+			<td style="text-align:right">27,784</td>
+			<td style="text-align:right">130,239</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Wairarapa</th>
+			<td style="text-align:right">34,631</td>
+			<td style="text-align:right">84%</td>
+			<td style="text-align:right">2,653</td>
+			<td style="text-align:right">28,309</td>
+			<td style="text-align:right">68%</td>
+			<td style="text-align:right">8,975</td>
+			<td style="text-align:right">41,427</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Nelson Marlborough</th>
+			<td style="text-align:right">114,814</td>
+			<td style="text-align:right">85%</td>
+			<td style="text-align:right">7,355</td>
+			<td style="text-align:right">98,763</td>
+			<td style="text-align:right">73%</td>
+			<td style="text-align:right">23,406</td>
+			<td style="text-align:right">135,743</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">West Coast</th>
+			<td style="text-align:right">21,893</td>
+			<td style="text-align:right">78%</td>
+			<td style="text-align:right">3,222</td>
+			<td style="text-align:right">17,447</td>
+			<td style="text-align:right">63%</td>
+			<td style="text-align:right">7,668</td>
+			<td style="text-align:right">27,906</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Canterbury</th>
+			<td style="text-align:right">424,841</td>
+			<td style="text-align:right">88%</td>
+			<td style="text-align:right">9,760</td>
+			<td style="text-align:right">315,638</td>
+			<td style="text-align:right">65%</td>
+			<td style="text-align:right">118,963</td>
+			<td style="text-align:right">482,890</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">South Canterbury</th>
+			<td style="text-align:right">44,119</td>
+			<td style="text-align:right">84%</td>
+			<td style="text-align:right">3,207</td>
+			<td style="text-align:right">36,547</td>
+			<td style="text-align:right">70%</td>
+			<td style="text-align:right">10,779</td>
+			<td style="text-align:right">52,584</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Southern</th>
+			<td style="text-align:right">252,587</td>
+			<td style="text-align:right">88%</td>
+			<td style="text-align:right">6,626</td>
+			<td style="text-align:right">210,004</td>
+			<td style="text-align:right">73%</td>
+			<td style="text-align:right">49,210</td>
+			<td style="text-align:right">288,015</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Overseas / Unknown</th>
+			<td style="text-align:right">2,017</td>
+			<td style="text-align:right">12%</td>
+			<td style="text-align:right">13,439</td>
+			<td style="text-align:right">1,574</td>
+			<td style="text-align:right">9%</td>
+			<td style="text-align:right">13,882</td>
+			<td style="text-align:right">17,173</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total</strong></th>
+			<td style="text-align:right"><strong>3,626,019</strong></td>
+			<td style="text-align:right"><strong>86%</strong></td>
+			<td style="text-align:right"><strong>162,132</strong></td>
+			<td style="text-align:right"><strong>2,935,712</strong></td>
+			<td style="text-align:right"><strong>70%</strong></td>
+			<td style="text-align:right"><strong>852,439</strong></td>
+			<td style="text-align:right"><strong>4,209,057</strong></td>
+		</tr>
+	</tbody>
+</table>
+
+<p>First/second doses % are the number of first/second doses administered divided by the eligible population. First/second doses to 90% are the number of doses required to reach 90% of the eligible population. For these two measures, the national total may not be the sum of DHB measures.</p>
+
+<h4><a id="90pct Māori" name="90pct Māori">Māori</a></h4>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">&nbsp;</th>
+			<th scope="col" style="text-align:right">First doses</th>
+			<th scope="col" style="text-align:right">First doses %</th>
+			<th scope="col" style="text-align:right">First doses to 90%</th>
+			<th scope="col" style="text-align:right">Second doses</th>
+			<th scope="col" style="text-align:right">Second doses %</th>
+			<th scope="col" style="text-align:right">Second doses to 90%</th>
+			<th scope="col" style="text-align:right">Population</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">Northland</th>
+			<td style="text-align:right">32,306</td>
+			<td style="text-align:right">64%</td>
+			<td style="text-align:right">13,133</td>
+			<td style="text-align:right">22,019</td>
+			<td style="text-align:right">44%</td>
+			<td style="text-align:right">23,420.0</td>
+			<td style="text-align:right">50,488</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waitemata</th>
+			<td style="text-align:right">31,629</td>
+			<td style="text-align:right">77%</td>
+			<td style="text-align:right">5,373</td>
+			<td style="text-align:right">22,978</td>
+			<td style="text-align:right">56%</td>
+			<td style="text-align:right">14,024.0</td>
+			<td style="text-align:right">41,113</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Auckland</th>
+			<td style="text-align:right">22,169</td>
+			<td style="text-align:right">80%</td>
+			<td style="text-align:right">2,844</td>
+			<td style="text-align:right">16,664</td>
+			<td style="text-align:right">60%</td>
+			<td style="text-align:right">8,349.0</td>
+			<td style="text-align:right">27,792</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Counties Manukau</th>
+			<td style="text-align:right">44,082</td>
+			<td style="text-align:right">69%</td>
+			<td style="text-align:right">13,062</td>
+			<td style="text-align:right">30,341</td>
+			<td style="text-align:right">48%</td>
+			<td style="text-align:right">26,803.0</td>
+			<td style="text-align:right">63,493</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waikato</th>
+			<td style="text-align:right">47,973</td>
+			<td style="text-align:right">69%</td>
+			<td style="text-align:right">14,763</td>
+			<td style="text-align:right">32,333</td>
+			<td style="text-align:right">46%</td>
+			<td style="text-align:right">30,403.0</td>
+			<td style="text-align:right">69,707</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Lakes</th>
+			<td style="text-align:right">18,715</td>
+			<td style="text-align:right">62%</td>
+			<td style="text-align:right">8,362</td>
+			<td style="text-align:right">12,778</td>
+			<td style="text-align:right">42%</td>
+			<td style="text-align:right">14,298.0</td>
+			<td style="text-align:right">30,085</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Bay of Plenty</th>
+			<td style="text-align:right">29,285</td>
+			<td style="text-align:right">61%</td>
+			<td style="text-align:right">13,676</td>
+			<td style="text-align:right">19,275</td>
+			<td style="text-align:right">40%</td>
+			<td style="text-align:right">23,686.0</td>
+			<td style="text-align:right">47,734</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Tairawhiti</th>
+			<td style="text-align:right">12,782</td>
+			<td style="text-align:right">64%</td>
+			<td style="text-align:right">5,073</td>
+			<td style="text-align:right">9,286</td>
+			<td style="text-align:right">47%</td>
+			<td style="text-align:right">8,569.0</td>
+			<td style="text-align:right">19,839</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Taranaki</th>
+			<td style="text-align:right">10,290</td>
+			<td style="text-align:right">65%</td>
+			<td style="text-align:right">4,024</td>
+			<td style="text-align:right">6,543</td>
+			<td style="text-align:right">41%</td>
+			<td style="text-align:right">7,771.0</td>
+			<td style="text-align:right">15,904</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hawkes Bay</th>
+			<td style="text-align:right">21,794</td>
+			<td style="text-align:right">64%</td>
+			<td style="text-align:right">8,859</td>
+			<td style="text-align:right">15,341</td>
+			<td style="text-align:right">45%</td>
+			<td style="text-align:right">15,312.0</td>
+			<td style="text-align:right">34,059</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">MidCentral</th>
+			<td style="text-align:right">16,482</td>
+			<td style="text-align:right">68%</td>
+			<td style="text-align:right">5,320</td>
+			<td style="text-align:right">11,617</td>
+			<td style="text-align:right">48%</td>
+			<td style="text-align:right">10,186.0</td>
+			<td style="text-align:right">24,225</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Whanganui</th>
+			<td style="text-align:right">8,453</td>
+			<td style="text-align:right">63%</td>
+			<td style="text-align:right">3,708</td>
+			<td style="text-align:right">6,194</td>
+			<td style="text-align:right">46%</td>
+			<td style="text-align:right">5,967.0</td>
+			<td style="text-align:right">13,512</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Capital and Coast</th>
+			<td style="text-align:right">20,987</td>
+			<td style="text-align:right">78%</td>
+			<td style="text-align:right">3,283</td>
+			<td style="text-align:right">15,549</td>
+			<td style="text-align:right">58%</td>
+			<td style="text-align:right">8,721.0</td>
+			<td style="text-align:right">26,967</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hutt Valley</th>
+			<td style="text-align:right">13,396</td>
+			<td style="text-align:right">70%</td>
+			<td style="text-align:right">3,815</td>
+			<td style="text-align:right">9,448</td>
+			<td style="text-align:right">49%</td>
+			<td style="text-align:right">7,763.0</td>
+			<td style="text-align:right">19,123</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Wairarapa</th>
+			<td style="text-align:right">4,185</td>
+			<td style="text-align:right">66%</td>
+			<td style="text-align:right">1,487</td>
+			<td style="text-align:right">2,884</td>
+			<td style="text-align:right">46%</td>
+			<td style="text-align:right">2,788.0</td>
+			<td style="text-align:right">6,302</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Nelson Marlborough</th>
+			<td style="text-align:right">7,513</td>
+			<td style="text-align:right">67%</td>
+			<td style="text-align:right">2,610</td>
+			<td style="text-align:right">5,633</td>
+			<td style="text-align:right">50%</td>
+			<td style="text-align:right">4,490.0</td>
+			<td style="text-align:right">11,248</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">West Coast</th>
+			<td style="text-align:right">1,896</td>
+			<td style="text-align:right">69%</td>
+			<td style="text-align:right">592</td>
+			<td style="text-align:right">1,338</td>
+			<td style="text-align:right">48%</td>
+			<td style="text-align:right">1,150.0</td>
+			<td style="text-align:right">2,765</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Canterbury</th>
+			<td style="text-align:right">26,433</td>
+			<td style="text-align:right">72%</td>
+			<td style="text-align:right">6,839</td>
+			<td style="text-align:right">17,584</td>
+			<td style="text-align:right">48%</td>
+			<td style="text-align:right">15,688.0</td>
+			<td style="text-align:right">36,969</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">South Canterbury</th>
+			<td style="text-align:right">2,293</td>
+			<td style="text-align:right">67%</td>
+			<td style="text-align:right">792</td>
+			<td style="text-align:right">1,671</td>
+			<td style="text-align:right">49%</td>
+			<td style="text-align:right">1,414.0</td>
+			<td style="text-align:right">3,428</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Southern</th>
+			<td style="text-align:right">17,044</td>
+			<td style="text-align:right">72%</td>
+			<td style="text-align:right">4,237</td>
+			<td style="text-align:right">12,845</td>
+			<td style="text-align:right">54%</td>
+			<td style="text-align:right">8,436.0</td>
+			<td style="text-align:right">23,646</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Overseas / Unknown</th>
+			<td style="text-align:right">177</td>
+			<td style="text-align:right">7%</td>
+			<td style="text-align:right">2,211</td>
+			<td style="text-align:right">125</td>
+			<td style="text-align:right">5%</td>
+			<td style="text-align:right">2,263.0</td>
+			<td style="text-align:right">2,653</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total</strong></th>
+			<td style="text-align:right"><strong>389,884</strong></td>
+			<td style="text-align:right"><strong>68%</strong></td>
+			<td style="text-align:right"><strong>124,063</strong></td>
+			<td style="text-align:right"><strong>272,446</strong></td>
+			<td style="text-align:right"><strong>48%</strong></td>
+			<td style="text-align:right"><strong>241,501.0</strong></td>
+			<td style="text-align:right"><strong>571,052</strong></td>
+		</tr>
+	</tbody>
+</table>
+
+<h4><a id="90pct Pacific Peoples" name="90pct Pacific Peoples"></a>Pacific Peoples</h4>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">&nbsp;</th>
+			<th scope="col" style="text-align:right">First doses</th>
+			<th scope="col" style="text-align:right">First doses %</th>
+			<th scope="col" style="text-align:right">First doses to 90%</th>
+			<th scope="col" style="text-align:right">Second doses</th>
+			<th scope="col" style="text-align:right">Second doses %</th>
+			<th scope="col" style="text-align:right">Second doses to 90%</th>
+			<th scope="col" style="text-align:right">Population</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">Northland</th>
+			<td style="text-align:right">2,298</td>
+			<td style="text-align:right">78%</td>
+			<td style="text-align:right">343</td>
+			<td style="text-align:right">1,608</td>
+			<td style="text-align:right">55%</td>
+			<td style="text-align:right">1,033</td>
+			<td style="text-align:right">2,934</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waitemata</th>
+			<td style="text-align:right">31,164</td>
+			<td style="text-align:right">83%</td>
+			<td style="text-align:right">2,652</td>
+			<td style="text-align:right">23,611</td>
+			<td style="text-align:right">63%</td>
+			<td style="text-align:right">10,205</td>
+			<td style="text-align:right">37,573</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Auckland</th>
+			<td style="text-align:right">38,231</td>
+			<td style="text-align:right">82%</td>
+			<td style="text-align:right">3,948</td>
+			<td style="text-align:right">29,325</td>
+			<td style="text-align:right">63%</td>
+			<td style="text-align:right">12,854</td>
+			<td style="text-align:right">46,866</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Counties Manukau</th>
+			<td style="text-align:right">93,473</td>
+			<td style="text-align:right">80%</td>
+			<td style="text-align:right">11,375</td>
+			<td style="text-align:right">71,481</td>
+			<td style="text-align:right">61%</td>
+			<td style="text-align:right">33,367</td>
+			<td style="text-align:right">116,498</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waikato</th>
+			<td style="text-align:right">8,905</td>
+			<td style="text-align:right">83%</td>
+			<td style="text-align:right">709</td>
+			<td style="text-align:right">6,772</td>
+			<td style="text-align:right">63%</td>
+			<td style="text-align:right">2,842</td>
+			<td style="text-align:right">10,682</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Lakes</th>
+			<td style="text-align:right">1,771</td>
+			<td style="text-align:right">77%</td>
+			<td style="text-align:right">286</td>
+			<td style="text-align:right">1,331</td>
+			<td style="text-align:right">58%</td>
+			<td style="text-align:right">726</td>
+			<td style="text-align:right">2,286</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Bay of Plenty</th>
+			<td style="text-align:right">3,914</td>
+			<td style="text-align:right">&gt;95%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">2,848</td>
+			<td style="text-align:right">77%</td>
+			<td style="text-align:right">463</td>
+			<td style="text-align:right">3,679</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Tairawhiti</th>
+			<td style="text-align:right">843</td>
+			<td style="text-align:right">87%</td>
+			<td style="text-align:right">26</td>
+			<td style="text-align:right">631</td>
+			<td style="text-align:right">65%</td>
+			<td style="text-align:right">238</td>
+			<td style="text-align:right">965</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Taranaki</th>
+			<td style="text-align:right">1,011</td>
+			<td style="text-align:right">80%</td>
+			<td style="text-align:right">132</td>
+			<td style="text-align:right">718</td>
+			<td style="text-align:right">57%</td>
+			<td style="text-align:right">425</td>
+			<td style="text-align:right">1,270</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hawkes Bay</th>
+			<td style="text-align:right">4,947</td>
+			<td style="text-align:right">&gt;95%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">3,940</td>
+			<td style="text-align:right">78%</td>
+			<td style="text-align:right">578</td>
+			<td style="text-align:right">5,020</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">MidCentral</th>
+			<td style="text-align:right">3,650</td>
+			<td style="text-align:right">82%</td>
+			<td style="text-align:right">371</td>
+			<td style="text-align:right">2,723</td>
+			<td style="text-align:right">61%</td>
+			<td style="text-align:right">1,298</td>
+			<td style="text-align:right">4,468</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Whanganui</th>
+			<td style="text-align:right">1,006</td>
+			<td style="text-align:right">73%</td>
+			<td style="text-align:right">237</td>
+			<td style="text-align:right">777</td>
+			<td style="text-align:right">56%</td>
+			<td style="text-align:right">466</td>
+			<td style="text-align:right">1,381</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Capital and Coast</th>
+			<td style="text-align:right">15,276</td>
+			<td style="text-align:right">80%</td>
+			<td style="text-align:right">1,983</td>
+			<td style="text-align:right">11,893</td>
+			<td style="text-align:right">62%</td>
+			<td style="text-align:right">5,366</td>
+			<td style="text-align:right">19,177</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hutt Valley</th>
+			<td style="text-align:right">7,744</td>
+			<td style="text-align:right">78%</td>
+			<td style="text-align:right">1,161</td>
+			<td style="text-align:right">5,867</td>
+			<td style="text-align:right">59%</td>
+			<td style="text-align:right">3,038</td>
+			<td style="text-align:right">9,894</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Wairarapa</th>
+			<td style="text-align:right">669</td>
+			<td style="text-align:right">80%</td>
+			<td style="text-align:right">84</td>
+			<td style="text-align:right">520</td>
+			<td style="text-align:right">62%</td>
+			<td style="text-align:right">233</td>
+			<td style="text-align:right">837</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Nelson Marlborough</th>
+			<td style="text-align:right">3,548</td>
+			<td style="text-align:right">&gt;95%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">3,059</td>
+			<td style="text-align:right">&gt;95%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">2,115</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">West Coast</th>
+			<td style="text-align:right">224</td>
+			<td style="text-align:right">79%</td>
+			<td style="text-align:right">30</td>
+			<td style="text-align:right">167</td>
+			<td style="text-align:right">59%</td>
+			<td style="text-align:right">87</td>
+			<td style="text-align:right">282</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Canterbury</th>
+			<td style="text-align:right">10,096</td>
+			<td style="text-align:right">79%</td>
+			<td style="text-align:right">1,367</td>
+			<td style="text-align:right">7,311</td>
+			<td style="text-align:right">57%</td>
+			<td style="text-align:right">4,152</td>
+			<td style="text-align:right">12,737</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">South Canterbury</th>
+			<td style="text-align:right">749</td>
+			<td style="text-align:right">89%</td>
+			<td style="text-align:right">4</td>
+			<td style="text-align:right">530</td>
+			<td style="text-align:right">63%</td>
+			<td style="text-align:right">223</td>
+			<td style="text-align:right">837</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Southern</th>
+			<td style="text-align:right">5,414</td>
+			<td style="text-align:right">90%</td>
+			<td style="text-align:right">14</td>
+			<td style="text-align:right">4,159</td>
+			<td style="text-align:right">69%</td>
+			<td style="text-align:right">1,269</td>
+			<td style="text-align:right">6,031</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Overseas / Unknown</th>
+			<td style="text-align:right">334</td>
+			<td style="text-align:right">29%</td>
+			<td style="text-align:right">700</td>
+			<td style="text-align:right">283</td>
+			<td style="text-align:right">25%</td>
+			<td style="text-align:right">751</td>
+			<td style="text-align:right">1,149</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total</strong></th>
+			<td style="text-align:right"><strong>235,267</strong></td>
+			<td style="text-align:right"><strong>82%</strong></td>
+			<td style="text-align:right"><strong>22,746</strong></td>
+			<td style="text-align:right"><strong>179,554</strong></td>
+			<td style="text-align:right"><strong>63%</strong></td>
+			<td style="text-align:right"><strong>78,459</strong></td>
+			<td style="text-align:right"><strong>286,681</strong></td>
+		</tr>
+	</tbody>
+</table>
+<!--daily_end-->
+
+<hr/>
+<h2><a id="weekly-updates" name="weekly-updates"></a>COVID-19 vaccinations: weekly updates</h2>
+
+<div class="well well-sm">
+<p style="margin-top: 0"><strong>Data in this section is as at 11:59pm 19 October 2021 and is updated weekly on Wednesdays.</strong></p>
+</div>
+
+<h3><a id="model" model="" name="id="></a>Cumulative vaccinations</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccination doses administered compared to plan doses" class="img-responsive" height="830" src="/web/20211023081356im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/vaccineplanmodel_12.png" width="1780"/></figure>
+
+<p>Production plan figures are the volumes agreed with DHBs and national providers for expected vaccinations. These figures have been matched with expected supply. Detailed plans are available in the Excel file at the bottom of this page.</p>
+
+<p>The Stock received figures are the cumulative supply of doses to date.</p>
+
+<p>DHB capacity plans for the remainder of the year are undergoing review.</p>
+
+<hr/><!--
+<h3><a id="model" model="" name="id="></a>Cumulative vaccinations for last 6 weeks</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccination doses administered compared to plan doses - 6wks" class="img-responsive" height="830" src="/vaccineplanmodel_wks.png" width="1780" /></figure>
+
+<hr />
+-->
+<h3><a id="uptake" name="uptake"></a>Vaccine uptake</h3>
+
+<p>Maps and data related to uptake rates of the COVID-19 vaccine across the country are available on the pages linked below. These show&nbsp;vaccination records aggregated by area of residence for all New Zealand residents, Māori communities, and Pacific communities.</p>
+
+<ul>
+	<li><a href="/web/20211023081356/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-across-nz">COVID-19 Vaccination uptake rates across NZ</a></li>
+	<li><a href="/web/20211023081356/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-maori-communities-across-nz">COVID-19 Vaccination uptake rates within Māori communities across NZ</a></li>
+	<li><a href="/web/20211023081356/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-pacific-communities-across-nz">COVID-19 Vaccination uptake rates within Pacific communities across NZ</a></li>
+</ul>
+
+<h4><a id="uptake" name="uptake"></a>Vaccine uptake per rate ratio (unadjusted) Māori and Pacific compared with Non-Māori non-Pacific</h4>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine Uptake per 1,000 (HSU) Rate Ratio, Showing Prioritised Ethnicity, vs Non-Māori Non-Pacific, By Age Band" class="img-responsive" height="830" src="/web/20211023081356im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_mix_7.png" width="1780"/></figure>
+
+<p>In the Chart above, rate ratios tell us the rate Māori or Pacific People per population are being vaccinated compared with non-Māori non-Pacific. This comparison can be split by age group.</p>
+
+<ul>
+	<li>A rate of one means the groups being compared are being vaccinated at the same rate.</li>
+	<li>A rate over one means Māori (or Pacific) are being vaccinated at a higher rate than non-Māori non-Pacific.</li>
+	<li>A rate under one means Māori (or Pacific) are being vaccinated at a lower rate than non-Māori non-Pacific.</li>
+</ul>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<td colspan="2" style="border-top: 0 !important; border-bottom-color: #FDD6AF !important; border-right: 0 !important;">&nbsp;</td>
+			<th colspan="6" id="ac1">Māori</th>
+			<th colspan="6" id="ac8">Pacific Peoples</th>
+		</tr>
+		<tr>
+			<th id="ar1">DHB</th>
+			<th>Dose number</th>
+			<th headers="ac1" id="ac2">65+</th>
+			<th headers="ac1" id="ac3">50-64</th>
+			<th headers="ac1" id="ac4">35-49</th>
+			<th headers="ac1" id="ac5">20-34</th>
+			<th headers="ac1" id="ac6">12-19</th>
+			<th headers="ac1" id="ac7">All ages</th>
+			<th headers="ac8" id="ac9">65+</th>
+			<th headers="ac8" id="ac10">50-64</th>
+			<th headers="ac8" id="ac11">35-49</th>
+			<th headers="ac8" id="ac12">20-34</th>
+			<th headers="ac8" id="ac13">12-19</th>
+			<th headers="ac8" id="ac14">All ages</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th headers="ar1" id="ar2" rowspan="2">National</th>
+			<th headers="ar1 ar2" id="ar3">Dose 1</th>
+			<td headers="ar1 ar2 ar3 ac1 ac2" style="background-color:green; color: #FFF;"><strong>0.99</strong></td>
+			<td headers="ar1 ar2 ar3 ac1 ac3" style="background-color:mediumseagreen"><strong>0.92</strong></td>
+			<td headers="ar1 ar2 ar3 ac1 ac4" style="background-color:yellow"><strong>0.77</strong></td>
+			<td headers="ar1 ar2 ar3 ac1 ac5" style="background-color:tomato"><strong>0.64</strong></td>
+			<td headers="ar1 ar2 ar3 ac1 ac6" style="background-color:coral"><strong>0.69</strong></td>
+			<td headers="ar1 ar2 ar3 ac1 ac7" style="background-color:yellow"><strong>0.75</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac9" style="background-color:mediumseagreen"><strong>0.94</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac10" style="background-color:green; color: #FFF;"><strong>0.99</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac11" style="background-color:green; color: #FFF;"><strong>0.97</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac12" style="background-color:lightgreen"><strong>0.87</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac13" style="background-color:lightgreen"><strong>0.89</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac14" style="background-color:mediumseagreen"><strong>0.91</strong></td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar2" id="ar4">Dose 2</th>
+			<td headers="ar1 ar2 ar4 ac1 ac2" style="background-color:green; color: #FFF;"><strong>0.96</strong></td>
+			<td headers="ar1 ar2 ar4 ac1 ac3" style="background-color:lightgreen"><strong>0.87</strong></td>
+			<td headers="ar1 ar2 ar4 ac1 ac4" style="background-color:coral"><strong>0.68</strong></td>
+			<td headers="ar1 ar2 ar4 ac1 ac5" style="background-color:crimson; color: #FFF;"><strong>0.51</strong></td>
+			<td headers="ar1 ar2 ar4 ac1 ac6" style="background-color:crimson; color: #FFF;"><strong>0.57</strong></td>
+			<td headers="ar1 ar2 ar4 ac1 ac7" style="background-color:tomato"><strong>0.64</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac9" style="background-color:mediumseagreen"><strong>0.91</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac10" style="background-color:green; color: #FFF;"><strong>0.99</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac11" style="background-color:green; color: #FFF;"><strong>0.98</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac12" style="background-color:palegreen"><strong>0.82</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac13" style="background-color:lightgreen"><strong>0.85</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac14" style="background-color:palegreen"><strong>0.84</strong></td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar5" rowspan="2">Northland</th>
+			<th headers="ar1 ar5" id="ar6">Dose 1</th>
+			<td headers="ar1 ar5 ar6 ac1 ac2" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar5 ar6 ac1 ac3" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar5 ar6 ac1 ac4" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar5 ar6 ac1 ac5" style="background-color:tomato">0.64</td>
+			<td headers="ar1 ar5 ar6 ac1 ac6" style="background-color:orange">0.72</td>
+			<td headers="ar1 ar5 ar6 ac1 ac7" style="background-color:yellow">0.76</td>
+			<td headers="ar1 ar5 ar6 ac8 ac9" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar5 ar6 ac8 ac10" style="background-color:green; color: #FFF;">1.05</td>
+			<td headers="ar1 ar5 ar6 ac8 ac11" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar5 ar6 ac8 ac12" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar5 ar6 ac8 ac13" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar5 ar6 ac8 ac14" style="background-color:mediumseagreen">0.93</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar5" id="ar7">Dose 2</th>
+			<td headers="ar1 ar5 ar7 ac1 ac2" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar5 ar7 ac1 ac3" style="background-color:lightgreen">0.86</td>
+			<td headers="ar1 ar5 ar7 ac1 ac4" style="background-color:coral">0.68</td>
+			<td headers="ar1 ar5 ar7 ac1 ac5" style="background-color:crimson; color: #FFF;">0.48</td>
+			<td headers="ar1 ar5 ar7 ac1 ac6" style="background-color:crimson; color: #FFF;">0.58</td>
+			<td headers="ar1 ar5 ar7 ac1 ac7" style="background-color:tomato">0.62</td>
+			<td headers="ar1 ar5 ar7 ac8 ac9" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar5 ar7 ac8 ac10" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar5 ar7 ac8 ac11" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar5 ar7 ac8 ac12" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar5 ar7 ac8 ac13" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar5 ar7 ac8 ac14" style="background-color:yellow">0.78</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar8" rowspan="2">Auckland Metro</th>
+			<th headers="ar1 ar8" id="ar9">Dose 1</th>
+			<td headers="ar1 ar8 ar9 ac1 ac2" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar8 ar9 ac1 ac3" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar8 ar9 ac1 ac4" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar8 ar9 ac1 ac5" style="background-color:coral">0.68</td>
+			<td headers="ar1 ar8 ar9 ac1 ac6" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar8 ar9 ac1 ac7" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar8 ar9 ac8 ac9" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar8 ar9 ac8 ac10" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar8 ar9 ac8 ac11" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar8 ar9 ac8 ac12" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar8 ar9 ac8 ac13" style="background-color:palegreen">0.81</td>
+			<td headers="ar1 ar8 ar9 ac8 ac14" style="background-color:lightgreen">0.86</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar8" id="ar10">Dose 2</th>
+			<td headers="ar1 ar8 ar10 ac1 ac2" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar8 ar10 ac1 ac3" style="background-color:lightgreen">0.88</td>
+			<td headers="ar1 ar8 ar10 ac1 ac4" style="background-color:coral">0.68</td>
+			<td headers="ar1 ar8 ar10 ac1 ac5" style="background-color:crimson; color: #FFF;">0.52</td>
+			<td headers="ar1 ar8 ar10 ac1 ac6" style="background-color:crimson; color: #FFF;">0.57</td>
+			<td headers="ar1 ar8 ar10 ac1 ac7" style="background-color:coral">0.65</td>
+			<td headers="ar1 ar8 ar10 ac8 ac9" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar8 ar10 ac8 ac10" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar8 ar10 ac8 ac11" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar8 ar10 ac8 ac12" style="background-color:coral">0.65</td>
+			<td headers="ar1 ar8 ar10 ac8 ac13" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar8 ar10 ac8 ac14" style="background-color:yellow">0.77</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar11" rowspan="2">Waikato</th>
+			<th headers="ar1 ar11" id="ar12">Dose 1</th>
+			<td headers="ar1 ar11 ar12 ac1 ac2" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar11 ar12 ac1 ac3" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar11 ar12 ac1 ac4" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar11 ar12 ac1 ac5" style="background-color:coral">0.66</td>
+			<td headers="ar1 ar11 ar12 ac1 ac6" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar11 ar12 ac1 ac7" style="background-color:yellow">0.76</td>
+			<td headers="ar1 ar11 ar12 ac8 ac9" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar11 ar12 ac8 ac10" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar11 ar12 ac8 ac11" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar11 ar12 ac8 ac12" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar11 ar12 ac8 ac13" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar11 ar12 ac8 ac14" style="background-color:mediumseagreen">0.93</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar11" id="ar13">Dose 2</th>
+			<td headers="ar1 ar11 ar13 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar11 ar13 ac1 ac3" style="background-color:lightgreen">0.87</td>
+			<td headers="ar1 ar11 ar13 ac1 ac4" style="background-color:coral">0.68</td>
+			<td headers="ar1 ar11 ar13 ac1 ac5" style="background-color:crimson; color: #FFF;">0.50</td>
+			<td headers="ar1 ar11 ar13 ac1 ac6" style="background-color:crimson; color: #FFF;">0.56</td>
+			<td headers="ar1 ar11 ar13 ac1 ac7" style="background-color:tomato">0.63</td>
+			<td headers="ar1 ar11 ar13 ac8 ac9" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar11 ar13 ac8 ac10" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar11 ar13 ac8 ac11" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar11 ar13 ac8 ac12" style="background-color:lightgreen">0.86</td>
+			<td headers="ar1 ar11 ar13 ac8 ac13" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar11 ar13 ac8 ac14" style="background-color:lightgreen">0.87</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar14" rowspan="2">Bay of Plenty</th>
+			<th headers="ar1 ar14" id="ar15">Dose 1</th>
+			<td headers="ar1 ar14 ar15 ac1 ac2" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar14 ar15 ac1 ac3" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar14 ar15 ac1 ac4" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar14 ar15 ac1 ac5" style="background-color:crimson; color: #FFF;">0.55</td>
+			<td headers="ar1 ar14 ar15 ac1 ac6" style="background-color:tomato">0.62</td>
+			<td headers="ar1 ar14 ar15 ac1 ac7" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar14 ar15 ac8 ac9" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar14 ar15 ac8 ac10" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar14 ar15 ac8 ac11" style="background-color:green; color: #FFF;">1.44</td>
+			<td headers="ar1 ar14 ar15 ac8 ac12" style="background-color:green; color: #FFF;">1.50</td>
+			<td headers="ar1 ar14 ar15 ac8 ac13" style="background-color:lightgreen">0.87</td>
+			<td headers="ar1 ar14 ar15 ac8 ac14" style="background-color:green; color: #FFF;">1.20</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar14" id="ar16">Dose 2</th>
+			<td headers="ar1 ar14 ar16 ac1 ac2" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar14 ar16 ac1 ac3" style="background-color:palegreen">0.84</td>
+			<td headers="ar1 ar14 ar16 ac1 ac4" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar14 ar16 ac1 ac5" style="background-color:crimson; color: #FFF;">0.46</td>
+			<td headers="ar1 ar14 ar16 ac1 ac6" style="background-color:crimson; color: #FFF;">0.54</td>
+			<td headers="ar1 ar14 ar16 ac1 ac7" style="background-color:crimson; color: #FFF;">0.59</td>
+			<td headers="ar1 ar14 ar16 ac8 ac9" style="background-color:lightgreen">0.88</td>
+			<td headers="ar1 ar14 ar16 ac8 ac10" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar14 ar16 ac8 ac11" style="background-color:green; color: #FFF;">1.64</td>
+			<td headers="ar1 ar14 ar16 ac8 ac12" style="background-color:green; color: #FFF;">1.91</td>
+			<td headers="ar1 ar14 ar16 ac8 ac13" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar14 ar16 ac8 ac14" style="background-color:green; color: #FFF;">1.13</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar17" rowspan="2">Tairawhiti</th>
+			<th headers="ar1 ar17" id="ar18">Dose 1</th>
+			<td headers="ar1 ar17 ar18 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar17 ar18 ac1 ac3" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar17 ar18 ac1 ac4" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar17 ar18 ac1 ac5" style="background-color:tomato">0.60</td>
+			<td headers="ar1 ar17 ar18 ac1 ac6" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar17 ar18 ac1 ac7" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar17 ar18 ac8 ac9" style="background-color:green; color: #FFF;">1.05</td>
+			<td headers="ar1 ar17 ar18 ac8 ac10" style="background-color:green; color: #FFF;">1.07</td>
+			<td headers="ar1 ar17 ar18 ac8 ac11" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar17 ar18 ac8 ac12" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar17 ar18 ac8 ac13" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar17 ar18 ac8 ac14" style="background-color:green; color: #FFF;">0.99</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar17" id="ar19">Dose 2</th>
+			<td headers="ar1 ar17 ar19 ac1 ac2" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar17 ar19 ac1 ac3" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar17 ar19 ac1 ac4" style="background-color:coral">0.69</td>
+			<td headers="ar1 ar17 ar19 ac1 ac5" style="background-color:crimson; color: #FFF;">0.49</td>
+			<td headers="ar1 ar17 ar19 ac1 ac6" style="background-color:crimson; color: #FFF;">0.55</td>
+			<td headers="ar1 ar17 ar19 ac1 ac7" style="background-color:tomato">0.64</td>
+			<td headers="ar1 ar17 ar19 ac8 ac9" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar17 ar19 ac8 ac10" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar17 ar19 ac8 ac11" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar17 ar19 ac8 ac12" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar17 ar19 ac8 ac13" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar17 ar19 ac8 ac14" style="background-color:lightgreen">0.88</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar20" rowspan="2">Lakes</th>
+			<th headers="ar1 ar20" id="ar21">Dose 1</th>
+			<td headers="ar1 ar20 ar21 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar20 ar21 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar20 ar21 ac1 ac4" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar20 ar21 ac1 ac5" style="background-color:crimson; color: #FFF;">0.56</td>
+			<td headers="ar1 ar20 ar21 ac1 ac6" style="background-color:tomato">0.64</td>
+			<td headers="ar1 ar20 ar21 ac1 ac7" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar20 ar21 ac8 ac9" style="background-color:green; color: #FFF;">1.06</td>
+			<td headers="ar1 ar20 ar21 ac8 ac10" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar20 ar21 ac8 ac11" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar20 ar21 ac8 ac12" style="background-color:palegreen">0.81</td>
+			<td headers="ar1 ar20 ar21 ac8 ac13" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar20 ar21 ac8 ac14" style="background-color:lightgreen">0.89</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar20" id="ar22">Dose 2</th>
+			<td headers="ar1 ar20 ar22 ac1 ac2" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar20 ar22 ac1 ac3" style="background-color:palegreen">0.84</td>
+			<td headers="ar1 ar20 ar22 ac1 ac4" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar20 ar22 ac1 ac5" style="background-color:crimson; color: #FFF;">0.45</td>
+			<td headers="ar1 ar20 ar22 ac1 ac6" style="background-color:crimson; color: #FFF;">0.54</td>
+			<td headers="ar1 ar20 ar22 ac1 ac7" style="background-color:tomato">0.60</td>
+			<td headers="ar1 ar20 ar22 ac8 ac9" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar20 ar22 ac8 ac10" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar20 ar22 ac8 ac11" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar20 ar22 ac8 ac12" style="background-color:lightgreen">0.87</td>
+			<td headers="ar1 ar20 ar22 ac8 ac13" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar20 ar22 ac8 ac14" style="background-color:palegreen">0.84</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar23" rowspan="2">Taranaki</th>
+			<th headers="ar1 ar23" id="ar24">Dose 1</th>
+			<td headers="ar1 ar23 ar24 ac1 ac2" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar23 ar24 ac1 ac3" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar23 ar24 ac1 ac4" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar23 ar24 ac1 ac5" style="background-color:coral">0.65</td>
+			<td headers="ar1 ar23 ar24 ac1 ac6" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar23 ar24 ac1 ac7" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar23 ar24 ac8 ac9" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar23 ar24 ac8 ac10" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar23 ar24 ac8 ac11" style="background-color:green; color: #FFF;">1.05</td>
+			<td headers="ar1 ar23 ar24 ac8 ac12" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar23 ar24 ac8 ac13" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar23 ar24 ac8 ac14" style="background-color:mediumseagreen">0.93</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar23" id="ar25">Dose 2</th>
+			<td headers="ar1 ar23 ar25 ac1 ac2" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar23 ar25 ac1 ac3" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar23 ar25 ac1 ac4" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar23 ar25 ac1 ac5" style="background-color:crimson; color: #FFF;">0.52</td>
+			<td headers="ar1 ar23 ar25 ac1 ac6" style="background-color:crimson; color: #FFF;">0.54</td>
+			<td headers="ar1 ar23 ar25 ac1 ac7" style="background-color:tomato">0.62</td>
+			<td headers="ar1 ar23 ar25 ac8 ac9" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar23 ar25 ac8 ac10" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar23 ar25 ac8 ac11" style="background-color:green; color: #FFF;">1.23</td>
+			<td headers="ar1 ar23 ar25 ac8 ac12" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar23 ar25 ac8 ac13" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar23 ar25 ac8 ac14" style="background-color:lightgreen">0.88</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar26" rowspan="2">Whanganui</th>
+			<th headers="ar1 ar26" id="ar27">Dose 1</th>
+			<td headers="ar1 ar26 ar27 ac1 ac2" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar26 ar27 ac1 ac3" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar26 ar27 ac1 ac4" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar26 ar27 ac1 ac5" style="background-color:tomato">0.63</td>
+			<td headers="ar1 ar26 ar27 ac1 ac6" style="background-color:coral">0.68</td>
+			<td headers="ar1 ar26 ar27 ac1 ac7" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar26 ar27 ac8 ac9" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar26 ar27 ac8 ac10" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar26 ar27 ac8 ac11" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar26 ar27 ac8 ac12" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar26 ar27 ac8 ac13" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar26 ar27 ac8 ac14" style="background-color:lightgreen">0.86</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar26" id="ar28">Dose 2</th>
+			<td headers="ar1 ar26 ar28 ac1 ac2" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar26 ar28 ac1 ac3" style="background-color:lightgreen">0.88</td>
+			<td headers="ar1 ar26 ar28 ac1 ac4" style="background-color:coral">0.69</td>
+			<td headers="ar1 ar26 ar28 ac1 ac5" style="background-color:crimson; color: #FFF;">0.49</td>
+			<td headers="ar1 ar26 ar28 ac1 ac6" style="background-color:crimson; color: #FFF;">0.59</td>
+			<td headers="ar1 ar26 ar28 ac1 ac7" style="background-color:tomato">0.63</td>
+			<td headers="ar1 ar26 ar28 ac8 ac9" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar26 ar28 ac8 ac10" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar26 ar28 ac8 ac11" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar26 ar28 ac8 ac12" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar26 ar28 ac8 ac13" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar26 ar28 ac8 ac14" style="background-color:yellow">0.77</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar29" rowspan="2">Hawke&#39;s Bay</th>
+			<th headers="ar1 ar29" id="ar30">Dose 1</th>
+			<td headers="ar1 ar29 ar30 ac1 ac2" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar29 ar30 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar29 ar30 ac1 ac4" style="background-color:yellow">0.77</td>
+			<td headers="ar1 ar29 ar30 ac1 ac5" style="background-color:crimson; color: #FFF;">0.58</td>
+			<td headers="ar1 ar29 ar30 ac1 ac6" style="background-color:coral">0.69</td>
+			<td headers="ar1 ar29 ar30 ac1 ac7" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar29 ar30 ac8 ac9" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar29 ar30 ac8 ac10" style="background-color:green; color: #FFF;">1.05</td>
+			<td headers="ar1 ar29 ar30 ac8 ac11" style="background-color:green; color: #FFF;">1.41</td>
+			<td headers="ar1 ar29 ar30 ac8 ac12" style="background-color:green; color: #FFF;">1.33</td>
+			<td headers="ar1 ar29 ar30 ac8 ac13" style="background-color:lightgreen">0.88</td>
+			<td headers="ar1 ar29 ar30 ac8 ac14" style="background-color:green; color: #FFF;">1.15</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar29" id="ar31">Dose 2</th>
+			<td headers="ar1 ar29 ar31 ac1 ac2" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar29 ar31 ac1 ac3" style="background-color:palegreen">0.84</td>
+			<td headers="ar1 ar29 ar31 ac1 ac4" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar29 ar31 ac1 ac5" style="background-color:crimson; color: #FFF;">0.48</td>
+			<td headers="ar1 ar29 ar31 ac1 ac6" style="background-color:crimson; color: #FFF;">0.57</td>
+			<td headers="ar1 ar29 ar31 ac1 ac7" style="background-color:tomato">0.61</td>
+			<td headers="ar1 ar29 ar31 ac8 ac9" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar29 ar31 ac8 ac10" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar29 ar31 ac8 ac11" style="background-color:green; color: #FFF;">1.52</td>
+			<td headers="ar1 ar29 ar31 ac8 ac12" style="background-color:green; color: #FFF;">1.56</td>
+			<td headers="ar1 ar29 ar31 ac8 ac13" style="background-color:lightgreen">0.86</td>
+			<td headers="ar1 ar29 ar31 ac8 ac14" style="background-color:green; color: #FFF;">1.10</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar32" rowspan="2">MidCentral</th>
+			<th headers="ar1 ar32" id="ar33">Dose 1</th>
+			<td headers="ar1 ar32 ar33 ac1 ac2" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar32 ar33 ac1 ac3" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar32 ar33 ac1 ac4" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar32 ar33 ac1 ac5" style="background-color:coral">0.69</td>
+			<td headers="ar1 ar32 ar33 ac1 ac6" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar32 ar33 ac1 ac7" style="background-color:yellow">0.76</td>
+			<td headers="ar1 ar32 ar33 ac8 ac9" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar32 ar33 ac8 ac10" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar32 ar33 ac8 ac11" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar32 ar33 ac8 ac12" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar32 ar33 ac8 ac13" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar32 ar33 ac8 ac14" style="background-color:mediumseagreen">0.93</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar32" id="ar34">Dose 2</th>
+			<td headers="ar1 ar32 ar34 ac1 ac2" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar32 ar34 ac1 ac3" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar32 ar34 ac1 ac4" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar32 ar34 ac1 ac5" style="background-color:crimson; color: #FFF;">0.58</td>
+			<td headers="ar1 ar32 ar34 ac1 ac6" style="background-color:tomato">0.60</td>
+			<td headers="ar1 ar32 ar34 ac1 ac7" style="background-color:coral">0.66</td>
+			<td headers="ar1 ar32 ar34 ac8 ac9" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar32 ar34 ac8 ac10" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar32 ar34 ac8 ac11" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar32 ar34 ac8 ac12" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar32 ar34 ac8 ac13" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar32 ar34 ac8 ac14" style="background-color:palegreen">0.84</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar35" rowspan="2">Wairarapa</th>
+			<th headers="ar1 ar35" id="ar36">Dose 1</th>
+			<td headers="ar1 ar35 ar36 ac1 ac2" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar35 ar36 ac1 ac3" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar35 ar36 ac1 ac4" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar35 ar36 ac1 ac5" style="background-color:coral">0.68</td>
+			<td headers="ar1 ar35 ar36 ac1 ac6" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar35 ar36 ac1 ac7" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar35 ar36 ac8 ac9" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar35 ar36 ac8 ac10" style="background-color:green; color: #FFF;">1.07</td>
+			<td headers="ar1 ar35 ar36 ac8 ac11" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar35 ar36 ac8 ac12" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar35 ar36 ac8 ac13" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar35 ar36 ac8 ac14" style="background-color:mediumseagreen">0.92</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar35" id="ar37">Dose 2</th>
+			<td headers="ar1 ar35 ar37 ac1 ac2" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar35 ar37 ac1 ac3" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar35 ar37 ac1 ac4" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar35 ar37 ac1 ac5" style="background-color:crimson; color: #FFF;">0.54</td>
+			<td headers="ar1 ar35 ar37 ac1 ac6" style="background-color:crimson; color: #FFF;">0.59</td>
+			<td headers="ar1 ar35 ar37 ac1 ac7" style="background-color:tomato">0.62</td>
+			<td headers="ar1 ar35 ar37 ac8 ac9" style="background-color:green; color: #FFF;">1.06</td>
+			<td headers="ar1 ar35 ar37 ac8 ac10" style="background-color:green; color: #FFF;">1.06</td>
+			<td headers="ar1 ar35 ar37 ac8 ac11" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar35 ar37 ac8 ac12" style="background-color:green; color: #FFF;">1.06</td>
+			<td headers="ar1 ar35 ar37 ac8 ac13" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar35 ar37 ac8 ac14" style="background-color:lightgreen">0.85</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar38" rowspan="2">Capital &amp; Coast and Hutt Valley</th>
+			<th headers="ar1 ar38" id="ar39">Dose 1</th>
+			<td headers="ar1 ar38 ar39 ac1 ac2" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar38 ar39 ac1 ac3" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar38 ar39 ac1 ac4" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar38 ar39 ac1 ac5" style="background-color:orange">0.72</td>
+			<td headers="ar1 ar38 ar39 ac1 ac6" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar38 ar39 ac1 ac7" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar38 ar39 ac8 ac9" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar38 ar39 ac8 ac10" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar38 ar39 ac8 ac11" style="background-color:lightgreen">0.88</td>
+			<td headers="ar1 ar38 ar39 ac8 ac12" style="background-color:yellow">0.76</td>
+			<td headers="ar1 ar38 ar39 ac8 ac13" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar38 ar39 ac8 ac14" style="background-color:lightgreen">0.85</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar38" id="ar40">Dose 2</th>
+			<td headers="ar1 ar38 ar40 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar38 ar40 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar38 ar40 ac1 ac4" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar38 ar40 ac1 ac5" style="background-color:tomato">0.63</td>
+			<td headers="ar1 ar38 ar40 ac1 ac6" style="background-color:tomato">0.62</td>
+			<td headers="ar1 ar38 ar40 ac1 ac7" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar38 ar40 ac8 ac9" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar38 ar40 ac8 ac10" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar38 ar40 ac8 ac11" style="background-color:lightgreen">0.87</td>
+			<td headers="ar1 ar38 ar40 ac8 ac12" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar38 ar40 ac8 ac13" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar38 ar40 ac8 ac14" style="background-color:palegreen">0.80</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar41" rowspan="2">Nelson Marlborough</th>
+			<th headers="ar1 ar41" id="ar42">Dose 1</th>
+			<td headers="ar1 ar41 ar42 ac1 ac2" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar41 ar42 ac1 ac3" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar41 ar42 ac1 ac4" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar41 ar42 ac1 ac5" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar41 ar42 ac1 ac6" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar41 ar42 ac1 ac7" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar41 ar42 ac8 ac9" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar41 ar42 ac8 ac10" style="background-color:green; color: #FFF;">1.27</td>
+			<td headers="ar1 ar41 ar42 ac8 ac11" style="background-color:green; color: #FFF;">2.48</td>
+			<td headers="ar1 ar41 ar42 ac8 ac12" style="background-color:green; color: #FFF;">2.97</td>
+			<td headers="ar1 ar41 ar42 ac8 ac13" style="background-color:green; color: #FFF;">1.07</td>
+			<td headers="ar1 ar41 ar42 ac8 ac14" style="background-color:green; color: #FFF;">1.97</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar41" id="ar43">Dose 2</th>
+			<td headers="ar1 ar41 ar43 ac1 ac2" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar41 ar43 ac1 ac3" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar41 ar43 ac1 ac4" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar41 ar43 ac1 ac5" style="background-color:crimson; color: #FFF;">0.54</td>
+			<td headers="ar1 ar41 ar43 ac1 ac6" style="background-color:coral">0.66</td>
+			<td headers="ar1 ar41 ar43 ac1 ac7" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar41 ar43 ac8 ac9" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar41 ar43 ac8 ac10" style="background-color:green; color: #FFF;">1.25</td>
+			<td headers="ar1 ar41 ar43 ac8 ac11" style="background-color:green; color: #FFF;">2.65</td>
+			<td headers="ar1 ar41 ar43 ac8 ac12" style="background-color:green; color: #FFF;">3.65</td>
+			<td headers="ar1 ar41 ar43 ac8 ac13" style="background-color:green; color: #FFF;">1.05</td>
+			<td headers="ar1 ar41 ar43 ac8 ac14" style="background-color:green; color: #FFF;">1.96</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar44" rowspan="2">West Coast</th>
+			<th headers="ar1 ar44" id="ar45">Dose 1</th>
+			<td headers="ar1 ar44 ar45 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar44 ar45 ac1 ac3" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar44 ar45 ac1 ac4" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar44 ar45 ac1 ac5" style="background-color:yellow">0.77</td>
+			<td headers="ar1 ar44 ar45 ac1 ac6" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar44 ar45 ac1 ac7" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar44 ar45 ac8 ac9" style="background-color:green; color: #FFF;">1.34</td>
+			<td headers="ar1 ar44 ar45 ac8 ac10" style="background-color:green; color: #FFF;">1.05</td>
+			<td headers="ar1 ar44 ar45 ac8 ac11" style="background-color:green; color: #FFF;">1.07</td>
+			<td headers="ar1 ar44 ar45 ac8 ac12" style="background-color:green; color: #FFF;">1.27</td>
+			<td headers="ar1 ar44 ar45 ac8 ac13" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar44 ar45 ac8 ac14" style="background-color:green; color: #FFF;">0.99</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar44" id="ar46">Dose 2</th>
+			<td headers="ar1 ar44 ar46 ac1 ac2" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar44 ar46 ac1 ac3" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar44 ar46 ac1 ac4" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar44 ar46 ac1 ac5" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar44 ar46 ac1 ac6" style="background-color:lightgreen">0.88</td>
+			<td headers="ar1 ar44 ar46 ac1 ac7" style="background-color:yellow">0.76</td>
+			<td headers="ar1 ar44 ar46 ac8 ac9" style="background-color:green; color: #FFF;">1.35</td>
+			<td headers="ar1 ar44 ar46 ac8 ac10" style="background-color:green; color: #FFF;">1.07</td>
+			<td headers="ar1 ar44 ar46 ac8 ac11" style="background-color:green; color: #FFF;">1.07</td>
+			<td headers="ar1 ar44 ar46 ac8 ac12" style="background-color:green; color: #FFF;">1.58</td>
+			<td headers="ar1 ar44 ar46 ac8 ac13" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar44 ar46 ac8 ac14" style="background-color:mediumseagreen">0.92</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar47" rowspan="2">Canterbury</th>
+			<th headers="ar1 ar47" id="ar48">Dose 1</th>
+			<td headers="ar1 ar47 ar48 ac1 ac2" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar47 ar48 ac1 ac3" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar47 ar48 ac1 ac4" style="background-color:palegreen">0.81</td>
+			<td headers="ar1 ar47 ar48 ac1 ac5" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar47 ar48 ac1 ac6" style="background-color:yellow">0.76</td>
+			<td headers="ar1 ar47 ar48 ac1 ac7" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar47 ar48 ac8 ac9" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar47 ar48 ac8 ac10" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar47 ar48 ac8 ac11" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar47 ar48 ac8 ac12" style="background-color:palegreen">0.84</td>
+			<td headers="ar1 ar47 ar48 ac8 ac13" style="background-color:lightgreen">0.88</td>
+			<td headers="ar1 ar47 ar48 ac8 ac14" style="background-color:lightgreen">0.88</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar47" id="ar49">Dose 2</th>
+			<td headers="ar1 ar47 ar49 ac1 ac2" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar47 ar49 ac1 ac3" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar47 ar49 ac1 ac4" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar47 ar49 ac1 ac5" style="background-color:coral">0.68</td>
+			<td headers="ar1 ar47 ar49 ac1 ac6" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar47 ar49 ac1 ac7" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar47 ar49 ac8 ac9" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar47 ar49 ac8 ac10" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar47 ar49 ac8 ac11" style="background-color:green; color: #FFF;">1.10</td>
+			<td headers="ar1 ar47 ar49 ac8 ac12" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar47 ar49 ac8 ac13" style="background-color:green; color: #FFF;">1.10</td>
+			<td headers="ar1 ar47 ar49 ac8 ac14" style="background-color:lightgreen">0.87</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar50" rowspan="2">South Canterbury</th>
+			<th headers="ar1 ar50" id="ar51">Dose 1</th>
+			<td headers="ar1 ar50 ar51 ac1 ac2" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar50 ar51 ac1 ac3" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar50 ar51 ac1 ac4" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar50 ar51 ac1 ac5" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar50 ar51 ac1 ac6" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar50 ar51 ac1 ac7" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar50 ar51 ac8 ac9" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar50 ar51 ac8 ac10" style="background-color:green; color: #FFF;">1.10</td>
+			<td headers="ar1 ar50 ar51 ac8 ac11" style="background-color:green; color: #FFF;">1.19</td>
+			<td headers="ar1 ar50 ar51 ac8 ac12" style="background-color:green; color: #FFF;">1.21</td>
+			<td headers="ar1 ar50 ar51 ac8 ac13" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar50 ar51 ac8 ac14" style="background-color:green; color: #FFF;">1.05</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar50" id="ar52">Dose 2</th>
+			<td headers="ar1 ar50 ar52 ac1 ac2" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar50 ar52 ac1 ac3" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar50 ar52 ac1 ac4" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar50 ar52 ac1 ac5" style="background-color:tomato">0.64</td>
+			<td headers="ar1 ar50 ar52 ac1 ac6" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar50 ar52 ac1 ac7" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar50 ar52 ac8 ac9" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar50 ar52 ac8 ac10" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar50 ar52 ac8 ac11" style="background-color:green; color: #FFF;">1.15</td>
+			<td headers="ar1 ar50 ar52 ac8 ac12" style="background-color:green; color: #FFF;">1.17</td>
+			<td headers="ar1 ar50 ar52 ac8 ac13" style="background-color:green; color: #FFF;">1.07</td>
+			<td headers="ar1 ar50 ar52 ac8 ac14" style="background-color:lightgreen">0.87</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar53" rowspan="2">Southern</th>
+			<th headers="ar1 ar53" id="ar54">Dose 1</th>
+			<td headers="ar1 ar53 ar54 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar53 ar54 ac1 ac3" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar53 ar54 ac1 ac4" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar53 ar54 ac1 ac5" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar53 ar54 ac1 ac6" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar53 ar54 ac1 ac7" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar53 ar54 ac8 ac9" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar53 ar54 ac8 ac10" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar53 ar54 ac8 ac11" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar53 ar54 ac8 ac12" style="background-color:green; color: #FFF;">1.09</td>
+			<td headers="ar1 ar53 ar54 ac8 ac13" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar53 ar54 ac8 ac14" style="background-color:green; color: #FFF;">1.01</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar53" id="ar55">Dose 2</th>
+			<td headers="ar1 ar53 ar55 ac1 ac2" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar53 ar55 ac1 ac3" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar53 ar55 ac1 ac4" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar53 ar55 ac1 ac5" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar53 ar55 ac1 ac6" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar53 ar55 ac1 ac7" style="background-color:orange">0.72</td>
+			<td headers="ar1 ar53 ar55 ac8 ac9" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar53 ar55 ac8 ac10" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar53 ar55 ac8 ac11" style="background-color:green; color: #FFF;">1.11</td>
+			<td headers="ar1 ar53 ar55 ac8 ac12" style="background-color:green; color: #FFF;">1.07</td>
+			<td headers="ar1 ar53 ar55 ac8 ac13" style="background-color:lightgreen">0.86</td>
+			<td headers="ar1 ar53 ar55 ac8 ac14" style="background-color:mediumseagreen">0.92</td>
+		</tr>
+	</tbody>
+</table>
+
+<p>This table shows the rate of doses administered (per 1,000 population) to Māori or Pacific Peoples, relative to the rate of doses for Non-Māori and Non-Pacific groups. Less than one means the group is receiving a lower proportion of doses than would be expected if equity is being achieved. More than one means they are receiving a higher proportion of doses than would be expected if equity is being achieved. Exactly one means doses administered are in line with their proportion of population.</p>
+
+<ul>
+	<li><a download="" href="/web/20211023081356/https://www.health.govt.nz/system/files/documents/pages/rateratioexplainer_1.docx">Rate Ratio Explainer (Word, 434 KB)</a></li>
+</ul>
+
+<p>At all ages the size (weightings) of the age groups becomes a major contributing factor to comparative ratios, which is why the all ages (12+) figure may not appear to be in line with the age splits.</p>
+
+<h4><a id="uptake" name="uptake"></a>Vaccine uptake per 1,000 people by ethnicity</h4>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine uptake per 1,000 people by ethnicity" class="img-responsive" height="830" src="/web/20211023081356im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_eth_7.png" width="1780"/></figure>
+
+<h4><a id="uptake" name="uptake"></a>Vaccine uptake per 1,000 people by age band</h4>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine uptake per 1,000 people by age band" class="img-responsive" height="1030" src="/web/20211023081356im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_age_8.png" width="1780"/></figure>
+
+<h4><a id="uptake" name="location"></a>Vaccine uptake per 1,000 people by DHB of residence</h4>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine uptake per 1,000 people by DHB of residence" class="img-responsive" height="1030" src="/web/20211023081356im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_dhb_3.png" width="1780"/></figure>
+<!--
+<hr />
+<h3><a id="by_dhb_plan" name="dhb_plan"></a>Cumulative vaccination plan for DHBs</h3>
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">DHB of service</th>
+			<th scope="col" style="text-align:right">Actuals to Sunday 17 October</th>
+			<th scope="col" style="text-align:right">DHB Plan to Sunday 17 October</th>
+			<th scope="col" style="text-align:right">Variance</th>
+			<th scope="col" style="text-align:right">% of Plan</th>
+			<th scope="col" style="text-align:right">Week to date</th>
+		</tr>
+	</thead>
+	<tbody> --><!--plan--><!--
+<tr><td nowrap="nowrap">Auckland Metro</td><td>190621</td><td>205515</td><td>-14894</td><td>93%</td><td>9913</td></tr>
+<tr><td nowrap="nowrap">Bay of Plenty</td><td>22841</td><td>14255</td><td>8586</td><td>160%</td><td>1843</td></tr>
+<tr><td nowrap="nowrap">Canterbury</td><td>50558</td><td>39266</td><td>11292</td><td>129%</td><td>2769</td></tr>
+<tr><td nowrap="nowrap">Capital & Coast and Hutt Valley</td><td>48758</td><td>39742</td><td>9016</td><td>123%</td><td>1796</td></tr>
+<tr><td nowrap="nowrap">Hawke's Bay</td><td>15319</td><td>18205</td><td>-2886</td><td>84%</td><td>1351</td></tr>
+<tr><td nowrap="nowrap">Lakes</td><td>13437</td><td>12810</td><td>627</td><td>105%</td><td>731</td></tr>
+<tr><td nowrap="nowrap">MidCentral</td><td>10708</td><td>7237</td><td>3471</td><td>148%</td><td>1191</td></tr>
+<tr><td nowrap="nowrap">Nelson Marlborough</td><td>30198</td><td>18574</td><td>11624</td><td>163%</td><td>1285</td></tr>
+<tr><td nowrap="nowrap">Northland</td><td>21469</td><td>24762</td><td>-3293</td><td>87%</td><td>1257</td></tr>
+<tr><td nowrap="nowrap">South Canterbury</td><td>8106</td><td>8033</td><td>73</td><td>101%</td><td>389</td></tr>
+<tr><td nowrap="nowrap">Southern</td><td>35234</td><td>34594</td><td>640</td><td>102%</td><td>1794</td></tr>
+<tr><td nowrap="nowrap">Tairāwhiti</td><td>4579</td><td>4928</td><td>-349</td><td>93%</td><td>290</td></tr>
+<tr><td nowrap="nowrap">Taranaki</td><td>5619</td><td>5297</td><td>322</td><td>106%</td><td>168</td></tr>
+<tr><td nowrap="nowrap">Waikato</td><td>36070</td><td>32842</td><td>3228</td><td>110%</td><td>1905</td></tr>
+<tr><td nowrap="nowrap">Wairarapa</td><td>4516</td><td>4960</td><td>-444</td><td>91%</td><td>468</td></tr>
+<tr><td nowrap="nowrap">West Coast</td><td>3533</td><td>3300</td><td>233</td><td>107%</td><td>336</td></tr>
+<tr><td nowrap="nowrap">Whanganui</td><td>6982</td><td>4711</td><td>2271</td><td>148%</td><td>612</td></tr>
+<tr><td nowrap="nowrap">Other Sites</td><td>24890</td><td>14575</td><td>10315</td><td>171%</td><td>613</td></tr>
+<tr><td nowrap="nowrap">Total</td><td>533438</td><td>493606</td><td>39832</td><td>108%</td><td>28711</td></tr>
+!--plan_end--><!--	</tbody>
+</table>
+
+
+<p>The information provided in this table is based on cumulative DHB plans to the last week ending on Sunday. The final column shows vaccinations administered since Sunday by DHB of service to reconcile total actuals in this table to other total numbers shown.   On-going, and as we roll-out the vaccination programme, we anticipate that there could be a potential variance of up to ten percent (plus or minus) between DHB Plans and actual vaccination numbers. This is on the basis that, for example, an unplanned significant event could affect roll-out implementation or some DHBs might exceed their planned vaccination numbers.
+</p>
+-->
+
+<hr/>
+<h3><a id="by_dhb" name="location"></a>Cumulative vaccinations by DHB</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Cumulative vaccinations for DHBs" class="img-responsive" height="830" src="/web/20211023081356im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/dhbstacked_11.png" width="1780"/></figure>
+
+<hr/>
+<h3><a id="by-day" name="by-day"></a>Vaccinations by day</h3>
+
+<figure class="image-captioned img-responsive"><img alt="Vaccination doses administered per day" class="img-responsive" height="830" src="/web/20211023081356im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/vaccinebyday_11.png" width="1780"/></figure>
+
+<p>This chart shows the count of vaccinations administered on a given day from the COVID-19 Immunisation Register. Note some records are entered in the register at a later date than the immunisation was received. This means that the figures for a given date may move for some time after that date.</p>
+
+<hr/>
+<h3><a id="group" name="group"></a>Vaccinations by group by week</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccinations by group" class="img-responsive" height="830" src="/web/20211023081356im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/vaccinebygroupwk_11.png" width="1780"/></figure>
+
+<hr/>
+<h3><a id="group_d" name="group_d"></a>Cumulative vaccinations by group</h3>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">Priority Group</th>
+			<th scope="col" style="text-align:right">First dose administered</th>
+			<th scope="col" style="text-align:right">Second dose administered</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">Group 1</th>
+			<td style="text-align:right">66,654</td>
+			<td style="text-align:right">64,835</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Group 2</th>
+			<td style="text-align:right">634,957</td>
+			<td style="text-align:right">595,136</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Group 3</th>
+			<td style="text-align:right">790,330</td>
+			<td style="text-align:right">734,465</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Group 4</th>
+			<td style="text-align:right">2,101,547</td>
+			<td style="text-align:right">1,443,270</td>
+		</tr>
+	</tbody>
+</table>
+
+<p>For definitions of the groups and further detail see the downloadable spreadsheet at the bottom of the page.</p>
+
+<hr/>
+<h3><a id="by_soh" name="stockonhand"></a>Vaccine available for distribution at week end</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine available for distribution at week end" class="img-responsive" height="830" src="/web/20211023081356im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/stockonhand_12.png" width="1780"/></figure>
+
+<p>Vaccine available for distribution is stock (in doses) held at central warehouses. It does not include stock in transit or available at sites ready for use.</p>
+
+<hr/>
+<h3><a id="by_eth" name="ethnicity"></a>Total cumulative doses per 1,000 people by ethnicity</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Total cumulative doses per 1,000 people by ethnicity" class="img-responsive" height="830" src="/web/20211023081356im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/ethnicity_11.png" width="1780"/></figure>
+
+<p>This chart shows both first and second doses. As a result this chart may exceed 1,000 doses per 1,000 people.</p>
+
+<p><strong>*</strong> The prioritised ethnicity classification system allocates each person to a single ethnic group, based on the ethnic groups they identify with. Where people identify with more than one group, they are assigned in this order of priority: Māori, Pacific Peoples, Asian, and European/Other. So, if a person identifies as being Māori and New Zealand European, the person is counted as Māori. See <a href="/web/20211023081356/https://www.health.govt.nz/publication/hiso-100012017-ethnicity-data-protocols">Ethnicity Data Protocols</a> for further information.</p>
+
+<p>Ethnicity breakdown by DHB of residence is available in the downloadable spreadsheet at the bottom of the page.</p>
+
+<hr/>
+<h3><a id="by_age" name="age"></a>Cumulative vaccinations by age</h3>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">Age</th>
+			<th scope="col" style="text-align:right">First dose administered</th>
+			<th scope="col" style="text-align:right">First doses per 1,000 people</th>
+			<th scope="col" style="text-align:right">Fully vaccinated</th>
+			<th scope="col" style="text-align:right">Fully vaccinated per 1,000 people</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">12 - 19 years</th>
+			<td style="text-align:right">389,918</td>
+			<td style="text-align:right">776</td>
+			<td style="text-align:right">247,401</td>
+			<td style="text-align:right">492</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">20 - 34 years</th>
+			<td style="text-align:right">819,368</td>
+			<td style="text-align:right">792</td>
+			<td style="text-align:right">542,717</td>
+			<td style="text-align:right">525</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">35 - 49 years</th>
+			<td style="text-align:right">810,315</td>
+			<td style="text-align:right">847</td>
+			<td style="text-align:right">620,812</td>
+			<td style="text-align:right">649</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">50 - 64 years</th>
+			<td style="text-align:right">828,152</td>
+			<td style="text-align:right">893</td>
+			<td style="text-align:right">722,868</td>
+			<td style="text-align:right">779</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">65 and over</th>
+			<td style="text-align:right">745,735</td>
+			<td style="text-align:right">946</td>
+			<td style="text-align:right">703,908</td>
+			<td style="text-align:right">893</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total</strong></th>
+			<td style="text-align:right"><strong>3,593,488</strong></td>
+			<td style="text-align:right"><strong>854</strong></td>
+			<td style="text-align:right"><strong>2,837,706</strong></td>
+			<td style="text-align:right"><strong>674</strong></td>
+		</tr>
+	</tbody>
+</table>
+
+<p>Age breakdown by ethnicity and gender is available in the downloadable spreadsheet at the bottom of the page.</p>
+
+<hr/>
+<h3><a id="workforce" name="workforce"></a>Trained vaccinators and active vaccinators</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Trained vaccinators and active vaccinators" class="img-responsive" height="830" src="/web/20211023081356im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/workforce_11.png" width="1780"/></figure>
+
+<p><strong>Trained vaccinators</strong> are individuals who have completed the COVID-19 training. Many trained people are only able to offer a small number of hours to the COVID-19 vaccination programme.</p>
+
+<p><strong>Active vaccinators</strong> are trained individuals who are actively vaccinating. The number of active vaccinators does not reflect the hours worked vaccinating. For example, one vaccinator may work 40 hours in a week at one DHB and will show as 1 vaccinator in the headcount. In another DHB, 4 vaccinators may work 10 hours each (total 40 hours), but will show as 4 vaccinators in the headcount for that week.</p>
+
+<p>Both counts of trained and active vaccinators are cumulative. The difference between the two is due to a number of factors. This includes: individuals being trained in anticipation of future sites being opened (the largest factor); rostering; leave or non-availability; local health priorities; sites opening and closing.</p>
+
+<hr/>
+<h3><a id="usage" name="usage"></a>Wastage of vaccine stock</h3>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">&nbsp;</th>
+			<th scope="col">Wastage</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">New Zealand</th>
+			<td>0.27%</td>
+		</tr>
+	</tbody>
+</table>
+
+<p>Wastage is vials that have been reported as wasted since 13 July in the Inventory portal by DHBs or central warehouses divided by vials used over the same time frame.</p>
+
+<h3><a id="download" name="download"></a>Details of vaccination data</h3>
+
+<p>Download a spreadsheet containing key vaccination data. This includes HSU based population estimates for calculating vaccine uptake rates.</p>
+
+<p><a download="" href="/web/20211023081356/https://www.health.govt.nz/system/files/documents/pages/covid_vaccinations_19_10_2021.xlsx">COVID-19 vaccination data through 19 Oct 2021 (Excel, 359 KB)</a></p>
+
+<p>This spreadsheet is based on the information made available at the time of publishing and may be subject to changes. Please take note of any notes and caveats on each sheet.</p>
+
+<p>The below attachments provide some analysis on our progress on equity. The two PDF files are high level summaries of overall progress. The Excel documents are interactive and provides the ability to delve further into those overall numbers. NB: These Excel workbooks use features that are non-compatible with versions of MS Office 2016 and earlier.</p>
+
+<ul>
+	<li><a download="" href="/web/20211023081356/https://www.health.govt.nz/system/files/documents/pages/211017_-_cvip_equity_-_rate_ratios_by_ethicity_ageband_and_dhb.pdf">Covid-19 Vaccine Rate Ratios by Ethnicity, Ageband and DHB (PDF, 642 KB)</a></li>
+	<li><a download="" href="/web/20211023081356/https://www.health.govt.nz/system/files/documents/pages/211017_-_cvip_equity_-_uptake_by_ethicity_ageband_and_dhb.pdf">Covid-19 Vaccine Uptake by Ethnicity, Ageband and DHB (PDF, 551 KB)</a></li>
+	<li><a download="" href="/web/20211023081356/https://www.health.govt.nz/system/files/documents/pages/211017_-_cvip_equity_-_level_1_ethnicity_uptake_and_rate_ratios.xlsx">Covid-19 Vaccine Equity - Level 1 Ethnicity Uptake and Rate Ratios (Excel, 152 KB)</a></li>
+	<li><a download="" href="/web/20211023081356/https://www.health.govt.nz/system/files/documents/pages/211017_-_cvip_equity_-_level_2_ethnicity_uptake_and_rate_ratios.xlsx">Covid-19 Vaccine Equity - Level 2 Ethnicity Uptake and Rate Ratios (Excel, 378 KB)</a></li>
+	<li><a download="" href="/web/20211023081356/https://www.health.govt.nz/system/files/documents/pages/211017_-_cvip_equity_-_rate_ratios_and_uptake_over_time.xlsx">Rate Ratios and Uptake Over Time (Excel, 972 KB)</a></li>
+</ul>
+
+<hr/>
+<h3><a id="adverse-events" name="adverse-events"></a>Adverse events following&nbsp;immunisations (AEFI)</h3>
+
+<p>Like all medicines, the COVID-19 vaccine may cause side effects in some people. These are common, are usually mild, don&rsquo;t last long and won&rsquo;t stop people from having the second dose or going about daily life. Serious allergic reactions do occur but are extremely rare.</p>
+
+<p>Suspected AEFI to COVID-19 vaccines are reported to the <a href="https://web.archive.org/web/20211023081356/https://nzphvc.otago.ac.nz/">Centre for Adverse Reactions Monitoring</a> (CARM).&nbsp;<a href="https://web.archive.org/web/20211023081356/https://www.medsafe.govt.nz/">Medsafe</a> is closely monitoring the AEFI reported from the use of the COVID-19 vaccine and will report regularly on their findings.&nbsp;</p>
+
+<p><a href="https://web.archive.org/web/20211023081356/https://www.medsafe.govt.nz/COVID-19/vaccine-report-overview.asp">View Medsafe data on COVID-19 vaccine adverse effects following immunisation</a></p>
+</div></div></div>    </article>
+  </div>
+
+
+  </div>
+<div class="panel-pane pane-node-links even">
+
+
+
+  <div class="pane-content">
+          </div>
+
+
+  </div>
+
+<div class="panel-pane pane-views pane-sub-pages even">
+
+        <h2 class="pane-title h3">In this section</h2>
+
+
+  <div class="pane-content">
+        <div class="view view-sub-pages view-id-sub_pages view-display-id-block view-dom-id-99b626cc798510775bcbae0950145624">
+
+
+
+      <div class="view-content">
+      <div class="item-list">    <ul>          <li class="views-row views-row-1 views-row-odd views-row-first">
+  <div class="views-field views-field-title">        <div class="field-content">
+<div class="views-field views-field-title">
+  <h3 class="field-content">
+    <a href="/web/20211023081356/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-across-nz">COVID-19 Vaccination uptake rates across NZ</a>  </h3>
+</div></div>  </div>
+  <span class="views-field views-field-body">        <span class="field-content">This page provides information related to uptake rates of the COVID-19 vaccine across the country.
+</span>  </span>
+  <span class="views-field views-field-view-node">        <span class="field-content"><a href="/web/20211023081356/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-across-nz">Read more</a></span>  </span></li>
+          <li class="views-row views-row-2 views-row-even">
+  <div class="views-field views-field-title">        <div class="field-content">
+<div class="views-field views-field-title">
+  <h3 class="field-content">
+    <a href="/web/20211023081356/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-maori-communities-across-nz">COVID-19 Vaccination uptake rates within Māori communities across NZ</a>  </h3>
+</div></div>  </div>
+  <span class="views-field views-field-body">        <span class="field-content">This page provides information related to uptake rates of the COVID-19 vaccine within Māori communities across New Zealand.
+</span>  </span>
+  <span class="views-field views-field-view-node">        <span class="field-content"><a href="/web/20211023081356/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-maori-communities-across-nz">Read more</a></span>  </span></li>
+          <li class="views-row views-row-3 views-row-odd views-row-last">
+  <div class="views-field views-field-title">        <div class="field-content">
+<div class="views-field views-field-title">
+  <h3 class="field-content">
+    <a href="/web/20211023081356/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-pacific-communities-across-nz">COVID-19 Vaccination uptake rates within Pacific communities across NZ</a>  </h3>
+</div></div>  </div>
+  <span class="views-field views-field-body">        <span class="field-content">This page provides information related to uptake rates of the COVID-19 vaccine within Pacific communities across New Zealand.
+</span>  </span>
+  <span class="views-field views-field-view-node">        <span class="field-content"><a href="/web/20211023081356/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-pacific-communities-across-nz">Read more</a></span>  </span></li>
+      </ul></div>    </div>
+
+
+
+
+
+
+</div>  </div>
+
+
+  </div>
+</div>          </div>
+
+  </div>
+
+</section>
+  </div>
+      </section>
+
+
+    </div>
+    <div id="content-footer-wrapper" class="clearfix">
+      <div id="content-footer" class="clearfix">
+                  <p class="page_updated">Page last updated: <span class="date">23 October 2021</span></p>                  <div class="region region-content-footer">
+    <section id="block-moh-tools-page-tools" class="block block-moh-tools clearfix">
+  <a href="#" data-placement="top" data-title="Share this content." data-html="true" data-content="<p>Share this page on some of the most popular social networking and content sites on the internet.</p><div class='service-links'><ul><li><a href='https://twitter.com/share?url=https%3A//www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data&amp;text=COVID-19%3A%20Vaccine%20data' title='Share this on Twitter' class='service-links-twitter' rel='nofollow'><img typeof='foaf:Image' class='img-responsive' src='https://www.health.govt.nz/sites/all/modules/contrib/service_links/images/twitter.png' alt='Twitter' /> Twitter</a></li>
+<li><a href='https://www.facebook.com/sharer.php?u=https%3A//www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data&amp;t=COVID-19%3A%20Vaccine%20data' title='Share on Facebook' class='service-links-facebook' rel='nofollow'><img typeof='foaf:Image' class='img-responsive' src='https://www.health.govt.nz/sites/all/modules/contrib/service_links/images/facebook.png' alt='Facebook' /> Facebook</a></li>
+</ul></div>" class="share-this-content"><i class="fa fa-share"></i> Share</a><a href="#" title="print this page" class="print"><i class="fa fa-print"></i> Print</a><a href="https://web.archive.org/web/20211023081356/https://www.health.govt.nz/forward?path=node/12052" title="Email this page" class="email"><i class="fa fa-envelope"></i> Email</a><a href="/web/20211023081356/https://www.health.govt.nz/feedback?ref=https%3A//www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="Feedback" class="rss"><i class="fa fa-comment"></i> Feedback</a></section>
+
+  </div>
+      </div>
+    </div>
+
+  </div>
+  <footer class="footer container">
+    <h2 class="hidden">Site Footer</h2>
+    <div class="footer-default">
+      <div class="row">
+        <div class="col-sm-6 col-md-6">
+          <div class="field field-name-field-tax-first-column-links">
+            <ul class="field-items"><li class="field-item"><a href="https://web.archive.org/web/20211023081356/https://www.health.govt.nz/node/492" class="">About this site</a></li><li class="field-item"><a href="https://web.archive.org/web/20211023081356/https://www.health.govt.nz/node/524" class="">Contact us</a></li><li class="field-item"><a href="https://web.archive.org/web/20211023081356/https://www.health.govt.nz/node/488" class="">Other Ministry of Health websites</a></li><li class="field-item"><a href="https://web.archive.org/web/20211023081356/https://www.health.govt.nz/node/7497" class="">Official Information Act requests</a></li><li class="field-item"><a href="https://web.archive.org/web/20211023081356/https://www.health.govt.nz/about-ministry/information-releases" class="">Information releases</a></li><li class="field-item"><a href="https://web.archive.org/web/20211023081356/https://consult.health.govt.nz/" class="">Consultations</a></li></ul>
+          </div>
+        </div>
+        <div class="col-sm-6 col-md-6">
+          <div class="field field-name-field-tax-footer-body field-type-text-long field-label-hidden"><div class="field-items"><div class="field-item even"><h3>Where to go for help</h3>
+
+<table>
+	<tbody>
+		<tr>
+			<th scope="row">Emergencies</th>
+			<td><strong>Dial <a href="tel:111">111</a></strong> (for ambulance, fire or police)</td>
+		</tr>
+		<tr>
+			<th scope="row">Healthline</th>
+			<td><strong>Dial <a href="tel:0800611116">0800 611 116</a></strong></td>
+		</tr>
+		<tr>
+			<th scope="row">Poisons</th>
+			<td><strong>Dial <a href="tel:0800764766">0800 POISON</a> </strong>(<a href="tel:0800764766">0800 764 766</a>)</td>
+		</tr>
+		<tr>
+			<th scope="row">Mental health crisis</th>
+			<td><strong><a href="/web/20211023081356/https://www.health.govt.nz/your-health/services-and-support/health-care-services/mental-health-services/crisis-assessment-teams">Emergency contact numbers</a></strong></td>
+		</tr>
+	</tbody>
+</table>
+</div></div></div>        </div>
+      </div>
+      <div class="row">
+        <div class="sub-footer">
+          <div class="column col-sm-12 col-md-3">
+            <a href="https://web.archive.org/web/20211023081356/https://www.govt.nz/">
+              <img src="/web/20211023081356im_/https://www.health.govt.nz/sites/all/themes/mohpub_bootstrap/images/nzgovtlogo_white.png" width="152" height="16" alt="govt.nz - connecting you to New Zealand central &amp; local government services" title="govt.nz - connecting you to New Zealand central &amp; local government services"/>
+            </a>
+          </div>
+          <div class="column col-sm-12 col-md-9">
+          <span class="bottom-menu-moh with-v-divider">&copy; Ministry of Health – Manatū Hauora</span><ul class="bottom-menu-list"><li class="bottom-menu-list-item with-v-divider"><a href="https://web.archive.org/web/20211023081356/https://www.health.govt.nz/sitemap" class="">Site map</a></li><li class="bottom-menu-list-item with-v-divider"><a href="https://web.archive.org/web/20211023081356/https://www.health.govt.nz/about-site/privacy-and-security" class="">Privacy &amp; security</a></li><li class="bottom-menu-list-item with-v-divider"><a href="https://web.archive.org/web/20211023081356/https://www.health.govt.nz/about-site/copyright" class="">Copyright</a></li></ul>          </div>
+        </div>
+      </div>
+    </div>
+    <div class="footer-print">&copy; Ministry of Health – Manatū Hauora</div>
+  </footer>
+  <a class="scrollToTop">Back to top <i class="fas fa-arrow-up"></i></a>
+</div>
+  <script src="https://web.archive.org/web/20211023081356js_/https://www.health.govt.nz/sites/default/files/js/js_akZOsKtodu3PdnQzY3_ElOfujkLxJcowmaWgHTBBLOE.js"></script>
+</body>
+</html>
+<!--
+     FILE ARCHIVED ON 08:13:56 Oct 23, 2021 AND RETRIEVED FROM THE
+     INTERNET ARCHIVE ON 03:25:59 Nov 07, 2021.
+     JAVASCRIPT APPENDED BY WAYBACK MACHINE, COPYRIGHT INTERNET ARCHIVE.
+
+     ALL OTHER CONTENT MAY ALSO BE PROTECTED BY COPYRIGHT (17 U.S.C.
+     SECTION 108(a)(3)).
+-->
+<!--
+playback timings (ms):
+  captures_list: 126.375
+  exclusion.robots: 0.17
+  exclusion.robots.policy: 0.162
+  RedisCDXSource: 0.505
+  esindex: 0.007
+  LoadShardBlock: 85.43 (3)
+  PetaboxLoader3.datanode: 85.65 (4)
+  CDXLines.iter: 29.231 (3)
+  load_resource: 106.53
+  PetaboxLoader3.resolve: 45.449
+-->

--- a/data/rawSite/2021-10-23.html
+++ b/data/rawSite/2021-10-23.html
@@ -1,0 +1,2510 @@
+
+<!DOCTYPE html>
+<html lang="en" dir="ltr" prefix="" class="no-js">
+<head><script src="//archive.org/includes/analytics.js?v=cf34f82" type="text/javascript"></script>
+<script type="text/javascript">window.addEventListener('DOMContentLoaded',function(){var v=archive_analytics.values;v.service='wb';v.server_name='wwwb-app209.us.archive.org';v.server_ms=486;archive_analytics.send_pageview({});});</script>
+<script type="text/javascript" src="/_static/js/bundle-playback.js?v=UfTkgsKx" charset="utf-8"></script>
+<script type="text/javascript" src="/_static/js/wombat.js?v=UHAOicsW" charset="utf-8"></script>
+<script type="text/javascript">
+  __wm.init("https://web.archive.org/web");
+  __wm.wombat("https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data","20211024013718","https://web.archive.org/","web","/_static/",
+	      "1635039438");
+</script>
+<link rel="stylesheet" type="text/css" href="/_static/css/banner-styles.css?v=omkqRugM" />
+<link rel="stylesheet" type="text/css" href="/_static/css/iconochive.css?v=qtvMKcIJ" />
+<!-- End Wayback Rewrite JS Include -->
+
+  <!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta name="format-detection" content="telephone=no"/>
+  <link rel="profile" href="http://www.w3.org/1999/xhtml/vocab"/>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+<link rel="shortcut icon" href="https://web.archive.org/web/20211024013718im_/https://www.health.govt.nz/sites/all/themes/mohpub_bootstrap/favicon.ico" type="image/vnd.microsoft.icon"/>
+<meta name="description" content="Dashboard of data and statistics about the rollout of COVID-19 vaccines in New Zealand"/>
+<meta name="generator" content="Drupal 7 (https://www.drupal.org)"/>
+<link rel="canonical" href="https://web.archive.org/web/20211024013718/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data"/>
+<link rel="shortlink" href="https://web.archive.org/web/20211024013718/https://www.health.govt.nz/node/12052"/>
+<meta property="og:site_name" content="Ministry of Health NZ"/>
+<meta property="og:type" content="article"/>
+<meta property="og:url" content="https://web.archive.org/web/20211024013718/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data"/>
+<meta property="og:title" content="COVID-19: Vaccine data"/>
+<meta property="og:description" content="Dashboard of data and statistics about the rollout of COVID-19 vaccines in New Zealand"/>
+  <title>COVID-19: Vaccine data | Ministry of Health NZ</title>
+  <link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211024013718cs_/https://www.health.govt.nz/sites/default/files/css/css_lQaZfjVpwP_oGNqdtWCSpJT1EMqXdMiU84ekLLxQnc4.css" media="all"/>
+<link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211024013718cs_/https://www.health.govt.nz/sites/default/files/css/css_jqUBpWfMaxMiP7LismdZVlyVv8azUJSE2yaH58nj0cE.css" media="all"/>
+<link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211024013718cs_/https://www.health.govt.nz/sites/default/files/css/css_Rb1wqFBC8VXCJC-BuNY53cvjjlj6UADGvqzo_f-1yN0.css" media="all"/>
+<link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211024013718cs_/https://www.health.govt.nz/sites/default/files/css/css_38_K1lHKg-98m4KKRfv57JBK0gvlKscexGt9MKoi0DE.css" media="all"/>
+<link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211024013718cs_/https://www.health.govt.nz/sites/default/files/css/css_r7NPyvpdYfAyZmk9zkK8OaFKEFj6er5ZJnam2H644DM.css" media="print"/>
+  <link rel="alternate stylesheet" type="text/css" href="/web/20211024013718cs_/https://www.health.govt.nz/sites/all/themes/mohpub_bootstrap/css/high-contrast.css" media="screen" title="High Contrast"/>
+  <script src="https://web.archive.org/web/20211024013718js_/https://www.health.govt.nz/sites/default/files/js/js_zS-CmNFGyegtLYJmqFRpxQvvQrfPIFrOMq_3T3C8sZE.js"></script>
+<script src="https://web.archive.org/web/20211024013718js_/https://www.health.govt.nz/sites/default/files/js/js_fNgZ4Okisfr70Q0yvAYsATgB0o_jD3-srhQQ-VHmlXE.js"></script>
+<script src="https://web.archive.org/web/20211024013718js_/https://www.health.govt.nz/sites/default/files/js/js_YAdPZfg12M1m7ROp3_gVJPS5sArqL0kYQgNRPoicvHE.js"></script>
+<script>(function(i,s,o,g,r,a,m){i["GoogleAnalyticsObject"]=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,"script","https://web.archive.org/web/20211024013718/https://www.google-analytics.com/analytics.js","ga");ga("create", "UA-3573389-24", {"cookieDomain":".www.health.govt.nz","siteSpeedSampleRate":15});ga("send", "pageview");</script>
+<script src="https://web.archive.org/web/20211024013718js_/https://www.health.govt.nz/sites/default/files/js/js_QAXZNPwLISRLHqyNpT4Vvr_iqD9foD6GTbEjlhIIjeo.js"></script>
+<script src="https://web.archive.org/web/20211024013718js_/https://www.health.govt.nz/sites/default/files/js/js_4VW9edmu3V8VjGJxFfXGAwkXeW2cJIa5h-6y7SgwVrk.js"></script>
+<script>    (function(h,o,t,j,a,r){
+        h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
+        h._hjSettings={hjid:930919,hjsv:6};
+        a=o.getElementsByTagName('head')[0];
+        r=o.createElement('script');r.async=1;
+        r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+        a.appendChild(r);
+    })(window,document,'https://web.archive.org/web/20211024013718/https://static.hotjar.com/c/hotjar-','.js?sv=');
+</script>
+<script>jQuery.extend(Drupal.settings, {"basePath":"\/","pathPrefix":"","ajaxPageState":{"theme":"mohpub_bootstrap","theme_token":"u14gpiuc3alXh4X1ny6VkFZQhbBCtGcQQp8l5mtAncY","js":{"sites\/all\/modules\/custom\/table_d3chart\/js\/table_d3chart.js":1,"sites\/all\/modules\/custom\/moh_d3\/moh_d3.js":1,"sites\/all\/modules\/contrib\/jquery_update\/replace\/jquery\/1.7\/jquery.min.js":1,"misc\/jquery-extend-3.4.0.js":1,"misc\/jquery-html-prefilter-3.5.0-backport.js":1,"misc\/jquery.once.js":1,"misc\/drupal.js":1,"sites\/all\/modules\/contrib\/ckeditor_accordion\/js\/ckeditor-accordion.js":1,"sites\/all\/modules\/contrib\/extlink\/extlink.js":1,"modules\/field\/modules\/text\/text.js":1,"sites\/all\/modules\/contrib\/field_group\/field_group.js":1,"sites\/all\/modules\/contrib\/google_analytics\/googleanalytics.js":1,"0":1,"sites\/all\/libraries\/c3\/c3.js":1,"sites\/all\/libraries\/d3\/d3.min.js":1,"sites\/all\/modules\/contrib\/d3\/js\/d3.js":1,"sites\/all\/libraries\/d3.helpers\/d3.helpers.js":1,"sites\/all\/libraries\/d3.c3\/d3-c3.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/assets\/ios-fix.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/affix.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/alert.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/button.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/carousel.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/collapse.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/dropdown.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/modal.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/tooltip.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/popover.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/scrollspy.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/tab.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/transition.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/jquery.cookie.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/jquery.moh.announcement.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/svgeezy.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/fitvids.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/bootstrap-tabcollapse.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/jquery.scrollTo.min.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/script.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/jquery.google_analytics.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/bootstrap-accessibility.min.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/style-switcher.js":1,"1":1},"css":{"modules\/system\/system.base.css":1,"sites\/all\/modules\/contrib\/calendar\/css\/calendar_multiday.css":1,"sites\/all\/modules\/contrib\/ckeditor_accordion\/css\/ckeditor-accordion.css":1,"modules\/field\/theme\/field.css":1,"modules\/node\/node.css":1,"sites\/all\/modules\/contrib\/extlink\/extlink.css":1,"sites\/all\/modules\/contrib\/views\/css\/views.css":1,"sites\/all\/modules\/contrib\/ckeditor\/css\/ckeditor.css":1,"sites\/all\/modules\/contrib\/ctools\/css\/ctools.css":1,"sites\/all\/modules\/contrib\/panels\/css\/panels.css":1,"sites\/all\/libraries\/c3\/c3.css":1,"sites\/all\/libraries\/d3.c3\/d3-c3.css":1,"sites\/all\/themes\/mohpub_bootstrap\/fontawesome\/css\/fontawesome.min.css":1,"sites\/all\/themes\/mohpub_bootstrap\/fontawesome\/css\/solid.min.css":1,"sites\/all\/themes\/mohpub_bootstrap\/fontawesome\/css\/brands.min.css":1,"sites\/all\/modules\/features\/site_profile\/css\/fix-rubik-multiselect-height.css":1,"sites\/all\/themes\/mohpub_bootstrap\/css\/style.css":1,"sites\/all\/themes\/mohpub_bootstrap\/css\/responsive-tables.css":1,"sites\/all\/themes\/mohpub_bootstrap\/css\/print.css":1}},"field_group":{"div":"full"},"ckeditor_accordion":{"collapseAll":1},"extlink":{"extTarget":0,"extClass":"ext","extLabel":"(link is external)","extImgClass":0,"extIconPlacement":"append","extSubdomains":0,"extExclude":"","extInclude":"","extCssExclude":"","extCssExplicit":"","extAlert":0,"extAlertText":"This link will take you to an external web site. We are not responsible for their content.","mailtoClass":"mailto","mailtoLabel":"(link sends e-mail)"},"googleanalytics":{"trackOutbound":1,"trackMailto":1,"trackDownload":1,"trackDownloadExtensions":"7z|aac|arc|arj|asf|asx|avi|bin|csv|doc|exe|flv|gif|gz|gzip|hqx|jar|jpe?g|js|mp(2|3|4|e?g)|mov(ie)?|msi|msp|pdf|phps|png|ppt|qtm?|ra(m|r)?|sea|sit|tar|tgz|torrent|txt|wav|wma|wmv|wpd|xls|xml|z|zip|docx|xlsx|pptx|pptm|ppsx|ppsm|epub"},"mohD3":{"C3Types":["line","spline","step","area","area-spline","area-step","bar","scatter","pie","donut","gauge"],"graphRender":"line","graphLegend":true,"graphDefaultColors":"#2b8cbe, #abdda4, #7f7f7f, #92cddc, #dc8b0c","graphDefaultGroupedTooltip":0,"graphDefaultGridX":0,"graphDefaultGridY":0,"graphDefaultLegendPosition":"top-right","graphDefaultTooltip":1,"graphDefaultDataLabel":0,"graphLegendStep":"5","graphInteraction":true,"graphTypes":"","graphXaxisShow":true,"graphXaxisLabel":"","graphYaxisLabel":"","graphXaxisType":"category","graphXaxisCentered":false,"graphXaxisRotation":"","graphXaxisHeight":"","graphYaxisShow":true,"graphYaxisMax":"","graphYaxisMin":"","graphYaxisInverted":false,"graphYaxisCenter":"","graphYaxisPrefix":"","graphYaxisSuffix":"","graphYaxisPosition":"","graphY2axisShow":false,"graphY2axisSource":"","graphY2axisMax":"","graphY2axisMin":"","graphGroups":"","graphRotated":false,"graphIgnoreEmpty":false,"graphLineDot":true,"graphBarRatio":"0.9","graphDot":true,"graphDotR":"2.5","graphFocus":false},"tableD3":{"show":"View table data source","hide":"Hide table data source"},"urlIsAjaxTrusted":{"\/our-work\/diseases-and-conditions\/covid-19-novel-coronavirus\/covid-19-data-and-statistics\/covid-19-vaccine-data":true},"bootstrap":{"anchorsFix":1,"anchorsSmoothScrolling":1,"formHasError":1,"popoverEnabled":1,"popoverOptions":{"animation":1,"html":0,"placement":"right","selector":"","trigger":"click","triggerAutoclose":1,"title":"","content":"","delay":0,"container":"body"},"tooltipEnabled":1,"tooltipOptions":{"animation":1,"html":0,"placement":"auto left","selector":"","trigger":"hover focus","delay":0,"container":"body"}}});</script>
+  <!-- HTML5 element support for IE6-8 -->
+  <!--[if lt IE 9]>
+    <script src="/sites/all/themes/mohpub_bootstrap/js/assets/html5shiv.js"></script>
+    <script src="/sites/all/themes/mohpub_bootstrap/js/assets/respond.min.js"></script>
+  <![endif]-->
+</head>
+<body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-12052 node-type-page node-has-intro"><!-- BEGIN WAYBACK TOOLBAR INSERT -->
+<style type="text/css">
+body {
+  margin-top:0 !important;
+  padding-top:0 !important;
+  /*min-width:800px !important;*/
+}
+</style>
+<script>__wm.rw(0);</script>
+<div id="wm-ipp-base" lang="en" style="display:none;direction:ltr;">
+<div id="wm-ipp" style="position:fixed;left:0;top:0;right:0;">
+<div id="wm-ipp-inside">
+  <div style="position:relative;">
+    <div id="wm-logo" style="float:left;width:110px;padding-top:12px;">
+      <a href="/web/" title="Wayback Machine home page"><img src="/_static/images/toolbar/wayback-toolbar-logo-200.png" srcset="/_static/images/toolbar/wayback-toolbar-logo-100.png, /_static/images/toolbar/wayback-toolbar-logo-150.png 1.5x, /_static/images/toolbar/wayback-toolbar-logo-200.png 2x" alt="Wayback Machine" style="width:100px" border="0" /></a>
+    </div>
+    <div class="r" style="float:right;">
+      <div id="wm-btns" style="text-align:right;height:25px;">
+                  <div id="wm-save-snapshot-success">success</div>
+          <div id="wm-save-snapshot-fail">fail</div>
+          <a id="wm-save-snapshot-open" href="#"
+	     title="Share via My Web Archive" >
+            <span class="iconochive-web"></span>
+          </a>
+          <a href="https://archive.org/account/login.php"
+             title="Sign In"
+             id="wm-sign-in"
+          >
+            <span class="iconochive-person"></span>
+          </a>
+          <span id="wm-save-snapshot-in-progress" class="iconochive-web"></span>
+        	<a href="http://faq.web.archive.org/" title="Get some help using the Wayback Machine" style="top:-6px;"><span class="iconochive-question" style="color:rgb(87,186,244);font-size:160%;"></span></a>
+	<a id="wm-tb-close" href="#close" onclick="__wm.h(event);return false;" style="top:-2px;" title="Close the toolbar"><span class="iconochive-remove-circle" style="color:#888888;font-size:240%;"></span></a>
+      </div>
+      <div id="wm-share">
+          <a href="/web/20211024013718/http://web.archive.org/screenshot/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data"
+             id="wm-screenshot"
+             title="screenshot">
+            <span class="wm-icon-screen-shot"></span>
+          </a>
+          <a href="#"
+            id="wm-video"
+            title="video">
+            <span class="iconochive-movies"></span>
+          </a>
+	<a id="wm-share-facebook" href="#" data-url="https://web.archive.org/web/20211024013718/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="Share on Facebook" style="margin-right:5px;" target="_blank"><span class="iconochive-facebook" style="color:#3b5998;font-size:160%;"></span></a>
+	<a id="wm-share-twitter" href="#" data-url="https://web.archive.org/web/20211024013718/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="Share on Twitter" style="margin-right:5px;" target="_blank"><span class="iconochive-twitter" style="color:#1dcaff;font-size:160%;"></span></a>
+      </div>
+    </div>
+    <table class="c" style="">
+      <tbody>
+	<tr>
+	  <td class="u" colspan="2">
+	    <form target="_top" method="get" action="/web/submit" name="wmtb" id="wmtb"><input type="text" name="url" id="wmtbURL" value="https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" onfocus="this.focus();this.select();" /><input type="hidden" name="type" value="replay" /><input type="hidden" name="date" value="20211024013718" /><input type="submit" value="Go" /></form>
+	  </td>
+	  <td class="n" rowspan="2" style="width:110px;">
+	    <table>
+	      <tbody>
+		<!-- NEXT/PREV MONTH NAV AND MONTH INDICATOR -->
+		<tr class="m">
+		  <td class="b" nowrap="nowrap"><a href="https://web.archive.org/web/20210924010831/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="24 Sep 2021"><strong>Sep</strong></a></td>
+		  <td class="c" id="displayMonthEl" title="You are here: 01:37:18 Oct 24, 2021">OCT</td>
+		  <td class="f" nowrap="nowrap">Nov</td>
+		</tr>
+		<!-- NEXT/PREV CAPTURE NAV AND DAY OF MONTH INDICATOR -->
+		<tr class="d">
+		  <td class="b" nowrap="nowrap"><a href="https://web.archive.org/web/20211022222849/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="22:28:49 Oct 22, 2021"><img src="/_static/images/toolbar/wm_tb_prv_on.png" alt="Previous capture" width="14" height="16" border="0" /></a></td>
+		  <td class="c" id="displayDayEl" style="width:34px;font-size:24px;white-space:nowrap;" title="You are here: 01:37:18 Oct 24, 2021">24</td>
+		  <td class="f" nowrap="nowrap"><a href="https://web.archive.org/web/20211025040431/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="04:04:31 Oct 25, 2021"><img src="/_static/images/toolbar/wm_tb_nxt_on.png" alt="Next capture" width="14" height="16" border="0" /></a></td>
+		</tr>
+		<!-- NEXT/PREV YEAR NAV AND YEAR INDICATOR -->
+		<tr class="y">
+		  <td class="b" nowrap="nowrap">2020</td>
+		  <td class="c" id="displayYearEl" title="You are here: 01:37:18 Oct 24, 2021">2021</td>
+		  <td class="f" nowrap="nowrap">2022</td>
+		</tr>
+	      </tbody>
+	    </table>
+	  </td>
+	</tr>
+	<tr>
+	  <td class="s">
+	    	    <div id="wm-nav-captures">
+	      	      <a class="t" href="/web/20211024013718*/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="See a list of every capture for this URL">682 captures</a>
+	      <div class="r" title="Timespan for captures of this URL">07 Apr 2021 - 06 Nov 2021</div>
+	      </div>
+	  </td>
+	  <td class="k">
+	    <a href="" id="wm-graph-anchor">
+	      <div id="wm-ipp-sparkline" title="Explore captures for this URL" style="position: relative">
+		<canvas id="wm-sparkline-canvas" width="650" height="27" border="0"></canvas>
+	      </div>
+	    </a>
+	  </td>
+	</tr>
+      </tbody>
+    </table>
+    <div style="position:absolute;bottom:0;right:2px;text-align:right;">
+      <a id="wm-expand" class="wm-btn wm-closed" href="#expand" onclick="__wm.ex(event);return false;"><span id="wm-expand-icon" class="iconochive-down-solid"></span> <span style="font-size:80%">About this capture</span></a>
+    </div>
+  </div>
+    <div id="wm-capinfo" style="border-top:1px solid #777;display:none; overflow: hidden">
+                    <div id="wm-capinfo-collected-by">
+    <div style="background-color:#666;color:#fff;font-weight:bold;text-align:center">COLLECTED BY</div>
+    <div style="padding:3px;position:relative" id="wm-collected-by-content">
+      <div style="display:inline-block;vertical-align:top;width:49%;">
+			<span class="c-logo" style="background-image:url(https://archive.org/services/img/GDELT_Project)"></span>
+		<div>Collection: <a style="color:#33f;" href="https://archive.org/details/GDELT_Project" target="_new"><span class="wm-title">GDELT Project</span></a></div>
+	      </div>
+    </div>
+    </div>
+    <div id="wm-capinfo-timestamps">
+    <div style="background-color:#666;color:#fff;font-weight:bold;text-align:center" title="Timestamps for the elements of this page">TIMESTAMPS</div>
+    <div>
+      <div id="wm-capresources" style="margin:0 5px 5px 5px;max-height:250px;overflow-y:scroll !important"></div>
+      <div id="wm-capresources-loading" style="text-align:left;margin:0 20px 5px 5px;display:none"><img src="/_static/images/loading.gif" alt="loading" /></div>
+    </div>
+    </div>
+  </div></div></div></div><div id="wm-ipp-print">The Wayback Machine - https://web.archive.org/web/20211024013718/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data</div>
+<div id="donato" style="position:relative;width:100%;">
+  <div id="donato-base">
+    <iframe id="donato-if" src="https://archive.org/includes/donate.php?as_page=1&amp;platform=wb&amp;referer=https%3A//web.archive.org/web/20211024013718/https%3A//www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data"
+	    scrolling="no" frameborder="0" style="width:100%; height:100%">
+    </iframe>
+  </div>
+</div><script type="text/javascript">
+__wm.bt(650,27,25,2,"web","https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data","20211024013718",1996,"/_static/",["/_static/css/banner-styles.css?v=omkqRugM","/_static/css/iconochive.css?v=qtvMKcIJ"], "False");
+  __wm.rw(1);
+</script>
+<!-- END WAYBACK TOOLBAR INSERT -->
+<!--googleoff: all-->
+  <div id="skip-link">
+    <a href="#skip-content" id="skipper" class="element-invisible element-focusable">Skip to main content</a>
+  </div>
+    <div id="page">
+  <header id="navbar" role="banner" class="navbar container navbar-default">
+          <ul class="menu nav navbar-nav secondary"><li class="first leaf jobs depth-1"><a href="https://web.archive.org/web/20211024013718/https://careers.health.govt.nz/" title="">Jobs</a></li>
+<li class="leaf news depth-1"><a href="/web/20211024013718/https://www.health.govt.nz/news-media" data-is-top-level="0" title="">News</a></li>
+<li class="leaf contact-us depth-1"><a href="/web/20211024013718/https://www.health.govt.nz/about-ministry/contact-us" title="">Contact us</a></li>
+<li class="leaf facebook depth-1"><a href="https://web.archive.org/web/20211024013718/https://www.facebook.com/minhealthnz/">Facebook</a></li>
+<li class="leaf twitter depth-1"><a href="https://web.archive.org/web/20211024013718/https://twitter.com/minhealthnz" data-is-top-level="0" title="">Twitter</a></li>
+<li class="last leaf youtube depth-1"><a href="https://web.archive.org/web/20211024013718/https://www.youtube.com/user/minhealthnz" data-is-top-level="0" title="">Youtube</a></li>
+</ul>        <div class="container">
+      <div class="navbar-header">
+                <a class="logo navbar-btn pull-left" href="/web/20211024013718/https://www.health.govt.nz/" title="Home">
+          <img src="/web/20211024013718im_/https://www.health.govt.nz/sites/all/themes/mohpub_bootstrap/images/mohlogo.svg" alt="Ministry of Health"/>
+        </a>
+                  <div class="region region-header-top">
+    <section id="block-apachesolr-panels-search-form" class="block block-apachesolr-panels clearfix">
+
+
+  <form action="/web/20211024013718/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" method="post" id="apachesolr-panels-search-block" accept-charset="UTF-8"><div><div class="form-item form-item-apachesolr-panels-search-form form-type-textfield form-group"> <label class="control-label" for="edit-apachesolr-panels-search-form">Search</label>
+<input title="Enter the terms you wish to search for." class="form-control form-text" type="text" id="edit-apachesolr-panels-search-form" name="apachesolr_panels_search_form" value="" size="15" maxlength="128"/></div><input type="hidden" name="form_build_id" value="form-bLGOhGSVfY-3eguLl0bBba_2VlH_0fEnscF6Ca677xU"/>
+<input type="hidden" name="form_id" value="apachesolr_panels_search_block"/>
+<div class="form-actions form-wrapper form-group" id="edit-actions"><button type="submit" id="edit-submit" name="op" value="Search" class="btn btn-primary form-submit">Search</button>
+</div></div></form>
+</section>
+  </div>
+        <!-- .btn-navbar is used as the toggle for collapsed navbar content -->
+        <button aria-expanded="false" aria-controls="megamenu" type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+                    <span class="menu-text">Menu</span><span class="sr-only">Toggle navigation</span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+
+        </button>
+      </div>
+
+              <div class="navbar-collapse collapse">
+          <nav id="megamenu" role="navigation">
+                          <h2 class="element-invisible">Main menu</h2><ul id="main-menu" class="menu nav navbar-nav yamm navbar"><li class="first dropdown"><a href="/web/20211024013718/https://www.health.govt.nz/your-health" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="megamenu-dropdown-780">Your health <b class="caret"></b></a>
+    <div id="megamenu-dropdown-780" class="dropdown-menu">
+    <div class="yamm-content">
+      <div class="row">
+                            <div class="col">
+            <h3><a href="/web/20211024013718/https://www.health.govt.nz/your-health/conditions-and-treatments?mega=Your%20health&amp;title=Conditions%20%26%20treatments" class="menu-header">Conditions &amp; treatments</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211024013718/https://www.health.govt.nz/your-health/conditions-and-treatments/mental-health/depression?mega=Your%20health&amp;title=Depression">Depression</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/diabetes?mega=Your%20health&amp;title=Diabetes">Diabetes</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/influenza?mega=Your%20health&amp;title=Influenza">Influenza</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/measles?mega=Your%20health&amp;title=Measles">Measles</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/meningococcal-disease-including-meningitis?mega=Your%20health&amp;title=Meningococcal%20disease">Meningococcal disease</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/mumps?mega=Your%20health&amp;title=Mumps">Mumps</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/respiratory-syncytial-virus-rsv?mega=Your%20health&amp;title=RSV">RSV</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/sore-throat?mega=Your%20health&amp;title=Sore%20throat">Sore throat</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/your-health/conditions-and-treatments?mega=Your%20health&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211024013718/https://www.health.govt.nz/your-health/healthy-living?mega=Your%20health&amp;title=Healthy%20living" class="menu-header">Healthy living</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211024013718/https://www.health.govt.nz/your-health/healthy-living/drinking-water?mega=Your%20health&amp;title=Drinking-water">Drinking-water</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/your-health/healthy-living/food-activity-and-sleep/green-prescriptions?mega=Your%20health&amp;title=Green%20Prescriptions">Green Prescriptions</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/your-health/healthy-living/food-activity-and-sleep/healthy-eating?mega=Your%20health&amp;title=Healthy%20eating">Healthy eating</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/your-health/healthy-living/immunisation?mega=Your%20health&amp;title=Immunisation">Immunisation</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/your-health/healthy-living/food-activity-and-sleep/physical-activity?mega=Your%20health&amp;title=Physical%20activity">Physical activity</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/your-health/healthy-living/addictions/quitting-smoking?mega=Your%20health&amp;title=Smoking">Smoking</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/your-health/healthy-living/teeth-and-gums?mega=Your%20health&amp;title=Teeth%20and%20gums">Teeth and gums</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/your-health/healthy-living?mega=Your%20health&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211024013718/https://www.health.govt.nz/your-health/pregnancy-and-kids?mega=Your%20health&amp;title=Pregnancy%20and%20kids" class="menu-header">Pregnancy and kids</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211024013718/https://www.health.govt.nz/your-health/pregnancy-and-kids/birth-and-afterwards?mega=Your%20health&amp;title=Birth%20and%20afterwards">Birth and afterwards</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/your-health/pregnancy-and-kids/first-year/helpful-advice-during-first-year/breastfeeding-perfect-you-and-your-baby?mega=Your%20health&amp;title=Breastfeeding">Breastfeeding</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/your-health/pregnancy-and-kids/pregnancy?mega=Your%20health&amp;title=Pregnancy">Pregnancy</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/your-health/pregnancy-and-kids/services-and-support-during-pregnancy?mega=Your%20health&amp;title=Services%20and%20support%20during%20pregnancy">Services and support during pregnancy</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/your-health/pregnancy-and-kids/services-and-support-you-and-your-child?mega=Your%20health&amp;title=Services%20and%20support%20for%20you%20and%20your%20child">Services and support for you and your child</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/your-health/pregnancy-and-kids/first-year?mega=Your%20health&amp;title=The%20first%20year">The first year</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/your-health/pregnancy-and-kids/under-fives?mega=Your%20health&amp;title=Under%20fives">Under fives</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/your-health/pregnancy-and-kids?mega=Your%20health&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211024013718/https://www.health.govt.nz/your-health/services-and-support?mega=Your%20health&amp;title=Services%20and%20support" class="menu-header">Services &amp; support</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211024013718/https://www.health.govt.nz/your-health/services-and-support/health-care-services/help-alcohol-and-drug-problems?mega=Your%20health&amp;title=Alcohol%20and%20drugs">Alcohol and drugs</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/your-health/services-and-support/disability-services?mega=Your%20health&amp;title=Disability%20services">Disability services</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/your-health/services-and-support/health-care-services/earthquake-support-line?mega=Your%20health&amp;title=Earthquake%20Support%20Line">Earthquake Support Line</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/your-health/services-and-support/health-care-services/healthline?mega=Your%20health&amp;title=Healthline">Healthline</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/your-health/services-and-support/health-care-services/mental-health-services?mega=Your%20health&amp;title=Mental%20health%20services">Mental health services</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/your-health/services-and-support/health-care-services/maori-health-provider-directory?mega=Your%20health&amp;title=M%C4%81ori%20health%20providers">Māori health providers</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/your-health/services-and-support/health-care-services/services-older-people/rest-home-certification-and-audits?mega=Your%20health&amp;title=Rest%20home%20certification">Rest home certification</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/your-health/services-and-support/health-care-services/hospitals-and-specialist-services/travel-assistance?mega=Your%20health&amp;title=Travel%20assistance">Travel assistance</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/your-health/services-and-support?mega=Your%20health&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                        </div>
+    </div>
+    <div class="feature-links">
+      <h3 class="sr-only">Other related resources</h3>
+      <a href="/web/20211024013718/https://www.health.govt.nz/your-health/full-a-z?mega=Your%20health&amp;title=A-Z">View the full A-Z</a>    </div>
+  </div>
+</li>
+<li class="dropdown"><a href="/web/20211024013718/https://www.health.govt.nz/new-zealand-health-system" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="megamenu-dropdown-6076">NZ health system <b class="caret"></b></a>
+    <div id="megamenu-dropdown-6076" class="dropdown-menu">
+    <div class="yamm-content">
+      <div class="row">
+                            <div class="col">
+            <h3><a href="/web/20211024013718/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people?mega=NZ%20health%20system&amp;title=Key%20organisations" class="menu-header">Key organisations</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211024013718/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/crown-entities-and-statutory-boards?mega=NZ%20health%20system&amp;title=Crown%20entities%20%26%20agencies">Crown entities &amp; agencies</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/district-health-boards?mega=NZ%20health%20system&amp;title=District%20health%20boards">District health boards</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/non-governmental-organisations?mega=NZ%20health%20system&amp;title=Non-governmental%20organisations">Non-governmental organisations</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/primary-health-organisations?mega=NZ%20health%20system&amp;title=Primary%20health%20organisations">Primary health organisations</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/public-health-units?mega=NZ%20health%20system&amp;title=Public%20health%20units">Public health units</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people?mega=NZ%20health%20system&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211024013718/https://www.health.govt.nz/new-zealand-health-system/health-system-indicators-framework?mega=NZ%20health%20system&amp;title=Health%20System%20Indicators%20framework" class="menu-header">Health System Indicators framework</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211024013718/https://www.health.govt.nz/new-zealand-health-system/health-system-indicators-framework?mega=NZ%20health%20system&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211024013718/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services?mega=NZ%20health%20system&amp;title=Eligibility%20for%20public%20health%20services" class="menu-header">Eligibility for public health services</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211024013718/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services/guide-eligibility-publicly-funded-health-services?mega=NZ%20health%20system&amp;title=Guide%20to%20eligibility">Guide to eligibility</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services/eligibility-questions-and-answers-consumers?mega=NZ%20health%20system&amp;title=Q%26A%20for%20consumers">Q&amp;A for consumers</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services/eligibility-questions-and-answers-service-providers?mega=NZ%20health%20system&amp;title=Q%26A%20for%20service%20providers">Q&amp;A for service providers</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services/reciprocal-health-agreements?mega=NZ%20health%20system&amp;title=Reciprocal%20health%20agreements">Reciprocal health agreements</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services?mega=NZ%20health%20system&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211024013718/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements?mega=NZ%20health%20system&amp;title=Claims%2C%20provider%20payments%20and%20entitlements" class="menu-header">Claims &amp; provider payments</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211024013718/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/carer-support-claims?mega=NZ%20health%20system&amp;title=Carer%20Support">Carer Support</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/high-use-health-card-payments?mega=NZ%20health%20system&amp;title=High%20Use%20Health%20Card%20payments">High Use Health Card payments</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/between-travel-settlement?mega=NZ%20health%20system&amp;title=In-Between%20Travel%20Settlement">In-Between Travel Settlement</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/maternity-claim-forms?mega=NZ%20health%20system&amp;title=Maternity%20claim%20forms">Maternity claim forms</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/national-travel-assistance?mega=NZ%20health%20system&amp;title=National%20travel%20assistance%20claims">National travel assistance claims</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements?mega=NZ%20health%20system&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                        </div>
+    </div>
+    <div class="feature-links">
+      <h3 class="sr-only">Other related resources</h3>
+      <a href="/web/20211024013718/https://www.health.govt.nz/new-zealand-health-system/overview-health-system?mega=NZ%20health%20system&amp;title=Overview">Overview of the health system</a>  <a href="/web/20211024013718/https://www.health.govt.nz/new-zealand-health-system/my-dhb?mega=NZ%20health%20system&amp;title=Mydhb">My DHB</a> <a href="/web/20211024013718/https://www.health.govt.nz/new-zealand-health-system/system-level-measures-framework?mega=NZ%20health%20system&amp;title=SLM">System level measures</a>  <a href="/web/20211024013718/https://www.health.govt.nz/publication/new-zealand-health-strategy-2016?mega=NZ%20health%20system&amp;title=HealthStrategy">NZ Health Strategy</a>    </div>
+  </div>
+</li>
+<li class="dropdown"><a href="/web/20211024013718/https://www.health.govt.nz/our-work" class="dropdown-toggle active-trail" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="megamenu-dropdown-776">Our work <b class="caret"></b></a>
+  <div id="megamenu-dropdown-776" class="dropdown-menu">
+    <div class="yamm-content">
+      <div class="row">
+                            <ul class="col list-unstyled no-menu-header">
+                                                                                <li>
+                <a href="/web/20211024013718/https://www.health.govt.nz/our-work/diseases-and-conditions/antimicrobial-resistance?mega=Our%20work&amp;title=Antimicrobial%20resistance" class="menu-header">Antimicrobial resistance</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211024013718/https://www.health.govt.nz/our-work/populations/asian-and-migrant-health?mega=Our%20work&amp;title=Asian%20and%20migrant%20health" class="menu-header">Asian and migrant health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211024013718/https://www.health.govt.nz/our-work/border-health?mega=Our%20work&amp;title=Border%20health" class="menu-header">Border health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211024013718/https://www.health.govt.nz/our-work/life-stages/breastfeeding?mega=Our%20work&amp;title=Breastfeeding" class="menu-header">Breastfeeding</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211024013718/https://www.health.govt.nz/our-work/diseases-and-conditions/cancer?mega=Our%20work&amp;title=Cancer" class="menu-header">Cancer</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211024013718/https://www.health.govt.nz/our-work/regulation-health-and-disability-system/certification-health-care-services?mega=Our%20work&amp;title=Certification%20of%20health%20care%20services" class="menu-header">Certification of health care services</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211024013718/https://www.health.govt.nz/our-work/life-stages/child-health?mega=Our%20work&amp;title=Child%20health" class="menu-header">Child health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211024013718/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus?mega=Our%20work&amp;title=COVID-19" class="menu-header">COVID-19 (novel coronavirus)</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211024013718/https://www.health.govt.nz/our-work/diseases-and-conditions/diabetes?mega=Our%20work&amp;title=Diabetes" class="menu-header">Diabetes</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211024013718/https://www.health.govt.nz/our-work/digital-health?mega=Our%20work&amp;title=Digital%20health" class="menu-header">Digital health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211024013718/https://www.health.govt.nz/our-work/disability-services?mega=Our%20work&amp;title=Disability%20services" class="menu-header">Disability services</a>                              </li>
+                                                                </ul>
+                            <ul class="col list-unstyled no-menu-header">
+                                                                                <li>
+                <a href="/web/20211024013718/https://www.health.govt.nz/our-work/diseases-and-conditions?mega=Our%20work&amp;title=Diseases%20and%20conditions" class="menu-header">Diseases and conditions</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211024013718/https://www.health.govt.nz/our-work/hospitals-and-specialist-care/emergency-departments?mega=Our%20work&amp;title=Emergency%20departments" class="menu-header">Emergency departments</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211024013718/https://www.health.govt.nz/our-work/emergency-management?mega=Our%20work&amp;title=Emergency%20management" class="menu-header">Emergency management</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211024013718/https://www.health.govt.nz/our-work/environmental-health?mega=Our%20work&amp;title=Environmental%20health" class="menu-header">Environmental health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211024013718/https://www.health.govt.nz/our-work/preventative-health-wellness/family-violence?mega=Our%20work&amp;title=Family%20violence" class="menu-header">Family violence</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211024013718/https://www.health.govt.nz/our-work/preventative-health-wellness/fluoride-and-oral-health?mega=Our%20work&amp;title=Fluoride%20and%20oral%20health" class="menu-header">Fluoride and oral health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211024013718/https://www.health.govt.nz/our-work/health-identity?mega=Our%20work&amp;title=Health%20identity" class="menu-header">Health identity</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211024013718/https://www.health.govt.nz/our-work/digital-health/digital-health-sector-architecture-standards-and-governance/health-information-standards-0?mega=Our%20work&amp;title=Health%20information%20standards" class="menu-header">Health information standards</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211024013718/https://www.health.govt.nz/our-work/life-stages/health-older-people?mega=Our%20work&amp;title=Health%20of%20older%20people" class="menu-header">Health of older people</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211024013718/https://www.health.govt.nz/our-work/health-workforce?mega=Our%20work&amp;title=Health%20workforce" class="menu-header">Health workforce</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211024013718/https://www.health.govt.nz/our-work/hospitals-and-specialist-care?mega=Our%20work&amp;title=Hospitals%20and%20specialist%20care" class="menu-header">Hospitals and specialist care</a>                              </li>
+                                                                </ul>
+                            <ul class="col list-unstyled no-menu-header">
+                                                                                <li>
+                <a href="/web/20211024013718/https://www.health.govt.nz/our-work/preventative-health-wellness/immunisation?mega=Our%20work&amp;title=Immunisation" class="menu-header">Immunisation</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211024013718/https://www.health.govt.nz/our-work/ionising-radiation-safety?mega=Our%20work&amp;title=Ionising%20radiation%20safety" class="menu-header">Ionising radiation safety</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211024013718/https://www.health.govt.nz/our-work/populations/maori-health?mega=Our%20work&amp;title=M%C4%81ori%20health" class="menu-header">Māori health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211024013718/https://www.health.govt.nz/our-work/life-stages/maternity-services?mega=Our%20work&amp;title=Maternity" class="menu-header">Maternity</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211024013718/https://www.health.govt.nz/our-work/regulation-health-and-disability-system/medicinal-cannabis-agency?mega=Our%20work&amp;title=Medicinal%20Cannabis%20Agency" class="menu-header">Medicinal cannabis</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211024013718/https://www.health.govt.nz/our-work/regulation-health-and-disability-system/medicines-control?mega=Our%20work&amp;title=Medicines%20control" class="menu-header">Medicines control</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211024013718/https://www.health.govt.nz/our-work/mental-health-and-addiction?mega=Our%20work&amp;title=Mental%20health%20and%20addiction" class="menu-header">Mental health and addiction</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211024013718/https://www.health.govt.nz/our-work/nursing?mega=Our%20work&amp;title=Nursing" class="menu-header">Nursing</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211024013718/https://www.health.govt.nz/our-work/preventative-health-wellness/nutrition?mega=Our%20work&amp;title=Nutrition" class="menu-header">Nutrition</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211024013718/https://www.health.govt.nz/our-work/preventative-health-wellness/oral-health?mega=Our%20work&amp;title=Oral%20health" class="menu-header">Oral health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211024013718/https://www.health.govt.nz/our-work/hospitals-and-specialist-care/organ-donation-and-transplantation?mega=Our%20work&amp;title=Organ%20donation%20and%20transplantation" class="menu-header">Organ donation and transplantation</a>                              </li>
+                                                                </ul>
+                            <ul class="col list-unstyled no-menu-header">
+                                                                                <li>
+                <a href="/web/20211024013718/https://www.health.govt.nz/our-work/populations/pacific-health?mega=Our%20work&amp;title=Pacific%20health" class="menu-header">Pacific health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211024013718/https://www.health.govt.nz/new-zealand-health-system/pay-equity-settlements?mega=Our%20work&amp;title=Pay%20equity%20settlements" class="menu-header">Pay equity</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211024013718/https://www.health.govt.nz/our-work/preventative-health-wellness/physical-activity?mega=Our%20work&amp;title=Physical%20activity" class="menu-header">Physical activity</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211024013718/https://www.health.govt.nz/our-work/hospitals-and-specialist-care/planned-care-services?mega=Our%20work&amp;title=Planned%20Care%20services" class="menu-header">Planned Care services</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211024013718/https://www.health.govt.nz/our-work/preventative-health-wellness?mega=Our%20work&amp;title=Preventative%20health/wellness" class="menu-header">Preventative health/wellness</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211024013718/https://www.health.govt.nz/our-work/primary-health-care?mega=Our%20work&amp;title=Primary%20health%20care" class="menu-header">Primary health care</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211024013718/https://www.health.govt.nz/our-work/public-health-workforce-development?mega=Our%20work&amp;title=Public%20health%20workforce%20development" class="menu-header">Public health workforce</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211024013718/https://www.health.govt.nz/our-work/regulation-health-and-disability-system?mega=Our%20work&amp;title=Regulation" class="menu-header">Regulation</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211024013718/https://www.health.govt.nz/our-work/preventative-health-wellness/tobacco-control?mega=Our%20work&amp;title=Tobacco%20control" class="menu-header">Tobacco control</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211024013718/https://www.health.govt.nz/our-work/regulation-health-and-disability-system/regulation-vaping-and-smokeless-tobacco-products?mega=Our%20work&amp;title=Vaping%20and%20smokeless%20tobacco%20products" class="menu-header">Vaping &amp; smokeless tobacco</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211024013718/https://www.health.govt.nz/our-work/who-code-nz?mega=Our%20work&amp;title=WHO%20Code%20in%20NZ" class="menu-header">WHO Code in NZ</a>                              </li>
+                      </ul>
+              </div>
+    </div>
+    <div class="feature-links">
+      <a href="/web/20211024013718/https://www.health.govt.nz/our-work?mega=Our%20work&amp;title=A-Z">View the full A-Z</a>    </div>
+  </div>
+</li>
+<li class="dropdown"><a href="/web/20211024013718/https://www.health.govt.nz/nz-health-statistics" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="megamenu-dropdown-778">Health statistics <b class="caret"></b></a>
+    <div id="megamenu-dropdown-778" class="dropdown-menu">
+    <div class="yamm-content">
+      <div class="row">
+                            <div class="col">
+            <h3><a href="/web/20211024013718/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets?mega=Health%20statistics&amp;title=Health%20statistics%20and%20data%20sets" class="menu-header">Statistics by topic</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211024013718/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/cancer-data-and-stats?mega=Health%20statistics&amp;title=Cancer">Cancer</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/diabetes-data-and-stats?mega=Health%20statistics&amp;title=Diabetes">Diabetes</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/mental-health-data-and-stats?mega=Health%20statistics&amp;title=Mental%20health">Mental health</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/maori-health-data-and-stats?mega=Health%20statistics&amp;title=M%C4%81ori%20health">Māori health</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/obesity-statistics?mega=Health%20statistics&amp;title=Obesity">Obesity</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/suicide-data-and-stats?mega=Health%20statistics&amp;title=Suicide">Suicide</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/tobacco-data-and-stats?mega=Health%20statistics&amp;title=Tobacco">Tobacco</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets?mega=Health%20statistics&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211024013718/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys?mega=Health%20statistics&amp;title=National%20collections%20and%20surveys" class="menu-header">About our surveys &amp; data collections</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211024013718/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/surveys/past-surveys/alcohol-and-drug-use-survey?mega=Health%20statistics&amp;title=Alcohol%20%26%20Drug%20Use%20Survey">Alcohol &amp; Drug Use Survey</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/national-collections-annual-maintenance-project?mega=Health%20statistics&amp;title=NCAMP">NCAMP</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/collections/new-zealand-cancer-registry-nzcr?mega=Health%20statistics&amp;title=NZ%20Cancer%20Registry">NZ Cancer Registry</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/surveys/new-zealand-health-survey?mega=Health%20statistics&amp;title=NZ%20Health%20Survey">NZ Health Survey</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/surveys/past-surveys/nutrition-survey?mega=Health%20statistics&amp;title=Nutrition%20Survey">Nutrition Survey</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/collections/primhd-mental-health-data?mega=Health%20statistics&amp;title=PRIMHD">PRIMHD</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys?mega=Health%20statistics&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211024013718/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology?mega=Health%20statistics&amp;title=Classification%20and%20Terminology" class="menu-header">Classification &amp; terminology</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211024013718/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology/using-icd-10-am-achi-acs/coding-queries/coding-query-database?mega=Health%20statistics&amp;title=Coding%20query%20database">Coding query database</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology/using-icd-10-am-achi-acs/courses-clinical-coding?mega=Health%20statistics&amp;title=Courses%20on%20clinical%20coding">Courses on clinical coding</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology/new-zealand-snomed-ct-national-release-centre?mega=Health%20statistics&amp;title=SNOMED%20CT">SNOMED CT</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology/using-icd-10-am-achi-acs?mega=Health%20statistics&amp;title=Using%20ICD-10-AM/ACHI/ACS">Using ICD-10-AM/ACHI/ACS</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology?mega=Health%20statistics&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211024013718/https://www.health.govt.nz/nz-health-statistics/data-references?mega=Health%20statistics&amp;title=Data%20references" class="menu-header">Data references</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211024013718/https://www.health.govt.nz/nz-health-statistics/data-references/code-tables?mega=Health%20statistics&amp;title=Code%20tables">Code tables</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/nz-health-statistics/data-references/data-dictionaries?mega=Health%20statistics&amp;title=Data%20dictionaries">Data dictionaries</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/nz-health-statistics/data-references/diagnosis-related-groups?mega=Health%20statistics&amp;title=Diagnosis-related%20groups">Diagnosis-related groups</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/nz-health-statistics/data-references/code-tables/common-code-tables/domicile-code-table?mega=Health%20statistics&amp;title=Domicile%20code%20table">Domicile code table</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/nz-health-statistics/data-references/mapping-tools?mega=Health%20statistics&amp;title=ICD%20mapping%20tools">ICD mapping tools</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/nz-health-statistics/data-references/weighted-inlier-equivalent-separations?mega=Health%20statistics&amp;title=Weighted%20Inlier%20Equivalent%20Separations">Weighted Inlier Equivalent Separations</a></li>
+                                  <li><a href="/web/20211024013718/https://www.health.govt.nz/nz-health-statistics/data-references?mega=Health%20statistics&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                        </div>
+    </div>
+    <div class="feature-links">
+      <h3 class="sr-only">Other related resources</h3>
+      <a href="/web/20211024013718/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/tier-1-health-statistics-release-calendar?mega=Health%20statistics&amp;title=Tier%201%20calendar">Release calendar for our Tier 1 statistics</a> <a href="/web/20211024013718/https://www.health.govt.nz/nz-health-statistics/about-data-collection?mega=Health%20statistics&amp;title=Enquiries">Data and survey enquiries</a>    </div>
+  </div>
+</li>
+<li class=""><a href="/web/20211024013718/https://www.health.govt.nz/publications" aria-haspopup="false">Publications</a></li>
+<li class=""><a href="/web/20211024013718/https://www.health.govt.nz/about-ministry" aria-haspopup="false">About us</a></li>
+<li class="visible-xs"><a href="/web/20211024013718/https://www.health.govt.nz/contactus" aria-haspopup="false">Contact us</a></li>
+</ul>
+                                  </nav>
+        </div>
+          </div>
+  </header>
+
+  <div class="main-container container">
+    <!-- announcement -->
+        <!-- /announcement -->
+
+    <header role="banner" id="page-header">
+
+          </header> <!-- /#page-header -->
+
+    <div class="row">
+
+      <section class="col-sm-12">
+                        <a id="main-content"></a>
+                                                                            <div class="breadcrumbs">
+            <ul><li><a href="/web/20211024013718/https://www.health.govt.nz/">Home</a></li><li><a href="/web/20211024013718/https://www.health.govt.nz/our-work">Our work</a></li><li><a href="/web/20211024013718/https://www.health.govt.nz/our-work/diseases-and-conditions">Diseases and conditions</a></li><li><a href="/web/20211024013718/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished" data-is-top-level="1" title="">COVID-19</a></li><li><a href="/web/20211024013718/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics" class="menu-node-unpublished menu-node-unpublished">Data and statistics</a></li><li><span class="current-breadcrumb">Vaccine data</span></li></ul>          </div>
+
+
+
+          <div class="region region-content">
+    <section id="block-system-main" class="block block-system clearfix">
+
+
+  <div class="bootstrap-threecol-stacked">
+
+      <div class="row"> <!-- @TODO: Add extra classes -->
+      <div class="panel-panel left col-xs-12 col-md-3 col-lg-3"><div class="panel-pane pane-block pane-menu-block-1 odd pane-top-link">
+
+        <span class="top-link"><a href="/web/20211024013718/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished active-trail" data-is-top-level="1">COVID-19</a></span>
+
+
+  <div class="pane-content">
+        <div class="menu-block-wrapper menu-block-1 menu-name-main-menu parent-mlid-1445 menu-level-2">
+  <ul class="menu nav"><li class="first collapsed menu-mlid-10163 health-advice depth-4"><a href="/web/20211024013718/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-health-advice-public" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished">Health advice</a></li>
+<li class="collapsed menu-mlid-10630 covid-19-vaccines- depth-4 section-overview hide-children"><a href="/web/20211024013718/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-vaccines" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished" data-is-top-level="1" title="">COVID-19 vaccines </a></li>
+<li class="collapsed menu-mlid-9997 health-professionals depth-4"><a href="/web/20211024013718/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-information-health-professionals" class="menu-node-unpublished menu-node-unpublished">Health professionals</a></li>
+<li class="collapsed menu-mlid-10019 specific-audiences depth-4"><a href="/web/20211024013718/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-information-specific-audiences" class="menu-node-unpublished">Specific audiences</a></li>
+<li class="expanded active-trail menu-mlid-10096 data-and-statistics depth-4"><a href="/web/20211024013718/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics" class="menu-node-unpublished menu-node-unpublished active-trail">Data and statistics</a><ul class="menu nav"><li class="first leaf menu-mlid-10062 current-cases depth-5 same-level-as-node"><a href="/web/20211024013718/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-current-cases" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Current cases</a></li>
+<li class="leaf menu-mlid-10146 case-demographics depth-5 same-level-as-node"><a href="/web/20211024013718/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-case-demographics">Case demographics</a></li>
+<li class="leaf menu-mlid-10097 source-of-cases depth-5 same-level-as-node"><a href="/web/20211024013718/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-source-cases" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Source of cases</a></li>
+<li class="leaf menu-mlid-10119 testing-for-covid-19 depth-5 same-level-as-node"><a href="/web/20211024013718/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/testing-covid-19" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Testing for COVID-19</a></li>
+<li class="leaf menu-mlid-10371 nz-covid-tracer-app-data depth-5 same-level-as-node"><a href="/web/20211024013718/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-nz-covid-tracer-app-data" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">NZ COVID Tracer app data</a></li>
+<li class="expanded active-trail active menu-mlid-10584 active vaccine-data depth-5 same-level-as-node"><a href="/web/20211024013718/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished active-trail active">Vaccine data</a><ul class="menu nav"><li class="first leaf menu-mlid-10867 covid-19-vaccination-uptake-rates-across-nz depth-6"><a href="/web/20211024013718/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-across-nz" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">COVID-19 Vaccination uptake rates across NZ</a></li>
+<li class="leaf menu-mlid-10868 covid-19-vaccination-uptake-rates---māori depth-6"><a href="/web/20211024013718/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-maori-communities-across-nz" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">COVID-19 Vaccination uptake rates - Māori</a></li>
+<li class="last leaf menu-mlid-10869 covid-19-vaccination-uptake-rates---pacific depth-6"><a href="/web/20211024013718/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-pacific-communities-across-nz" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">COVID-19 Vaccination uptake rates - Pacific</a></li>
+</ul></li>
+<li class="last leaf menu-mlid-10404 data-resources depth-5 same-level-as-node"><a href="/web/20211024013718/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-data-resources" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Data resources</a></li>
+</ul></li>
+<li class="collapsed menu-mlid-10369 response-planning depth-4"><a href="/web/20211024013718/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-response-planning" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Response planning</a></li>
+<li class="collapsed menu-mlid-10015 resources-and-tools depth-4"><a href="/web/20211024013718/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-resources-and-tools" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Resources and tools</a></li>
+<li class="last leaf menu-mlid-10004 news-and-media depth-4 section-overview hide-children"><a href="/web/20211024013718/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-news-and-media-updates" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">News and media</a></li>
+</ul></div>
+  </div>
+
+
+  </div>
+</div>      <div class="panel-panel middle col-xs-12 col-md-9 col-lg-9"><div class="panel-pane pane-page-title even">
+
+
+
+  <div class="pane-content">
+    <span id="skip-content" tabindex="-1"></span>    <h1>COVID-19: Vaccine data</h1>
+  </div>
+
+
+  </div>
+<div class="panel-pane pane-node-content odd">
+
+
+
+  <div class="pane-content">
+        <article id="node-12052" class="node node-page node-sticky view-mode-full clearfix" about="/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" typeof="sioc:Item foaf:Document">
+    <header>
+            <span property="dc:title" content="COVID-19: Vaccine data" class="rdf-meta element-hidden"></span>      </header>
+    <div class="field field-name-field-intro-text field-type-text-long field-label-hidden"><div class="field-items"><div class="field-item even"><p class="intro-text">Data and statistics about the rollout of COVID-19 vaccines in New Zealand.</p></div></div></div><div class="field field-name-body field-type-text-with-summary field-label-hidden"><div class="field-items"><div class="field-item even" property="content:encoded"><p>On this page:</p>
+
+<ul>
+	<li><a href="#daily">Daily updates</a>
+
+	<ul>
+		<li><a href="#total-vaccinations">Total vaccinations</a></li>
+		<li><a href="#ethnicity">Vaccinations by ethnicity</a></li>
+	</ul>
+	</li>
+	<li><a href="#weekly-updates">Weekly updates</a>
+	<ul>
+		<li><a href="#model">Vaccinations against plan</a></li>
+		<li><a href="#uptake">Vaccinations uptake</a></li>
+		<li><a href="#by-day">Vaccinations by day</a></li>
+		<li><a href="#location">Vaccinations by DHB</a></li>
+		<li><a href="#group">Vaccinations by group</a></li>
+		<li><a href="#by_soh">Stock on hand</a></li>
+		<li><a href="#age">Vaccinations by age</a></li>
+		<li><a href="#workforce">Trained vaccinator and active vaccinator</a></li>
+		<li><a href="#group">Vaccinations by group</a></li>
+		<li><a href="#download">Details of vaccination&nbsp;data</a></li>
+	</ul>
+	</li>
+	<li><a href="#adverse-events">Adverse events from immunisations</a></li>
+</ul>
+
+<hr/><!--daily-->
+<h2><a id="daily" name="daily"></a>COVID-19 vaccinations: daily updates</h2>
+
+<div class="well well-sm">
+<p style="margin-top: 0"><strong>Data in this section is as at 11:59pm 23 October 2021 and is updated daily.</strong></p>
+</div>
+
+<h3><a id="total-vaccinations" name="total-vaccinations"></a>Total Vaccinations</h3>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">&nbsp;</th>
+			<th scope="col" style="text-align:right">Vaccinations yesterday</th>
+			<th scope="col" style="text-align:right">Cumulative total</th>
+			<th scope="col" style="text-align:right">Eligible population vaccinated %</th>
+			<th scope="col" style="text-align:right">Total population vaccinated %</th>
+			<th scope="col" style="text-align:right">Vaccinated or booked</th>
+			<th scope="col" style="text-align:right">Eligible vaccinated or booked %</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">First dose</th>
+			<td style="text-align:right">11,777</td>
+			<td style="text-align:right">3,637,937</td>
+			<td style="text-align:right">86%</td>
+			<td style="text-align:right">73%</td>
+			<td style="text-align:right">3,657,975</td>
+			<td style="text-align:right">87%</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Second dose</th>
+			<td style="text-align:right">30,705</td>
+			<td style="text-align:right">2,966,474</td>
+			<td style="text-align:right">70%</td>
+			<td style="text-align:right">59%</td>
+			<td style="text-align:right">3,317,470</td>
+			<td style="text-align:right">79%</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total doses</strong></th>
+			<td style="text-align:right"><strong>42,482</strong></td>
+			<td style="text-align:right"><strong>6,604,411</strong></td>
+		</tr>
+	</tbody>
+</table>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Total vaccinations" class="img-responsive" height="900" src="/web/20211024013718im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_summary_15.png" width="5340"/></figure>
+
+<h5>Definitions</h5>
+
+<ul>
+	<li><strong>Cumulative total:</strong>&nbsp;All vaccinations that have been administered and entered into the COVID-19 Immunisation Register up until midnight of the night before the data is published.</li>
+	<li><strong>Eligible population vaccinated %:</strong>&nbsp;Vaccinations administered divided by HSU population estimates for the eligible population (12+).</li>
+	<li><strong>Total population vaccinated %:</strong>&nbsp;Vaccinations administered divided by HSU population estimates for the total population (0+).</li>
+	<li><strong>Vaccinated or booked:</strong>&nbsp;Count of individuals who have either received their vaccination or have booked via Book My Vaccine to receive a vaccination.</li>
+	<li><strong>Eligible vaccinated or booked %:</strong>&nbsp;Count of individuals who have either received their vaccination or have booked via Book My Vaccine to receive a vaccination divided by HSU population estimates for the eligible population (12+).</li>
+</ul>
+
+<p>HSU population estimates are available in the downloadable spreadsheet at the bottom of the page. Throughout the rest of this sheet doses per 1,000 are based on eligible (12+) population.</p>
+
+<p>Bookings are only counted if the site is using Book My Vaccine. Bookings made through other Patient Management Systems are not counted.</p>
+
+<hr/>
+<h3><a id="by_eth" name="ethnicity"></a>Cumulative vaccinations by ethnicity</h3>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">Ethnicity *</th>
+			<th scope="col" style="text-align:right">First dose administered</th>
+			<th scope="col" style="text-align:right">First doses per 1,000 people</th>
+			<th scope="col" style="text-align:right">Second dose administered</th>
+			<th scope="col" style="text-align:right">Second doses per 1,000 people</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">Māori</th>
+			<td style="text-align:right">392,440</td>
+			<td style="text-align:right">687</td>
+			<td style="text-align:right">275,344</td>
+			<td style="text-align:right">482</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Pacific Peoples</th>
+			<td style="text-align:right">237,212</td>
+			<td style="text-align:right">827</td>
+			<td style="text-align:right">183,311</td>
+			<td style="text-align:right">639</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Asian</th>
+			<td style="text-align:right">601,289</td>
+			<td style="text-align:right">&gt;950</td>
+			<td style="text-align:right">511,913</td>
+			<td style="text-align:right">855</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">European / Other</th>
+			<td style="text-align:right">2,373,553</td>
+			<td style="text-align:right">869</td>
+			<td style="text-align:right">1,969,345</td>
+			<td style="text-align:right">721</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Unknown</th>
+			<td style="text-align:right">33,443</td>
+			<td style="text-align:right">-</td>
+			<td style="text-align:right">26,561</td>
+			<td style="text-align:right">-</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total</strong></th>
+			<td style="text-align:right"><strong>3,637,937</strong></td>
+			<td style="text-align:right"><strong>864</strong></td>
+			<td style="text-align:right"><strong>2,966,474</strong></td>
+			<td style="text-align:right"><strong>705</strong></td>
+		</tr>
+	</tbody>
+</table>
+
+<p><strong>*</strong> The prioritised ethnicity classification system allocates each person to a single ethnic group, based on the ethnic groups they identify with. Where people identify with more than one group, they are assigned in this order of priority: Māori, Pacific Peoples, Asian, and European/Other. So, if a person identifies as being Māori and New Zealand European, the person is counted as Māori. See <a href="/web/20211024013718/https://www.health.govt.nz/publication/hiso-100012017-ethnicity-data-protocols">Ethnicity Data Protocols</a> for further information.</p>
+
+<p>Ethnicity breakdown by DHB of residence is available in the downloadable spreadsheet at the bottom of the page.</p>
+
+<hr/>
+<h3><a id="90pct" name="90pct"></a>Vaccinations to 90% by DHB</h3>
+
+<h4><a id="90pct all ethnicities" name="90pct all ethnicities"></a>All Ethnicities</h4>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">&nbsp;</th>
+			<th scope="col" style="text-align:right">First doses</th>
+			<th scope="col" style="text-align:right">First doses %</th>
+			<th scope="col" style="text-align:right">First doses to 90%</th>
+			<th scope="col" style="text-align:right">Second doses</th>
+			<th scope="col" style="text-align:right">Second doses %</th>
+			<th scope="col" style="text-align:right">Second doses to 90%</th>
+			<th scope="col" style="text-align:right">Population</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">Northland</th>
+			<td style="text-align:right">125,110</td>
+			<td style="text-align:right">78%</td>
+			<td style="text-align:right">20,078</td>
+			<td style="text-align:right">99,242</td>
+			<td style="text-align:right">62%</td>
+			<td style="text-align:right">45,946</td>
+			<td style="text-align:right">161,320</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waitemata</th>
+			<td style="text-align:right">474,237</td>
+			<td style="text-align:right">90%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">399,271</td>
+			<td style="text-align:right">76%</td>
+			<td style="text-align:right">74,207</td>
+			<td style="text-align:right">526,087</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Auckland</th>
+			<td style="text-align:right">394,356</td>
+			<td style="text-align:right">93%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">340,978</td>
+			<td style="text-align:right">80%</td>
+			<td style="text-align:right">40,584</td>
+			<td style="text-align:right">423,958</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Counties Manukau</th>
+			<td style="text-align:right">422,073</td>
+			<td style="text-align:right">87%</td>
+			<td style="text-align:right">12,423</td>
+			<td style="text-align:right">352,246</td>
+			<td style="text-align:right">73%</td>
+			<td style="text-align:right">82,250</td>
+			<td style="text-align:right">482,773</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waikato</th>
+			<td style="text-align:right">303,212</td>
+			<td style="text-align:right">85%</td>
+			<td style="text-align:right">18,246</td>
+			<td style="text-align:right">242,948</td>
+			<td style="text-align:right">68%</td>
+			<td style="text-align:right">78,510</td>
+			<td style="text-align:right">357,176</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Lakes</th>
+			<td style="text-align:right">74,241</td>
+			<td style="text-align:right">79%</td>
+			<td style="text-align:right">10,736</td>
+			<td style="text-align:right">58,047</td>
+			<td style="text-align:right">61%</td>
+			<td style="text-align:right">26,930</td>
+			<td style="text-align:right">94,419</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Bay of Plenty</th>
+			<td style="text-align:right">176,661</td>
+			<td style="text-align:right">81%</td>
+			<td style="text-align:right">18,586</td>
+			<td style="text-align:right">134,657</td>
+			<td style="text-align:right">62%</td>
+			<td style="text-align:right">60,590</td>
+			<td style="text-align:right">216,941</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Tairawhiti</th>
+			<td style="text-align:right">31,882</td>
+			<td style="text-align:right">76%</td>
+			<td style="text-align:right">5,886</td>
+			<td style="text-align:right">25,408</td>
+			<td style="text-align:right">61%</td>
+			<td style="text-align:right">12,360</td>
+			<td style="text-align:right">41,965</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Taranaki</th>
+			<td style="text-align:right">84,042</td>
+			<td style="text-align:right">82%</td>
+			<td style="text-align:right">7,890</td>
+			<td style="text-align:right">62,810</td>
+			<td style="text-align:right">61%</td>
+			<td style="text-align:right">29,122</td>
+			<td style="text-align:right">102,147</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hawkes Bay</th>
+			<td style="text-align:right">120,259</td>
+			<td style="text-align:right">83%</td>
+			<td style="text-align:right">10,755</td>
+			<td style="text-align:right">97,891</td>
+			<td style="text-align:right">67%</td>
+			<td style="text-align:right">33,123</td>
+			<td style="text-align:right">145,571</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">MidCentral</th>
+			<td style="text-align:right">128,749</td>
+			<td style="text-align:right">85%</td>
+			<td style="text-align:right">8,323</td>
+			<td style="text-align:right">104,271</td>
+			<td style="text-align:right">68%</td>
+			<td style="text-align:right">32,801</td>
+			<td style="text-align:right">152,302</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Whanganui</th>
+			<td style="text-align:right">45,151</td>
+			<td style="text-align:right">79%</td>
+			<td style="text-align:right">6,371</td>
+			<td style="text-align:right">37,379</td>
+			<td style="text-align:right">65%</td>
+			<td style="text-align:right">14,143</td>
+			<td style="text-align:right">57,247</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Capital and Coast</th>
+			<td style="text-align:right">247,213</td>
+			<td style="text-align:right">91%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">205,103</td>
+			<td style="text-align:right">76%</td>
+			<td style="text-align:right">38,954</td>
+			<td style="text-align:right">271,174</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hutt Valley</th>
+			<td style="text-align:right">112,688</td>
+			<td style="text-align:right">87%</td>
+			<td style="text-align:right">4,527</td>
+			<td style="text-align:right">90,348</td>
+			<td style="text-align:right">69%</td>
+			<td style="text-align:right">26,867</td>
+			<td style="text-align:right">130,239</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Wairarapa</th>
+			<td style="text-align:right">34,777</td>
+			<td style="text-align:right">84%</td>
+			<td style="text-align:right">2,507</td>
+			<td style="text-align:right">28,612</td>
+			<td style="text-align:right">69%</td>
+			<td style="text-align:right">8,672</td>
+			<td style="text-align:right">41,427</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Nelson Marlborough</th>
+			<td style="text-align:right">115,274</td>
+			<td style="text-align:right">85%</td>
+			<td style="text-align:right">6,895</td>
+			<td style="text-align:right">99,293</td>
+			<td style="text-align:right">73%</td>
+			<td style="text-align:right">22,876</td>
+			<td style="text-align:right">135,743</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">West Coast</th>
+			<td style="text-align:right">21,896</td>
+			<td style="text-align:right">78%</td>
+			<td style="text-align:right">3,219</td>
+			<td style="text-align:right">17,459</td>
+			<td style="text-align:right">63%</td>
+			<td style="text-align:right">7,656</td>
+			<td style="text-align:right">27,906</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Canterbury</th>
+			<td style="text-align:right">426,711</td>
+			<td style="text-align:right">88%</td>
+			<td style="text-align:right">7,890</td>
+			<td style="text-align:right">320,705</td>
+			<td style="text-align:right">66%</td>
+			<td style="text-align:right">113,896</td>
+			<td style="text-align:right">482,890</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">South Canterbury</th>
+			<td style="text-align:right">44,237</td>
+			<td style="text-align:right">84%</td>
+			<td style="text-align:right">3,089</td>
+			<td style="text-align:right">36,797</td>
+			<td style="text-align:right">70%</td>
+			<td style="text-align:right">10,529</td>
+			<td style="text-align:right">52,584</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Southern</th>
+			<td style="text-align:right">253,136</td>
+			<td style="text-align:right">88%</td>
+			<td style="text-align:right">6,078</td>
+			<td style="text-align:right">211,433</td>
+			<td style="text-align:right">73%</td>
+			<td style="text-align:right">47,780</td>
+			<td style="text-align:right">288,015</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Overseas / Unknown</th>
+			<td style="text-align:right">2,032</td>
+			<td style="text-align:right">12%</td>
+			<td style="text-align:right">13,424</td>
+			<td style="text-align:right">1,576</td>
+			<td style="text-align:right">9%</td>
+			<td style="text-align:right">13,880</td>
+			<td style="text-align:right">17,173</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total</strong></th>
+			<td style="text-align:right"><strong>3,637,937</strong></td>
+			<td style="text-align:right"><strong>86%</strong></td>
+			<td style="text-align:right"><strong>150,214</strong></td>
+			<td style="text-align:right"><strong>2,966,474</strong></td>
+			<td style="text-align:right"><strong>70%</strong></td>
+			<td style="text-align:right"><strong>821,677</strong></td>
+			<td style="text-align:right"><strong>4,209,057</strong></td>
+		</tr>
+	</tbody>
+</table>
+
+<p>First/second doses % are the number of first/second doses administered divided by the eligible population. First/second doses to 90% are the number of doses required to reach 90% of the eligible population. For these two measures, the national total may not be the sum of DHB measures.</p>
+
+<h4><a id="90pct Māori" name="90pct Māori">Māori</a></h4>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">&nbsp;</th>
+			<th scope="col" style="text-align:right">First doses</th>
+			<th scope="col" style="text-align:right">First doses %</th>
+			<th scope="col" style="text-align:right">First doses to 90%</th>
+			<th scope="col" style="text-align:right">Second doses</th>
+			<th scope="col" style="text-align:right">Second doses %</th>
+			<th scope="col" style="text-align:right">Second doses to 90%</th>
+			<th scope="col" style="text-align:right">Population</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">Northland</th>
+			<td style="text-align:right">32,546</td>
+			<td style="text-align:right">64%</td>
+			<td style="text-align:right">12,893</td>
+			<td style="text-align:right">22,204</td>
+			<td style="text-align:right">44%</td>
+			<td style="text-align:right">23,235</td>
+			<td style="text-align:right">50,488</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waitemata</th>
+			<td style="text-align:right">31,850</td>
+			<td style="text-align:right">77%</td>
+			<td style="text-align:right">5,152</td>
+			<td style="text-align:right">23,350</td>
+			<td style="text-align:right">57%</td>
+			<td style="text-align:right">13,652</td>
+			<td style="text-align:right">41,113</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Auckland</th>
+			<td style="text-align:right">22,319</td>
+			<td style="text-align:right">80%</td>
+			<td style="text-align:right">2,694</td>
+			<td style="text-align:right">16,881</td>
+			<td style="text-align:right">61%</td>
+			<td style="text-align:right">8,132</td>
+			<td style="text-align:right">27,792</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Counties Manukau</th>
+			<td style="text-align:right">44,484</td>
+			<td style="text-align:right">70%</td>
+			<td style="text-align:right">12,660</td>
+			<td style="text-align:right">30,841</td>
+			<td style="text-align:right">49%</td>
+			<td style="text-align:right">26,303</td>
+			<td style="text-align:right">63,493</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waikato</th>
+			<td style="text-align:right">48,285</td>
+			<td style="text-align:right">69%</td>
+			<td style="text-align:right">14,451</td>
+			<td style="text-align:right">32,593</td>
+			<td style="text-align:right">47%</td>
+			<td style="text-align:right">30,143</td>
+			<td style="text-align:right">69,707</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Lakes</th>
+			<td style="text-align:right">18,817</td>
+			<td style="text-align:right">63%</td>
+			<td style="text-align:right">8,260</td>
+			<td style="text-align:right">12,913</td>
+			<td style="text-align:right">43%</td>
+			<td style="text-align:right">14,164</td>
+			<td style="text-align:right">30,085</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Bay of Plenty</th>
+			<td style="text-align:right">29,459</td>
+			<td style="text-align:right">62%</td>
+			<td style="text-align:right">13,502</td>
+			<td style="text-align:right">19,496</td>
+			<td style="text-align:right">41%</td>
+			<td style="text-align:right">23,465</td>
+			<td style="text-align:right">47,734</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Tairawhiti</th>
+			<td style="text-align:right">12,854</td>
+			<td style="text-align:right">65%</td>
+			<td style="text-align:right">5,001</td>
+			<td style="text-align:right">9,326</td>
+			<td style="text-align:right">47%</td>
+			<td style="text-align:right">8,529</td>
+			<td style="text-align:right">19,839</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Taranaki</th>
+			<td style="text-align:right">10,365</td>
+			<td style="text-align:right">65%</td>
+			<td style="text-align:right">3,949</td>
+			<td style="text-align:right">6,590</td>
+			<td style="text-align:right">41%</td>
+			<td style="text-align:right">7,724</td>
+			<td style="text-align:right">15,904</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hawkes Bay</th>
+			<td style="text-align:right">21,858</td>
+			<td style="text-align:right">64%</td>
+			<td style="text-align:right">8,795</td>
+			<td style="text-align:right">15,383</td>
+			<td style="text-align:right">45%</td>
+			<td style="text-align:right">15,270</td>
+			<td style="text-align:right">34,059</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">MidCentral</th>
+			<td style="text-align:right">16,581</td>
+			<td style="text-align:right">68%</td>
+			<td style="text-align:right">5,222</td>
+			<td style="text-align:right">11,699</td>
+			<td style="text-align:right">48%</td>
+			<td style="text-align:right">10,104</td>
+			<td style="text-align:right">24,225</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Whanganui</th>
+			<td style="text-align:right">8,498</td>
+			<td style="text-align:right">63%</td>
+			<td style="text-align:right">3,663</td>
+			<td style="text-align:right">6,244</td>
+			<td style="text-align:right">46%</td>
+			<td style="text-align:right">5,917</td>
+			<td style="text-align:right">13,512</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Capital and Coast</th>
+			<td style="text-align:right">21,069</td>
+			<td style="text-align:right">78%</td>
+			<td style="text-align:right">3,201</td>
+			<td style="text-align:right">15,711</td>
+			<td style="text-align:right">58%</td>
+			<td style="text-align:right">8,559</td>
+			<td style="text-align:right">26,967</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hutt Valley</th>
+			<td style="text-align:right">13,496</td>
+			<td style="text-align:right">71%</td>
+			<td style="text-align:right">3,715</td>
+			<td style="text-align:right">9,549</td>
+			<td style="text-align:right">50%</td>
+			<td style="text-align:right">7,662</td>
+			<td style="text-align:right">19,123</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Wairarapa</th>
+			<td style="text-align:right">4,236</td>
+			<td style="text-align:right">67%</td>
+			<td style="text-align:right">1,436</td>
+			<td style="text-align:right">2,938</td>
+			<td style="text-align:right">47%</td>
+			<td style="text-align:right">2,734</td>
+			<td style="text-align:right">6,302</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Nelson Marlborough</th>
+			<td style="text-align:right">7,567</td>
+			<td style="text-align:right">67%</td>
+			<td style="text-align:right">2,556</td>
+			<td style="text-align:right">5,688</td>
+			<td style="text-align:right">51%</td>
+			<td style="text-align:right">4,435</td>
+			<td style="text-align:right">11,248</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">West Coast</th>
+			<td style="text-align:right">1,898</td>
+			<td style="text-align:right">69%</td>
+			<td style="text-align:right">590</td>
+			<td style="text-align:right">1,339</td>
+			<td style="text-align:right">48%</td>
+			<td style="text-align:right">1,150</td>
+			<td style="text-align:right">2,765</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Canterbury</th>
+			<td style="text-align:right">26,665</td>
+			<td style="text-align:right">72%</td>
+			<td style="text-align:right">6,607</td>
+			<td style="text-align:right">17,850</td>
+			<td style="text-align:right">48%</td>
+			<td style="text-align:right">15,422</td>
+			<td style="text-align:right">36,969</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">South Canterbury</th>
+			<td style="text-align:right">2,308</td>
+			<td style="text-align:right">67%</td>
+			<td style="text-align:right">777</td>
+			<td style="text-align:right">1,682</td>
+			<td style="text-align:right">49%</td>
+			<td style="text-align:right">1,403</td>
+			<td style="text-align:right">3,428</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Southern</th>
+			<td style="text-align:right">17,108</td>
+			<td style="text-align:right">72%</td>
+			<td style="text-align:right">4,173</td>
+			<td style="text-align:right">12,942</td>
+			<td style="text-align:right">55%</td>
+			<td style="text-align:right">8,339</td>
+			<td style="text-align:right">23,646</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Overseas / Unknown</th>
+			<td style="text-align:right">177</td>
+			<td style="text-align:right">7%</td>
+			<td style="text-align:right">2,211</td>
+			<td style="text-align:right">125</td>
+			<td style="text-align:right">5%</td>
+			<td style="text-align:right">2,263</td>
+			<td style="text-align:right">2,653</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total</strong></th>
+			<td style="text-align:right"><strong>392,440</strong></td>
+			<td style="text-align:right"><strong>69%</strong></td>
+			<td style="text-align:right"><strong>121,507</strong></td>
+			<td style="text-align:right"><strong>275,344</strong></td>
+			<td style="text-align:right"><strong>48%</strong></td>
+			<td style="text-align:right"><strong>238,603</strong></td>
+			<td style="text-align:right"><strong>571,052</strong></td>
+		</tr>
+	</tbody>
+</table>
+
+<h4><a id="90pct Pacific Peoples" name="90pct Pacific Peoples"></a>Pacific Peoples</h4>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">&nbsp;</th>
+			<th scope="col" style="text-align:right">First doses</th>
+			<th scope="col" style="text-align:right">First doses %</th>
+			<th scope="col" style="text-align:right">First doses to 90%</th>
+			<th scope="col" style="text-align:right">Second doses</th>
+			<th scope="col" style="text-align:right">Second doses %</th>
+			<th scope="col" style="text-align:right">Second doses to 90%</th>
+			<th scope="col" style="text-align:right">Population</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">Northland</th>
+			<td style="text-align:right">2,313</td>
+			<td style="text-align:right">79%</td>
+			<td style="text-align:right">328</td>
+			<td style="text-align:right">1,636</td>
+			<td style="text-align:right">56%</td>
+			<td style="text-align:right">1,005</td>
+			<td style="text-align:right">2,934</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waitemata</th>
+			<td style="text-align:right">31,413</td>
+			<td style="text-align:right">84%</td>
+			<td style="text-align:right">2,403</td>
+			<td style="text-align:right">24,108</td>
+			<td style="text-align:right">64%</td>
+			<td style="text-align:right">9,708</td>
+			<td style="text-align:right">37,573</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Auckland</th>
+			<td style="text-align:right">38,606</td>
+			<td style="text-align:right">82%</td>
+			<td style="text-align:right">3,573</td>
+			<td style="text-align:right">30,094</td>
+			<td style="text-align:right">64%</td>
+			<td style="text-align:right">12,085</td>
+			<td style="text-align:right">46,866</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Counties Manukau</th>
+			<td style="text-align:right">94,469</td>
+			<td style="text-align:right">81%</td>
+			<td style="text-align:right">10,379</td>
+			<td style="text-align:right">73,380</td>
+			<td style="text-align:right">63%</td>
+			<td style="text-align:right">31,468</td>
+			<td style="text-align:right">116,498</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waikato</th>
+			<td style="text-align:right">8,939</td>
+			<td style="text-align:right">84%</td>
+			<td style="text-align:right">675</td>
+			<td style="text-align:right">6,838</td>
+			<td style="text-align:right">64%</td>
+			<td style="text-align:right">2,776</td>
+			<td style="text-align:right">10,682</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Lakes</th>
+			<td style="text-align:right">1,777</td>
+			<td style="text-align:right">78%</td>
+			<td style="text-align:right">280</td>
+			<td style="text-align:right">1,347</td>
+			<td style="text-align:right">59%</td>
+			<td style="text-align:right">710</td>
+			<td style="text-align:right">2,286</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Bay of Plenty</th>
+			<td style="text-align:right">3,932</td>
+			<td style="text-align:right">&gt;95%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">2,873</td>
+			<td style="text-align:right">78%</td>
+			<td style="text-align:right">438</td>
+			<td style="text-align:right">3,679</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Tairawhiti</th>
+			<td style="text-align:right">844</td>
+			<td style="text-align:right">87%</td>
+			<td style="text-align:right">24</td>
+			<td style="text-align:right">637</td>
+			<td style="text-align:right">66%</td>
+			<td style="text-align:right">232</td>
+			<td style="text-align:right">965</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Taranaki</th>
+			<td style="text-align:right">1,015</td>
+			<td style="text-align:right">80%</td>
+			<td style="text-align:right">128</td>
+			<td style="text-align:right">732</td>
+			<td style="text-align:right">58%</td>
+			<td style="text-align:right">411</td>
+			<td style="text-align:right">1,270</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hawkes Bay</th>
+			<td style="text-align:right">4,953</td>
+			<td style="text-align:right">&gt;95%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">3,954</td>
+			<td style="text-align:right">79%</td>
+			<td style="text-align:right">564</td>
+			<td style="text-align:right">5,020</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">MidCentral</th>
+			<td style="text-align:right">3,669</td>
+			<td style="text-align:right">82%</td>
+			<td style="text-align:right">352</td>
+			<td style="text-align:right">2,755</td>
+			<td style="text-align:right">62%</td>
+			<td style="text-align:right">1,266</td>
+			<td style="text-align:right">4,468</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Whanganui</th>
+			<td style="text-align:right">1,015</td>
+			<td style="text-align:right">73%</td>
+			<td style="text-align:right">228</td>
+			<td style="text-align:right">788</td>
+			<td style="text-align:right">57%</td>
+			<td style="text-align:right">455</td>
+			<td style="text-align:right">1,381</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Capital and Coast</th>
+			<td style="text-align:right">15,332</td>
+			<td style="text-align:right">80%</td>
+			<td style="text-align:right">1,927</td>
+			<td style="text-align:right">12,003</td>
+			<td style="text-align:right">63%</td>
+			<td style="text-align:right">5,256</td>
+			<td style="text-align:right">19,177</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hutt Valley</th>
+			<td style="text-align:right">7,786</td>
+			<td style="text-align:right">79%</td>
+			<td style="text-align:right">1,119</td>
+			<td style="text-align:right">5,940</td>
+			<td style="text-align:right">60%</td>
+			<td style="text-align:right">2,965</td>
+			<td style="text-align:right">9,894</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Wairarapa</th>
+			<td style="text-align:right">672</td>
+			<td style="text-align:right">80%</td>
+			<td style="text-align:right">81</td>
+			<td style="text-align:right">528</td>
+			<td style="text-align:right">63%</td>
+			<td style="text-align:right">225</td>
+			<td style="text-align:right">837</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Nelson Marlborough</th>
+			<td style="text-align:right">3,562</td>
+			<td style="text-align:right">&gt;95%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">3,074</td>
+			<td style="text-align:right">&gt;95%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">2,115</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">West Coast</th>
+			<td style="text-align:right">224</td>
+			<td style="text-align:right">79%</td>
+			<td style="text-align:right">30</td>
+			<td style="text-align:right">167</td>
+			<td style="text-align:right">59%</td>
+			<td style="text-align:right">87</td>
+			<td style="text-align:right">282</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Canterbury</th>
+			<td style="text-align:right">10,166</td>
+			<td style="text-align:right">80%</td>
+			<td style="text-align:right">1,297</td>
+			<td style="text-align:right">7,406</td>
+			<td style="text-align:right">58%</td>
+			<td style="text-align:right">4,057</td>
+			<td style="text-align:right">12,737</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">South Canterbury</th>
+			<td style="text-align:right">755</td>
+			<td style="text-align:right">90%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">533</td>
+			<td style="text-align:right">64%</td>
+			<td style="text-align:right">220</td>
+			<td style="text-align:right">837</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Southern</th>
+			<td style="text-align:right">5,434</td>
+			<td style="text-align:right">90%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">4,232</td>
+			<td style="text-align:right">70%</td>
+			<td style="text-align:right">1,196</td>
+			<td style="text-align:right">6,031</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Overseas / Unknown</th>
+			<td style="text-align:right">336</td>
+			<td style="text-align:right">29%</td>
+			<td style="text-align:right">698</td>
+			<td style="text-align:right">286</td>
+			<td style="text-align:right">25%</td>
+			<td style="text-align:right">748</td>
+			<td style="text-align:right">1,149</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total</strong></th>
+			<td style="text-align:right"><strong>237,212</strong></td>
+			<td style="text-align:right"><strong>83%</strong></td>
+			<td style="text-align:right"><strong>20,801</strong></td>
+			<td style="text-align:right"><strong>183,311</strong></td>
+			<td style="text-align:right"><strong>64%</strong></td>
+			<td style="text-align:right"><strong>74,702</strong></td>
+			<td style="text-align:right"><strong>286,681</strong></td>
+		</tr>
+	</tbody>
+</table>
+<!--daily_end-->
+
+<hr/>
+<h2><a id="weekly-updates" name="weekly-updates"></a>COVID-19 vaccinations: weekly updates</h2>
+
+<div class="well well-sm">
+<p style="margin-top: 0"><strong>Data in this section is as at 11:59pm 19 October 2021 and is updated weekly on Wednesdays.</strong></p>
+</div>
+
+<h3><a id="model" model="" name="id="></a>Cumulative vaccinations</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccination doses administered compared to plan doses" class="img-responsive" height="830" src="/web/20211024013718im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/vaccineplanmodel_12.png" width="1780"/></figure>
+
+<p>Production plan figures are the volumes agreed with DHBs and national providers for expected vaccinations. These figures have been matched with expected supply. Detailed plans are available in the Excel file at the bottom of this page.</p>
+
+<p>The Stock received figures are the cumulative supply of doses to date.</p>
+
+<p>DHB capacity plans for the remainder of the year are undergoing review.</p>
+
+<hr/><!--
+<h3><a id="model" model="" name="id="></a>Cumulative vaccinations for last 6 weeks</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccination doses administered compared to plan doses - 6wks" class="img-responsive" height="830" src="/vaccineplanmodel_wks.png" width="1780" /></figure>
+
+<hr />
+-->
+<h3><a id="uptake" name="uptake"></a>Vaccine uptake</h3>
+
+<p>Maps and data related to uptake rates of the COVID-19 vaccine across the country are available on the pages linked below. These show&nbsp;vaccination records aggregated by area of residence for all New Zealand residents, Māori communities, and Pacific communities.</p>
+
+<ul>
+	<li><a href="/web/20211024013718/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-across-nz">COVID-19 Vaccination uptake rates across NZ</a></li>
+	<li><a href="/web/20211024013718/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-maori-communities-across-nz">COVID-19 Vaccination uptake rates within Māori communities across NZ</a></li>
+	<li><a href="/web/20211024013718/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-pacific-communities-across-nz">COVID-19 Vaccination uptake rates within Pacific communities across NZ</a></li>
+</ul>
+
+<h4><a id="uptake" name="uptake"></a>Vaccine uptake per rate ratio (unadjusted) Māori and Pacific compared with Non-Māori non-Pacific</h4>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine Uptake per 1,000 (HSU) Rate Ratio, Showing Prioritised Ethnicity, vs Non-Māori Non-Pacific, By Age Band" class="img-responsive" height="830" src="/web/20211024013718im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_mix_7.png" width="1780"/></figure>
+
+<p>In the Chart above, rate ratios tell us the rate Māori or Pacific People per population are being vaccinated compared with non-Māori non-Pacific. This comparison can be split by age group.</p>
+
+<ul>
+	<li>A rate of one means the groups being compared are being vaccinated at the same rate.</li>
+	<li>A rate over one means Māori (or Pacific) are being vaccinated at a higher rate than non-Māori non-Pacific.</li>
+	<li>A rate under one means Māori (or Pacific) are being vaccinated at a lower rate than non-Māori non-Pacific.</li>
+</ul>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<td colspan="2" style="border-top: 0 !important; border-bottom-color: #FDD6AF !important; border-right: 0 !important;">&nbsp;</td>
+			<th colspan="6" id="ac1">Māori</th>
+			<th colspan="6" id="ac8">Pacific Peoples</th>
+		</tr>
+		<tr>
+			<th id="ar1">DHB</th>
+			<th>Dose number</th>
+			<th headers="ac1" id="ac2">65+</th>
+			<th headers="ac1" id="ac3">50-64</th>
+			<th headers="ac1" id="ac4">35-49</th>
+			<th headers="ac1" id="ac5">20-34</th>
+			<th headers="ac1" id="ac6">12-19</th>
+			<th headers="ac1" id="ac7">All ages</th>
+			<th headers="ac8" id="ac9">65+</th>
+			<th headers="ac8" id="ac10">50-64</th>
+			<th headers="ac8" id="ac11">35-49</th>
+			<th headers="ac8" id="ac12">20-34</th>
+			<th headers="ac8" id="ac13">12-19</th>
+			<th headers="ac8" id="ac14">All ages</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th headers="ar1" id="ar2" rowspan="2">National</th>
+			<th headers="ar1 ar2" id="ar3">Dose 1</th>
+			<td headers="ar1 ar2 ar3 ac1 ac2" style="background-color:green; color: #FFF;"><strong>0.99</strong></td>
+			<td headers="ar1 ar2 ar3 ac1 ac3" style="background-color:mediumseagreen"><strong>0.92</strong></td>
+			<td headers="ar1 ar2 ar3 ac1 ac4" style="background-color:yellow"><strong>0.77</strong></td>
+			<td headers="ar1 ar2 ar3 ac1 ac5" style="background-color:tomato"><strong>0.64</strong></td>
+			<td headers="ar1 ar2 ar3 ac1 ac6" style="background-color:coral"><strong>0.69</strong></td>
+			<td headers="ar1 ar2 ar3 ac1 ac7" style="background-color:yellow"><strong>0.75</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac9" style="background-color:mediumseagreen"><strong>0.94</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac10" style="background-color:green; color: #FFF;"><strong>0.99</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac11" style="background-color:green; color: #FFF;"><strong>0.97</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac12" style="background-color:lightgreen"><strong>0.87</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac13" style="background-color:lightgreen"><strong>0.89</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac14" style="background-color:mediumseagreen"><strong>0.91</strong></td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar2" id="ar4">Dose 2</th>
+			<td headers="ar1 ar2 ar4 ac1 ac2" style="background-color:green; color: #FFF;"><strong>0.96</strong></td>
+			<td headers="ar1 ar2 ar4 ac1 ac3" style="background-color:lightgreen"><strong>0.87</strong></td>
+			<td headers="ar1 ar2 ar4 ac1 ac4" style="background-color:coral"><strong>0.68</strong></td>
+			<td headers="ar1 ar2 ar4 ac1 ac5" style="background-color:crimson; color: #FFF;"><strong>0.51</strong></td>
+			<td headers="ar1 ar2 ar4 ac1 ac6" style="background-color:crimson; color: #FFF;"><strong>0.57</strong></td>
+			<td headers="ar1 ar2 ar4 ac1 ac7" style="background-color:tomato"><strong>0.64</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac9" style="background-color:mediumseagreen"><strong>0.91</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac10" style="background-color:green; color: #FFF;"><strong>0.99</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac11" style="background-color:green; color: #FFF;"><strong>0.98</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac12" style="background-color:palegreen"><strong>0.82</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac13" style="background-color:lightgreen"><strong>0.85</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac14" style="background-color:palegreen"><strong>0.84</strong></td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar5" rowspan="2">Northland</th>
+			<th headers="ar1 ar5" id="ar6">Dose 1</th>
+			<td headers="ar1 ar5 ar6 ac1 ac2" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar5 ar6 ac1 ac3" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar5 ar6 ac1 ac4" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar5 ar6 ac1 ac5" style="background-color:tomato">0.64</td>
+			<td headers="ar1 ar5 ar6 ac1 ac6" style="background-color:orange">0.72</td>
+			<td headers="ar1 ar5 ar6 ac1 ac7" style="background-color:yellow">0.76</td>
+			<td headers="ar1 ar5 ar6 ac8 ac9" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar5 ar6 ac8 ac10" style="background-color:green; color: #FFF;">1.05</td>
+			<td headers="ar1 ar5 ar6 ac8 ac11" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar5 ar6 ac8 ac12" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar5 ar6 ac8 ac13" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar5 ar6 ac8 ac14" style="background-color:mediumseagreen">0.93</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar5" id="ar7">Dose 2</th>
+			<td headers="ar1 ar5 ar7 ac1 ac2" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar5 ar7 ac1 ac3" style="background-color:lightgreen">0.86</td>
+			<td headers="ar1 ar5 ar7 ac1 ac4" style="background-color:coral">0.68</td>
+			<td headers="ar1 ar5 ar7 ac1 ac5" style="background-color:crimson; color: #FFF;">0.48</td>
+			<td headers="ar1 ar5 ar7 ac1 ac6" style="background-color:crimson; color: #FFF;">0.58</td>
+			<td headers="ar1 ar5 ar7 ac1 ac7" style="background-color:tomato">0.62</td>
+			<td headers="ar1 ar5 ar7 ac8 ac9" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar5 ar7 ac8 ac10" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar5 ar7 ac8 ac11" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar5 ar7 ac8 ac12" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar5 ar7 ac8 ac13" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar5 ar7 ac8 ac14" style="background-color:yellow">0.78</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar8" rowspan="2">Auckland Metro</th>
+			<th headers="ar1 ar8" id="ar9">Dose 1</th>
+			<td headers="ar1 ar8 ar9 ac1 ac2" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar8 ar9 ac1 ac3" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar8 ar9 ac1 ac4" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar8 ar9 ac1 ac5" style="background-color:coral">0.68</td>
+			<td headers="ar1 ar8 ar9 ac1 ac6" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar8 ar9 ac1 ac7" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar8 ar9 ac8 ac9" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar8 ar9 ac8 ac10" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar8 ar9 ac8 ac11" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar8 ar9 ac8 ac12" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar8 ar9 ac8 ac13" style="background-color:palegreen">0.81</td>
+			<td headers="ar1 ar8 ar9 ac8 ac14" style="background-color:lightgreen">0.86</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar8" id="ar10">Dose 2</th>
+			<td headers="ar1 ar8 ar10 ac1 ac2" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar8 ar10 ac1 ac3" style="background-color:lightgreen">0.88</td>
+			<td headers="ar1 ar8 ar10 ac1 ac4" style="background-color:coral">0.68</td>
+			<td headers="ar1 ar8 ar10 ac1 ac5" style="background-color:crimson; color: #FFF;">0.52</td>
+			<td headers="ar1 ar8 ar10 ac1 ac6" style="background-color:crimson; color: #FFF;">0.57</td>
+			<td headers="ar1 ar8 ar10 ac1 ac7" style="background-color:coral">0.65</td>
+			<td headers="ar1 ar8 ar10 ac8 ac9" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar8 ar10 ac8 ac10" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar8 ar10 ac8 ac11" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar8 ar10 ac8 ac12" style="background-color:coral">0.65</td>
+			<td headers="ar1 ar8 ar10 ac8 ac13" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar8 ar10 ac8 ac14" style="background-color:yellow">0.77</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar11" rowspan="2">Waikato</th>
+			<th headers="ar1 ar11" id="ar12">Dose 1</th>
+			<td headers="ar1 ar11 ar12 ac1 ac2" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar11 ar12 ac1 ac3" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar11 ar12 ac1 ac4" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar11 ar12 ac1 ac5" style="background-color:coral">0.66</td>
+			<td headers="ar1 ar11 ar12 ac1 ac6" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar11 ar12 ac1 ac7" style="background-color:yellow">0.76</td>
+			<td headers="ar1 ar11 ar12 ac8 ac9" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar11 ar12 ac8 ac10" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar11 ar12 ac8 ac11" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar11 ar12 ac8 ac12" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar11 ar12 ac8 ac13" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar11 ar12 ac8 ac14" style="background-color:mediumseagreen">0.93</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar11" id="ar13">Dose 2</th>
+			<td headers="ar1 ar11 ar13 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar11 ar13 ac1 ac3" style="background-color:lightgreen">0.87</td>
+			<td headers="ar1 ar11 ar13 ac1 ac4" style="background-color:coral">0.68</td>
+			<td headers="ar1 ar11 ar13 ac1 ac5" style="background-color:crimson; color: #FFF;">0.50</td>
+			<td headers="ar1 ar11 ar13 ac1 ac6" style="background-color:crimson; color: #FFF;">0.56</td>
+			<td headers="ar1 ar11 ar13 ac1 ac7" style="background-color:tomato">0.63</td>
+			<td headers="ar1 ar11 ar13 ac8 ac9" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar11 ar13 ac8 ac10" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar11 ar13 ac8 ac11" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar11 ar13 ac8 ac12" style="background-color:lightgreen">0.86</td>
+			<td headers="ar1 ar11 ar13 ac8 ac13" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar11 ar13 ac8 ac14" style="background-color:lightgreen">0.87</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar14" rowspan="2">Bay of Plenty</th>
+			<th headers="ar1 ar14" id="ar15">Dose 1</th>
+			<td headers="ar1 ar14 ar15 ac1 ac2" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar14 ar15 ac1 ac3" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar14 ar15 ac1 ac4" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar14 ar15 ac1 ac5" style="background-color:crimson; color: #FFF;">0.55</td>
+			<td headers="ar1 ar14 ar15 ac1 ac6" style="background-color:tomato">0.62</td>
+			<td headers="ar1 ar14 ar15 ac1 ac7" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar14 ar15 ac8 ac9" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar14 ar15 ac8 ac10" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar14 ar15 ac8 ac11" style="background-color:green; color: #FFF;">1.44</td>
+			<td headers="ar1 ar14 ar15 ac8 ac12" style="background-color:green; color: #FFF;">1.50</td>
+			<td headers="ar1 ar14 ar15 ac8 ac13" style="background-color:lightgreen">0.87</td>
+			<td headers="ar1 ar14 ar15 ac8 ac14" style="background-color:green; color: #FFF;">1.20</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar14" id="ar16">Dose 2</th>
+			<td headers="ar1 ar14 ar16 ac1 ac2" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar14 ar16 ac1 ac3" style="background-color:palegreen">0.84</td>
+			<td headers="ar1 ar14 ar16 ac1 ac4" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar14 ar16 ac1 ac5" style="background-color:crimson; color: #FFF;">0.46</td>
+			<td headers="ar1 ar14 ar16 ac1 ac6" style="background-color:crimson; color: #FFF;">0.54</td>
+			<td headers="ar1 ar14 ar16 ac1 ac7" style="background-color:crimson; color: #FFF;">0.59</td>
+			<td headers="ar1 ar14 ar16 ac8 ac9" style="background-color:lightgreen">0.88</td>
+			<td headers="ar1 ar14 ar16 ac8 ac10" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar14 ar16 ac8 ac11" style="background-color:green; color: #FFF;">1.64</td>
+			<td headers="ar1 ar14 ar16 ac8 ac12" style="background-color:green; color: #FFF;">1.91</td>
+			<td headers="ar1 ar14 ar16 ac8 ac13" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar14 ar16 ac8 ac14" style="background-color:green; color: #FFF;">1.13</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar17" rowspan="2">Tairawhiti</th>
+			<th headers="ar1 ar17" id="ar18">Dose 1</th>
+			<td headers="ar1 ar17 ar18 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar17 ar18 ac1 ac3" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar17 ar18 ac1 ac4" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar17 ar18 ac1 ac5" style="background-color:tomato">0.60</td>
+			<td headers="ar1 ar17 ar18 ac1 ac6" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar17 ar18 ac1 ac7" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar17 ar18 ac8 ac9" style="background-color:green; color: #FFF;">1.05</td>
+			<td headers="ar1 ar17 ar18 ac8 ac10" style="background-color:green; color: #FFF;">1.07</td>
+			<td headers="ar1 ar17 ar18 ac8 ac11" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar17 ar18 ac8 ac12" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar17 ar18 ac8 ac13" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar17 ar18 ac8 ac14" style="background-color:green; color: #FFF;">0.99</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar17" id="ar19">Dose 2</th>
+			<td headers="ar1 ar17 ar19 ac1 ac2" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar17 ar19 ac1 ac3" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar17 ar19 ac1 ac4" style="background-color:coral">0.69</td>
+			<td headers="ar1 ar17 ar19 ac1 ac5" style="background-color:crimson; color: #FFF;">0.49</td>
+			<td headers="ar1 ar17 ar19 ac1 ac6" style="background-color:crimson; color: #FFF;">0.55</td>
+			<td headers="ar1 ar17 ar19 ac1 ac7" style="background-color:tomato">0.64</td>
+			<td headers="ar1 ar17 ar19 ac8 ac9" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar17 ar19 ac8 ac10" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar17 ar19 ac8 ac11" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar17 ar19 ac8 ac12" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar17 ar19 ac8 ac13" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar17 ar19 ac8 ac14" style="background-color:lightgreen">0.88</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar20" rowspan="2">Lakes</th>
+			<th headers="ar1 ar20" id="ar21">Dose 1</th>
+			<td headers="ar1 ar20 ar21 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar20 ar21 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar20 ar21 ac1 ac4" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar20 ar21 ac1 ac5" style="background-color:crimson; color: #FFF;">0.56</td>
+			<td headers="ar1 ar20 ar21 ac1 ac6" style="background-color:tomato">0.64</td>
+			<td headers="ar1 ar20 ar21 ac1 ac7" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar20 ar21 ac8 ac9" style="background-color:green; color: #FFF;">1.06</td>
+			<td headers="ar1 ar20 ar21 ac8 ac10" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar20 ar21 ac8 ac11" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar20 ar21 ac8 ac12" style="background-color:palegreen">0.81</td>
+			<td headers="ar1 ar20 ar21 ac8 ac13" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar20 ar21 ac8 ac14" style="background-color:lightgreen">0.89</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar20" id="ar22">Dose 2</th>
+			<td headers="ar1 ar20 ar22 ac1 ac2" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar20 ar22 ac1 ac3" style="background-color:palegreen">0.84</td>
+			<td headers="ar1 ar20 ar22 ac1 ac4" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar20 ar22 ac1 ac5" style="background-color:crimson; color: #FFF;">0.45</td>
+			<td headers="ar1 ar20 ar22 ac1 ac6" style="background-color:crimson; color: #FFF;">0.54</td>
+			<td headers="ar1 ar20 ar22 ac1 ac7" style="background-color:tomato">0.60</td>
+			<td headers="ar1 ar20 ar22 ac8 ac9" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar20 ar22 ac8 ac10" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar20 ar22 ac8 ac11" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar20 ar22 ac8 ac12" style="background-color:lightgreen">0.87</td>
+			<td headers="ar1 ar20 ar22 ac8 ac13" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar20 ar22 ac8 ac14" style="background-color:palegreen">0.84</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar23" rowspan="2">Taranaki</th>
+			<th headers="ar1 ar23" id="ar24">Dose 1</th>
+			<td headers="ar1 ar23 ar24 ac1 ac2" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar23 ar24 ac1 ac3" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar23 ar24 ac1 ac4" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar23 ar24 ac1 ac5" style="background-color:coral">0.65</td>
+			<td headers="ar1 ar23 ar24 ac1 ac6" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar23 ar24 ac1 ac7" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar23 ar24 ac8 ac9" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar23 ar24 ac8 ac10" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar23 ar24 ac8 ac11" style="background-color:green; color: #FFF;">1.05</td>
+			<td headers="ar1 ar23 ar24 ac8 ac12" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar23 ar24 ac8 ac13" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar23 ar24 ac8 ac14" style="background-color:mediumseagreen">0.93</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar23" id="ar25">Dose 2</th>
+			<td headers="ar1 ar23 ar25 ac1 ac2" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar23 ar25 ac1 ac3" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar23 ar25 ac1 ac4" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar23 ar25 ac1 ac5" style="background-color:crimson; color: #FFF;">0.52</td>
+			<td headers="ar1 ar23 ar25 ac1 ac6" style="background-color:crimson; color: #FFF;">0.54</td>
+			<td headers="ar1 ar23 ar25 ac1 ac7" style="background-color:tomato">0.62</td>
+			<td headers="ar1 ar23 ar25 ac8 ac9" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar23 ar25 ac8 ac10" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar23 ar25 ac8 ac11" style="background-color:green; color: #FFF;">1.23</td>
+			<td headers="ar1 ar23 ar25 ac8 ac12" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar23 ar25 ac8 ac13" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar23 ar25 ac8 ac14" style="background-color:lightgreen">0.88</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar26" rowspan="2">Whanganui</th>
+			<th headers="ar1 ar26" id="ar27">Dose 1</th>
+			<td headers="ar1 ar26 ar27 ac1 ac2" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar26 ar27 ac1 ac3" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar26 ar27 ac1 ac4" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar26 ar27 ac1 ac5" style="background-color:tomato">0.63</td>
+			<td headers="ar1 ar26 ar27 ac1 ac6" style="background-color:coral">0.68</td>
+			<td headers="ar1 ar26 ar27 ac1 ac7" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar26 ar27 ac8 ac9" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar26 ar27 ac8 ac10" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar26 ar27 ac8 ac11" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar26 ar27 ac8 ac12" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar26 ar27 ac8 ac13" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar26 ar27 ac8 ac14" style="background-color:lightgreen">0.86</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar26" id="ar28">Dose 2</th>
+			<td headers="ar1 ar26 ar28 ac1 ac2" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar26 ar28 ac1 ac3" style="background-color:lightgreen">0.88</td>
+			<td headers="ar1 ar26 ar28 ac1 ac4" style="background-color:coral">0.69</td>
+			<td headers="ar1 ar26 ar28 ac1 ac5" style="background-color:crimson; color: #FFF;">0.49</td>
+			<td headers="ar1 ar26 ar28 ac1 ac6" style="background-color:crimson; color: #FFF;">0.59</td>
+			<td headers="ar1 ar26 ar28 ac1 ac7" style="background-color:tomato">0.63</td>
+			<td headers="ar1 ar26 ar28 ac8 ac9" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar26 ar28 ac8 ac10" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar26 ar28 ac8 ac11" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar26 ar28 ac8 ac12" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar26 ar28 ac8 ac13" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar26 ar28 ac8 ac14" style="background-color:yellow">0.77</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar29" rowspan="2">Hawke&#39;s Bay</th>
+			<th headers="ar1 ar29" id="ar30">Dose 1</th>
+			<td headers="ar1 ar29 ar30 ac1 ac2" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar29 ar30 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar29 ar30 ac1 ac4" style="background-color:yellow">0.77</td>
+			<td headers="ar1 ar29 ar30 ac1 ac5" style="background-color:crimson; color: #FFF;">0.58</td>
+			<td headers="ar1 ar29 ar30 ac1 ac6" style="background-color:coral">0.69</td>
+			<td headers="ar1 ar29 ar30 ac1 ac7" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar29 ar30 ac8 ac9" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar29 ar30 ac8 ac10" style="background-color:green; color: #FFF;">1.05</td>
+			<td headers="ar1 ar29 ar30 ac8 ac11" style="background-color:green; color: #FFF;">1.41</td>
+			<td headers="ar1 ar29 ar30 ac8 ac12" style="background-color:green; color: #FFF;">1.33</td>
+			<td headers="ar1 ar29 ar30 ac8 ac13" style="background-color:lightgreen">0.88</td>
+			<td headers="ar1 ar29 ar30 ac8 ac14" style="background-color:green; color: #FFF;">1.15</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar29" id="ar31">Dose 2</th>
+			<td headers="ar1 ar29 ar31 ac1 ac2" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar29 ar31 ac1 ac3" style="background-color:palegreen">0.84</td>
+			<td headers="ar1 ar29 ar31 ac1 ac4" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar29 ar31 ac1 ac5" style="background-color:crimson; color: #FFF;">0.48</td>
+			<td headers="ar1 ar29 ar31 ac1 ac6" style="background-color:crimson; color: #FFF;">0.57</td>
+			<td headers="ar1 ar29 ar31 ac1 ac7" style="background-color:tomato">0.61</td>
+			<td headers="ar1 ar29 ar31 ac8 ac9" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar29 ar31 ac8 ac10" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar29 ar31 ac8 ac11" style="background-color:green; color: #FFF;">1.52</td>
+			<td headers="ar1 ar29 ar31 ac8 ac12" style="background-color:green; color: #FFF;">1.56</td>
+			<td headers="ar1 ar29 ar31 ac8 ac13" style="background-color:lightgreen">0.86</td>
+			<td headers="ar1 ar29 ar31 ac8 ac14" style="background-color:green; color: #FFF;">1.10</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar32" rowspan="2">MidCentral</th>
+			<th headers="ar1 ar32" id="ar33">Dose 1</th>
+			<td headers="ar1 ar32 ar33 ac1 ac2" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar32 ar33 ac1 ac3" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar32 ar33 ac1 ac4" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar32 ar33 ac1 ac5" style="background-color:coral">0.69</td>
+			<td headers="ar1 ar32 ar33 ac1 ac6" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar32 ar33 ac1 ac7" style="background-color:yellow">0.76</td>
+			<td headers="ar1 ar32 ar33 ac8 ac9" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar32 ar33 ac8 ac10" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar32 ar33 ac8 ac11" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar32 ar33 ac8 ac12" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar32 ar33 ac8 ac13" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar32 ar33 ac8 ac14" style="background-color:mediumseagreen">0.93</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar32" id="ar34">Dose 2</th>
+			<td headers="ar1 ar32 ar34 ac1 ac2" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar32 ar34 ac1 ac3" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar32 ar34 ac1 ac4" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar32 ar34 ac1 ac5" style="background-color:crimson; color: #FFF;">0.58</td>
+			<td headers="ar1 ar32 ar34 ac1 ac6" style="background-color:tomato">0.60</td>
+			<td headers="ar1 ar32 ar34 ac1 ac7" style="background-color:coral">0.66</td>
+			<td headers="ar1 ar32 ar34 ac8 ac9" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar32 ar34 ac8 ac10" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar32 ar34 ac8 ac11" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar32 ar34 ac8 ac12" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar32 ar34 ac8 ac13" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar32 ar34 ac8 ac14" style="background-color:palegreen">0.84</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar35" rowspan="2">Wairarapa</th>
+			<th headers="ar1 ar35" id="ar36">Dose 1</th>
+			<td headers="ar1 ar35 ar36 ac1 ac2" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar35 ar36 ac1 ac3" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar35 ar36 ac1 ac4" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar35 ar36 ac1 ac5" style="background-color:coral">0.68</td>
+			<td headers="ar1 ar35 ar36 ac1 ac6" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar35 ar36 ac1 ac7" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar35 ar36 ac8 ac9" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar35 ar36 ac8 ac10" style="background-color:green; color: #FFF;">1.07</td>
+			<td headers="ar1 ar35 ar36 ac8 ac11" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar35 ar36 ac8 ac12" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar35 ar36 ac8 ac13" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar35 ar36 ac8 ac14" style="background-color:mediumseagreen">0.92</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar35" id="ar37">Dose 2</th>
+			<td headers="ar1 ar35 ar37 ac1 ac2" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar35 ar37 ac1 ac3" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar35 ar37 ac1 ac4" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar35 ar37 ac1 ac5" style="background-color:crimson; color: #FFF;">0.54</td>
+			<td headers="ar1 ar35 ar37 ac1 ac6" style="background-color:crimson; color: #FFF;">0.59</td>
+			<td headers="ar1 ar35 ar37 ac1 ac7" style="background-color:tomato">0.62</td>
+			<td headers="ar1 ar35 ar37 ac8 ac9" style="background-color:green; color: #FFF;">1.06</td>
+			<td headers="ar1 ar35 ar37 ac8 ac10" style="background-color:green; color: #FFF;">1.06</td>
+			<td headers="ar1 ar35 ar37 ac8 ac11" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar35 ar37 ac8 ac12" style="background-color:green; color: #FFF;">1.06</td>
+			<td headers="ar1 ar35 ar37 ac8 ac13" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar35 ar37 ac8 ac14" style="background-color:lightgreen">0.85</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar38" rowspan="2">Capital &amp; Coast and Hutt Valley</th>
+			<th headers="ar1 ar38" id="ar39">Dose 1</th>
+			<td headers="ar1 ar38 ar39 ac1 ac2" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar38 ar39 ac1 ac3" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar38 ar39 ac1 ac4" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar38 ar39 ac1 ac5" style="background-color:orange">0.72</td>
+			<td headers="ar1 ar38 ar39 ac1 ac6" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar38 ar39 ac1 ac7" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar38 ar39 ac8 ac9" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar38 ar39 ac8 ac10" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar38 ar39 ac8 ac11" style="background-color:lightgreen">0.88</td>
+			<td headers="ar1 ar38 ar39 ac8 ac12" style="background-color:yellow">0.76</td>
+			<td headers="ar1 ar38 ar39 ac8 ac13" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar38 ar39 ac8 ac14" style="background-color:lightgreen">0.85</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar38" id="ar40">Dose 2</th>
+			<td headers="ar1 ar38 ar40 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar38 ar40 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar38 ar40 ac1 ac4" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar38 ar40 ac1 ac5" style="background-color:tomato">0.63</td>
+			<td headers="ar1 ar38 ar40 ac1 ac6" style="background-color:tomato">0.62</td>
+			<td headers="ar1 ar38 ar40 ac1 ac7" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar38 ar40 ac8 ac9" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar38 ar40 ac8 ac10" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar38 ar40 ac8 ac11" style="background-color:lightgreen">0.87</td>
+			<td headers="ar1 ar38 ar40 ac8 ac12" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar38 ar40 ac8 ac13" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar38 ar40 ac8 ac14" style="background-color:palegreen">0.80</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar41" rowspan="2">Nelson Marlborough</th>
+			<th headers="ar1 ar41" id="ar42">Dose 1</th>
+			<td headers="ar1 ar41 ar42 ac1 ac2" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar41 ar42 ac1 ac3" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar41 ar42 ac1 ac4" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar41 ar42 ac1 ac5" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar41 ar42 ac1 ac6" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar41 ar42 ac1 ac7" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar41 ar42 ac8 ac9" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar41 ar42 ac8 ac10" style="background-color:green; color: #FFF;">1.27</td>
+			<td headers="ar1 ar41 ar42 ac8 ac11" style="background-color:green; color: #FFF;">2.48</td>
+			<td headers="ar1 ar41 ar42 ac8 ac12" style="background-color:green; color: #FFF;">2.97</td>
+			<td headers="ar1 ar41 ar42 ac8 ac13" style="background-color:green; color: #FFF;">1.07</td>
+			<td headers="ar1 ar41 ar42 ac8 ac14" style="background-color:green; color: #FFF;">1.97</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar41" id="ar43">Dose 2</th>
+			<td headers="ar1 ar41 ar43 ac1 ac2" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar41 ar43 ac1 ac3" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar41 ar43 ac1 ac4" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar41 ar43 ac1 ac5" style="background-color:crimson; color: #FFF;">0.54</td>
+			<td headers="ar1 ar41 ar43 ac1 ac6" style="background-color:coral">0.66</td>
+			<td headers="ar1 ar41 ar43 ac1 ac7" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar41 ar43 ac8 ac9" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar41 ar43 ac8 ac10" style="background-color:green; color: #FFF;">1.25</td>
+			<td headers="ar1 ar41 ar43 ac8 ac11" style="background-color:green; color: #FFF;">2.65</td>
+			<td headers="ar1 ar41 ar43 ac8 ac12" style="background-color:green; color: #FFF;">3.65</td>
+			<td headers="ar1 ar41 ar43 ac8 ac13" style="background-color:green; color: #FFF;">1.05</td>
+			<td headers="ar1 ar41 ar43 ac8 ac14" style="background-color:green; color: #FFF;">1.96</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar44" rowspan="2">West Coast</th>
+			<th headers="ar1 ar44" id="ar45">Dose 1</th>
+			<td headers="ar1 ar44 ar45 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar44 ar45 ac1 ac3" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar44 ar45 ac1 ac4" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar44 ar45 ac1 ac5" style="background-color:yellow">0.77</td>
+			<td headers="ar1 ar44 ar45 ac1 ac6" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar44 ar45 ac1 ac7" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar44 ar45 ac8 ac9" style="background-color:green; color: #FFF;">1.34</td>
+			<td headers="ar1 ar44 ar45 ac8 ac10" style="background-color:green; color: #FFF;">1.05</td>
+			<td headers="ar1 ar44 ar45 ac8 ac11" style="background-color:green; color: #FFF;">1.07</td>
+			<td headers="ar1 ar44 ar45 ac8 ac12" style="background-color:green; color: #FFF;">1.27</td>
+			<td headers="ar1 ar44 ar45 ac8 ac13" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar44 ar45 ac8 ac14" style="background-color:green; color: #FFF;">0.99</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar44" id="ar46">Dose 2</th>
+			<td headers="ar1 ar44 ar46 ac1 ac2" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar44 ar46 ac1 ac3" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar44 ar46 ac1 ac4" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar44 ar46 ac1 ac5" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar44 ar46 ac1 ac6" style="background-color:lightgreen">0.88</td>
+			<td headers="ar1 ar44 ar46 ac1 ac7" style="background-color:yellow">0.76</td>
+			<td headers="ar1 ar44 ar46 ac8 ac9" style="background-color:green; color: #FFF;">1.35</td>
+			<td headers="ar1 ar44 ar46 ac8 ac10" style="background-color:green; color: #FFF;">1.07</td>
+			<td headers="ar1 ar44 ar46 ac8 ac11" style="background-color:green; color: #FFF;">1.07</td>
+			<td headers="ar1 ar44 ar46 ac8 ac12" style="background-color:green; color: #FFF;">1.58</td>
+			<td headers="ar1 ar44 ar46 ac8 ac13" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar44 ar46 ac8 ac14" style="background-color:mediumseagreen">0.92</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar47" rowspan="2">Canterbury</th>
+			<th headers="ar1 ar47" id="ar48">Dose 1</th>
+			<td headers="ar1 ar47 ar48 ac1 ac2" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar47 ar48 ac1 ac3" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar47 ar48 ac1 ac4" style="background-color:palegreen">0.81</td>
+			<td headers="ar1 ar47 ar48 ac1 ac5" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar47 ar48 ac1 ac6" style="background-color:yellow">0.76</td>
+			<td headers="ar1 ar47 ar48 ac1 ac7" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar47 ar48 ac8 ac9" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar47 ar48 ac8 ac10" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar47 ar48 ac8 ac11" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar47 ar48 ac8 ac12" style="background-color:palegreen">0.84</td>
+			<td headers="ar1 ar47 ar48 ac8 ac13" style="background-color:lightgreen">0.88</td>
+			<td headers="ar1 ar47 ar48 ac8 ac14" style="background-color:lightgreen">0.88</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar47" id="ar49">Dose 2</th>
+			<td headers="ar1 ar47 ar49 ac1 ac2" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar47 ar49 ac1 ac3" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar47 ar49 ac1 ac4" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar47 ar49 ac1 ac5" style="background-color:coral">0.68</td>
+			<td headers="ar1 ar47 ar49 ac1 ac6" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar47 ar49 ac1 ac7" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar47 ar49 ac8 ac9" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar47 ar49 ac8 ac10" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar47 ar49 ac8 ac11" style="background-color:green; color: #FFF;">1.10</td>
+			<td headers="ar1 ar47 ar49 ac8 ac12" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar47 ar49 ac8 ac13" style="background-color:green; color: #FFF;">1.10</td>
+			<td headers="ar1 ar47 ar49 ac8 ac14" style="background-color:lightgreen">0.87</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar50" rowspan="2">South Canterbury</th>
+			<th headers="ar1 ar50" id="ar51">Dose 1</th>
+			<td headers="ar1 ar50 ar51 ac1 ac2" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar50 ar51 ac1 ac3" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar50 ar51 ac1 ac4" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar50 ar51 ac1 ac5" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar50 ar51 ac1 ac6" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar50 ar51 ac1 ac7" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar50 ar51 ac8 ac9" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar50 ar51 ac8 ac10" style="background-color:green; color: #FFF;">1.10</td>
+			<td headers="ar1 ar50 ar51 ac8 ac11" style="background-color:green; color: #FFF;">1.19</td>
+			<td headers="ar1 ar50 ar51 ac8 ac12" style="background-color:green; color: #FFF;">1.21</td>
+			<td headers="ar1 ar50 ar51 ac8 ac13" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar50 ar51 ac8 ac14" style="background-color:green; color: #FFF;">1.05</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar50" id="ar52">Dose 2</th>
+			<td headers="ar1 ar50 ar52 ac1 ac2" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar50 ar52 ac1 ac3" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar50 ar52 ac1 ac4" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar50 ar52 ac1 ac5" style="background-color:tomato">0.64</td>
+			<td headers="ar1 ar50 ar52 ac1 ac6" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar50 ar52 ac1 ac7" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar50 ar52 ac8 ac9" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar50 ar52 ac8 ac10" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar50 ar52 ac8 ac11" style="background-color:green; color: #FFF;">1.15</td>
+			<td headers="ar1 ar50 ar52 ac8 ac12" style="background-color:green; color: #FFF;">1.17</td>
+			<td headers="ar1 ar50 ar52 ac8 ac13" style="background-color:green; color: #FFF;">1.07</td>
+			<td headers="ar1 ar50 ar52 ac8 ac14" style="background-color:lightgreen">0.87</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar53" rowspan="2">Southern</th>
+			<th headers="ar1 ar53" id="ar54">Dose 1</th>
+			<td headers="ar1 ar53 ar54 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar53 ar54 ac1 ac3" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar53 ar54 ac1 ac4" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar53 ar54 ac1 ac5" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar53 ar54 ac1 ac6" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar53 ar54 ac1 ac7" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar53 ar54 ac8 ac9" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar53 ar54 ac8 ac10" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar53 ar54 ac8 ac11" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar53 ar54 ac8 ac12" style="background-color:green; color: #FFF;">1.09</td>
+			<td headers="ar1 ar53 ar54 ac8 ac13" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar53 ar54 ac8 ac14" style="background-color:green; color: #FFF;">1.01</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar53" id="ar55">Dose 2</th>
+			<td headers="ar1 ar53 ar55 ac1 ac2" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar53 ar55 ac1 ac3" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar53 ar55 ac1 ac4" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar53 ar55 ac1 ac5" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar53 ar55 ac1 ac6" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar53 ar55 ac1 ac7" style="background-color:orange">0.72</td>
+			<td headers="ar1 ar53 ar55 ac8 ac9" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar53 ar55 ac8 ac10" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar53 ar55 ac8 ac11" style="background-color:green; color: #FFF;">1.11</td>
+			<td headers="ar1 ar53 ar55 ac8 ac12" style="background-color:green; color: #FFF;">1.07</td>
+			<td headers="ar1 ar53 ar55 ac8 ac13" style="background-color:lightgreen">0.86</td>
+			<td headers="ar1 ar53 ar55 ac8 ac14" style="background-color:mediumseagreen">0.92</td>
+		</tr>
+	</tbody>
+</table>
+
+<p>This table shows the rate of doses administered (per 1,000 population) to Māori or Pacific Peoples, relative to the rate of doses for Non-Māori and Non-Pacific groups. Less than one means the group is receiving a lower proportion of doses than would be expected if equity is being achieved. More than one means they are receiving a higher proportion of doses than would be expected if equity is being achieved. Exactly one means doses administered are in line with their proportion of population.</p>
+
+<ul>
+	<li><a download="" href="/web/20211024013718/https://www.health.govt.nz/system/files/documents/pages/rateratioexplainer_1.docx">Rate Ratio Explainer (Word, 434 KB)</a></li>
+</ul>
+
+<p>At all ages the size (weightings) of the age groups becomes a major contributing factor to comparative ratios, which is why the all ages (12+) figure may not appear to be in line with the age splits.</p>
+
+<h4><a id="uptake" name="uptake"></a>Vaccine uptake per 1,000 people by ethnicity</h4>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine uptake per 1,000 people by ethnicity" class="img-responsive" height="830" src="/web/20211024013718im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_eth_7.png" width="1780"/></figure>
+
+<h4><a id="uptake" name="uptake"></a>Vaccine uptake per 1,000 people by age band</h4>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine uptake per 1,000 people by age band" class="img-responsive" height="1030" src="/web/20211024013718im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_age_8.png" width="1780"/></figure>
+
+<h4><a id="uptake" name="location"></a>Vaccine uptake per 1,000 people by DHB of residence</h4>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine uptake per 1,000 people by DHB of residence" class="img-responsive" height="1030" src="/web/20211024013718im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_dhb_3.png" width="1780"/></figure>
+<!--
+<hr />
+<h3><a id="by_dhb_plan" name="dhb_plan"></a>Cumulative vaccination plan for DHBs</h3>
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">DHB of service</th>
+			<th scope="col" style="text-align:right">Actuals to Sunday 17 October</th>
+			<th scope="col" style="text-align:right">DHB Plan to Sunday 17 October</th>
+			<th scope="col" style="text-align:right">Variance</th>
+			<th scope="col" style="text-align:right">% of Plan</th>
+			<th scope="col" style="text-align:right">Week to date</th>
+		</tr>
+	</thead>
+	<tbody> --><!--plan--><!--
+<tr><td nowrap="nowrap">Auckland Metro</td><td>190621</td><td>205515</td><td>-14894</td><td>93%</td><td>9913</td></tr>
+<tr><td nowrap="nowrap">Bay of Plenty</td><td>22841</td><td>14255</td><td>8586</td><td>160%</td><td>1843</td></tr>
+<tr><td nowrap="nowrap">Canterbury</td><td>50558</td><td>39266</td><td>11292</td><td>129%</td><td>2769</td></tr>
+<tr><td nowrap="nowrap">Capital & Coast and Hutt Valley</td><td>48758</td><td>39742</td><td>9016</td><td>123%</td><td>1796</td></tr>
+<tr><td nowrap="nowrap">Hawke's Bay</td><td>15319</td><td>18205</td><td>-2886</td><td>84%</td><td>1351</td></tr>
+<tr><td nowrap="nowrap">Lakes</td><td>13437</td><td>12810</td><td>627</td><td>105%</td><td>731</td></tr>
+<tr><td nowrap="nowrap">MidCentral</td><td>10708</td><td>7237</td><td>3471</td><td>148%</td><td>1191</td></tr>
+<tr><td nowrap="nowrap">Nelson Marlborough</td><td>30198</td><td>18574</td><td>11624</td><td>163%</td><td>1285</td></tr>
+<tr><td nowrap="nowrap">Northland</td><td>21469</td><td>24762</td><td>-3293</td><td>87%</td><td>1257</td></tr>
+<tr><td nowrap="nowrap">South Canterbury</td><td>8106</td><td>8033</td><td>73</td><td>101%</td><td>389</td></tr>
+<tr><td nowrap="nowrap">Southern</td><td>35234</td><td>34594</td><td>640</td><td>102%</td><td>1794</td></tr>
+<tr><td nowrap="nowrap">Tairāwhiti</td><td>4579</td><td>4928</td><td>-349</td><td>93%</td><td>290</td></tr>
+<tr><td nowrap="nowrap">Taranaki</td><td>5619</td><td>5297</td><td>322</td><td>106%</td><td>168</td></tr>
+<tr><td nowrap="nowrap">Waikato</td><td>36070</td><td>32842</td><td>3228</td><td>110%</td><td>1905</td></tr>
+<tr><td nowrap="nowrap">Wairarapa</td><td>4516</td><td>4960</td><td>-444</td><td>91%</td><td>468</td></tr>
+<tr><td nowrap="nowrap">West Coast</td><td>3533</td><td>3300</td><td>233</td><td>107%</td><td>336</td></tr>
+<tr><td nowrap="nowrap">Whanganui</td><td>6982</td><td>4711</td><td>2271</td><td>148%</td><td>612</td></tr>
+<tr><td nowrap="nowrap">Other Sites</td><td>24890</td><td>14575</td><td>10315</td><td>171%</td><td>613</td></tr>
+<tr><td nowrap="nowrap">Total</td><td>533438</td><td>493606</td><td>39832</td><td>108%</td><td>28711</td></tr>
+!--plan_end--><!--	</tbody>
+</table>
+
+
+<p>The information provided in this table is based on cumulative DHB plans to the last week ending on Sunday. The final column shows vaccinations administered since Sunday by DHB of service to reconcile total actuals in this table to other total numbers shown.   On-going, and as we roll-out the vaccination programme, we anticipate that there could be a potential variance of up to ten percent (plus or minus) between DHB Plans and actual vaccination numbers. This is on the basis that, for example, an unplanned significant event could affect roll-out implementation or some DHBs might exceed their planned vaccination numbers.
+</p>
+-->
+
+<hr/>
+<h3><a id="by_dhb" name="location"></a>Cumulative vaccinations by DHB</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Cumulative vaccinations for DHBs" class="img-responsive" height="830" src="/web/20211024013718im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/dhbstacked_11.png" width="1780"/></figure>
+
+<hr/>
+<h3><a id="by-day" name="by-day"></a>Vaccinations by day</h3>
+
+<figure class="image-captioned img-responsive"><img alt="Vaccination doses administered per day" class="img-responsive" height="830" src="/web/20211024013718im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/vaccinebyday_11.png" width="1780"/></figure>
+
+<p>This chart shows the count of vaccinations administered on a given day from the COVID-19 Immunisation Register. Note some records are entered in the register at a later date than the immunisation was received. This means that the figures for a given date may move for some time after that date.</p>
+
+<hr/>
+<h3><a id="group" name="group"></a>Vaccinations by group by week</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccinations by group" class="img-responsive" height="830" src="/web/20211024013718im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/vaccinebygroupwk_11.png" width="1780"/></figure>
+
+<hr/>
+<h3><a id="group_d" name="group_d"></a>Cumulative vaccinations by group</h3>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">Priority Group</th>
+			<th scope="col" style="text-align:right">First dose administered</th>
+			<th scope="col" style="text-align:right">Second dose administered</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">Group 1</th>
+			<td style="text-align:right">66,654</td>
+			<td style="text-align:right">64,835</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Group 2</th>
+			<td style="text-align:right">634,957</td>
+			<td style="text-align:right">595,136</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Group 3</th>
+			<td style="text-align:right">790,330</td>
+			<td style="text-align:right">734,465</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Group 4</th>
+			<td style="text-align:right">2,101,547</td>
+			<td style="text-align:right">1,443,270</td>
+		</tr>
+	</tbody>
+</table>
+
+<p>For definitions of the groups and further detail see the downloadable spreadsheet at the bottom of the page.</p>
+
+<hr/>
+<h3><a id="by_soh" name="stockonhand"></a>Vaccine available for distribution at week end</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine available for distribution at week end" class="img-responsive" height="830" src="/web/20211024013718im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/stockonhand_12.png" width="1780"/></figure>
+
+<p>Vaccine available for distribution is stock (in doses) held at central warehouses. It does not include stock in transit or available at sites ready for use.</p>
+
+<hr/>
+<h3><a id="by_eth" name="ethnicity"></a>Total cumulative doses per 1,000 people by ethnicity</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Total cumulative doses per 1,000 people by ethnicity" class="img-responsive" height="830" src="/web/20211024013718im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/ethnicity_11.png" width="1780"/></figure>
+
+<p>This chart shows both first and second doses. As a result this chart may exceed 1,000 doses per 1,000 people.</p>
+
+<p><strong>*</strong> The prioritised ethnicity classification system allocates each person to a single ethnic group, based on the ethnic groups they identify with. Where people identify with more than one group, they are assigned in this order of priority: Māori, Pacific Peoples, Asian, and European/Other. So, if a person identifies as being Māori and New Zealand European, the person is counted as Māori. See <a href="/web/20211024013718/https://www.health.govt.nz/publication/hiso-100012017-ethnicity-data-protocols">Ethnicity Data Protocols</a> for further information.</p>
+
+<p>Ethnicity breakdown by DHB of residence is available in the downloadable spreadsheet at the bottom of the page.</p>
+
+<hr/>
+<h3><a id="by_age" name="age"></a>Cumulative vaccinations by age</h3>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">Age</th>
+			<th scope="col" style="text-align:right">First dose administered</th>
+			<th scope="col" style="text-align:right">First doses per 1,000 people</th>
+			<th scope="col" style="text-align:right">Fully vaccinated</th>
+			<th scope="col" style="text-align:right">Fully vaccinated per 1,000 people</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">12 - 19 years</th>
+			<td style="text-align:right">389,918</td>
+			<td style="text-align:right">776</td>
+			<td style="text-align:right">247,401</td>
+			<td style="text-align:right">492</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">20 - 34 years</th>
+			<td style="text-align:right">819,368</td>
+			<td style="text-align:right">792</td>
+			<td style="text-align:right">542,717</td>
+			<td style="text-align:right">525</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">35 - 49 years</th>
+			<td style="text-align:right">810,315</td>
+			<td style="text-align:right">847</td>
+			<td style="text-align:right">620,812</td>
+			<td style="text-align:right">649</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">50 - 64 years</th>
+			<td style="text-align:right">828,152</td>
+			<td style="text-align:right">893</td>
+			<td style="text-align:right">722,868</td>
+			<td style="text-align:right">779</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">65 and over</th>
+			<td style="text-align:right">745,735</td>
+			<td style="text-align:right">946</td>
+			<td style="text-align:right">703,908</td>
+			<td style="text-align:right">893</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total</strong></th>
+			<td style="text-align:right"><strong>3,593,488</strong></td>
+			<td style="text-align:right"><strong>854</strong></td>
+			<td style="text-align:right"><strong>2,837,706</strong></td>
+			<td style="text-align:right"><strong>674</strong></td>
+		</tr>
+	</tbody>
+</table>
+
+<p>Age breakdown by ethnicity and gender is available in the downloadable spreadsheet at the bottom of the page.</p>
+
+<hr/>
+<h3><a id="workforce" name="workforce"></a>Trained vaccinators and active vaccinators</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Trained vaccinators and active vaccinators" class="img-responsive" height="830" src="/web/20211024013718im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/workforce_11.png" width="1780"/></figure>
+
+<p><strong>Trained vaccinators</strong> are individuals who have completed the COVID-19 training. Many trained people are only able to offer a small number of hours to the COVID-19 vaccination programme.</p>
+
+<p><strong>Active vaccinators</strong> are trained individuals who are actively vaccinating. The number of active vaccinators does not reflect the hours worked vaccinating. For example, one vaccinator may work 40 hours in a week at one DHB and will show as 1 vaccinator in the headcount. In another DHB, 4 vaccinators may work 10 hours each (total 40 hours), but will show as 4 vaccinators in the headcount for that week.</p>
+
+<p>Both counts of trained and active vaccinators are cumulative. The difference between the two is due to a number of factors. This includes: individuals being trained in anticipation of future sites being opened (the largest factor); rostering; leave or non-availability; local health priorities; sites opening and closing.</p>
+
+<hr/>
+<h3><a id="usage" name="usage"></a>Wastage of vaccine stock</h3>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">&nbsp;</th>
+			<th scope="col">Wastage</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">New Zealand</th>
+			<td>0.27%</td>
+		</tr>
+	</tbody>
+</table>
+
+<p>Wastage is vials that have been reported as wasted since 13 July in the Inventory portal by DHBs or central warehouses divided by vials used over the same time frame.</p>
+
+<h3><a id="download" name="download"></a>Details of vaccination data</h3>
+
+<p>Download a spreadsheet containing key vaccination data. This includes HSU based population estimates for calculating vaccine uptake rates.</p>
+
+<p><a download="" href="/web/20211024013718/https://www.health.govt.nz/system/files/documents/pages/covid_vaccinations_19_10_2021.xlsx">COVID-19 vaccination data through 19 Oct 2021 (Excel, 359 KB)</a></p>
+
+<p>This spreadsheet is based on the information made available at the time of publishing and may be subject to changes. Please take note of any notes and caveats on each sheet.</p>
+
+<p>The below attachments provide some analysis on our progress on equity. The two PDF files are high level summaries of overall progress. The Excel documents are interactive and provides the ability to delve further into those overall numbers. NB: These Excel workbooks use features that are non-compatible with versions of MS Office 2016 and earlier.</p>
+
+<ul>
+	<li><a download="" href="/web/20211024013718/https://www.health.govt.nz/system/files/documents/pages/211017_-_cvip_equity_-_rate_ratios_by_ethicity_ageband_and_dhb.pdf">Covid-19 Vaccine Rate Ratios by Ethnicity, Ageband and DHB (PDF, 642 KB)</a></li>
+	<li><a download="" href="/web/20211024013718/https://www.health.govt.nz/system/files/documents/pages/211017_-_cvip_equity_-_uptake_by_ethicity_ageband_and_dhb.pdf">Covid-19 Vaccine Uptake by Ethnicity, Ageband and DHB (PDF, 551 KB)</a></li>
+	<li><a download="" href="/web/20211024013718/https://www.health.govt.nz/system/files/documents/pages/211017_-_cvip_equity_-_level_1_ethnicity_uptake_and_rate_ratios.xlsx">Covid-19 Vaccine Equity - Level 1 Ethnicity Uptake and Rate Ratios (Excel, 152 KB)</a></li>
+	<li><a download="" href="/web/20211024013718/https://www.health.govt.nz/system/files/documents/pages/211017_-_cvip_equity_-_level_2_ethnicity_uptake_and_rate_ratios.xlsx">Covid-19 Vaccine Equity - Level 2 Ethnicity Uptake and Rate Ratios (Excel, 378 KB)</a></li>
+	<li><a download="" href="/web/20211024013718/https://www.health.govt.nz/system/files/documents/pages/211017_-_cvip_equity_-_rate_ratios_and_uptake_over_time.xlsx">Rate Ratios and Uptake Over Time (Excel, 972 KB)</a></li>
+</ul>
+
+<hr/>
+<h3><a id="adverse-events" name="adverse-events"></a>Adverse events following&nbsp;immunisations (AEFI)</h3>
+
+<p>Like all medicines, the COVID-19 vaccine may cause side effects in some people. These are common, are usually mild, don&rsquo;t last long and won&rsquo;t stop people from having the second dose or going about daily life. Serious allergic reactions do occur but are extremely rare.</p>
+
+<p>Suspected AEFI to COVID-19 vaccines are reported to the <a href="https://web.archive.org/web/20211024013718/https://nzphvc.otago.ac.nz/">Centre for Adverse Reactions Monitoring</a> (CARM).&nbsp;<a href="https://web.archive.org/web/20211024013718/https://www.medsafe.govt.nz/">Medsafe</a> is closely monitoring the AEFI reported from the use of the COVID-19 vaccine and will report regularly on their findings.&nbsp;</p>
+
+<p><a href="https://web.archive.org/web/20211024013718/https://www.medsafe.govt.nz/COVID-19/vaccine-report-overview.asp">View Medsafe data on COVID-19 vaccine adverse effects following immunisation</a></p>
+</div></div></div>    </article>
+  </div>
+
+
+  </div>
+<div class="panel-pane pane-node-links even">
+
+
+
+  <div class="pane-content">
+          </div>
+
+
+  </div>
+
+<div class="panel-pane pane-views pane-sub-pages even">
+
+        <h2 class="pane-title h3">In this section</h2>
+
+
+  <div class="pane-content">
+        <div class="view view-sub-pages view-id-sub_pages view-display-id-block view-dom-id-e13f57da852d1718e871ee13e0ad4abd">
+
+
+
+      <div class="view-content">
+      <div class="item-list">    <ul>          <li class="views-row views-row-1 views-row-odd views-row-first">
+  <div class="views-field views-field-title">        <div class="field-content">
+<div class="views-field views-field-title">
+  <h3 class="field-content">
+    <a href="/web/20211024013718/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-across-nz">COVID-19 Vaccination uptake rates across NZ</a>  </h3>
+</div></div>  </div>
+  <span class="views-field views-field-body">        <span class="field-content">This page provides information related to uptake rates of the COVID-19 vaccine across the country.
+</span>  </span>
+  <span class="views-field views-field-view-node">        <span class="field-content"><a href="/web/20211024013718/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-across-nz">Read more</a></span>  </span></li>
+          <li class="views-row views-row-2 views-row-even">
+  <div class="views-field views-field-title">        <div class="field-content">
+<div class="views-field views-field-title">
+  <h3 class="field-content">
+    <a href="/web/20211024013718/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-maori-communities-across-nz">COVID-19 Vaccination uptake rates within Māori communities across NZ</a>  </h3>
+</div></div>  </div>
+  <span class="views-field views-field-body">        <span class="field-content">This page provides information related to uptake rates of the COVID-19 vaccine within Māori communities across New Zealand.
+</span>  </span>
+  <span class="views-field views-field-view-node">        <span class="field-content"><a href="/web/20211024013718/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-maori-communities-across-nz">Read more</a></span>  </span></li>
+          <li class="views-row views-row-3 views-row-odd views-row-last">
+  <div class="views-field views-field-title">        <div class="field-content">
+<div class="views-field views-field-title">
+  <h3 class="field-content">
+    <a href="/web/20211024013718/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-pacific-communities-across-nz">COVID-19 Vaccination uptake rates within Pacific communities across NZ</a>  </h3>
+</div></div>  </div>
+  <span class="views-field views-field-body">        <span class="field-content">This page provides information related to uptake rates of the COVID-19 vaccine within Pacific communities across New Zealand.
+</span>  </span>
+  <span class="views-field views-field-view-node">        <span class="field-content"><a href="/web/20211024013718/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-pacific-communities-across-nz">Read more</a></span>  </span></li>
+      </ul></div>    </div>
+
+
+
+
+
+
+</div>  </div>
+
+
+  </div>
+</div>          </div>
+
+  </div>
+
+</section>
+  </div>
+      </section>
+
+
+    </div>
+    <div id="content-footer-wrapper" class="clearfix">
+      <div id="content-footer" class="clearfix">
+                  <p class="page_updated">Page last updated: <span class="date">24 October 2021</span></p>                  <div class="region region-content-footer">
+    <section id="block-moh-tools-page-tools" class="block block-moh-tools clearfix">
+  <a href="#" data-placement="top" data-title="Share this content." data-html="true" data-content="<p>Share this page on some of the most popular social networking and content sites on the internet.</p><div class='service-links'><ul><li><a href='https://twitter.com/share?url=https%3A//www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data&amp;text=COVID-19%3A%20Vaccine%20data' title='Share this on Twitter' class='service-links-twitter' rel='nofollow'><img typeof='foaf:Image' class='img-responsive' src='https://www.health.govt.nz/sites/all/modules/contrib/service_links/images/twitter.png' alt='Twitter' /> Twitter</a></li>
+<li><a href='https://www.facebook.com/sharer.php?u=https%3A//www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data&amp;t=COVID-19%3A%20Vaccine%20data' title='Share on Facebook' class='service-links-facebook' rel='nofollow'><img typeof='foaf:Image' class='img-responsive' src='https://www.health.govt.nz/sites/all/modules/contrib/service_links/images/facebook.png' alt='Facebook' /> Facebook</a></li>
+</ul></div>" class="share-this-content"><i class="fa fa-share"></i> Share</a><a href="#" title="print this page" class="print"><i class="fa fa-print"></i> Print</a><a href="https://web.archive.org/web/20211024013718/https://www.health.govt.nz/forward?path=node/12052" title="Email this page" class="email"><i class="fa fa-envelope"></i> Email</a><a href="/web/20211024013718/https://www.health.govt.nz/feedback?ref=https%3A//www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="Feedback" class="rss"><i class="fa fa-comment"></i> Feedback</a></section>
+
+  </div>
+      </div>
+    </div>
+
+  </div>
+  <footer class="footer container">
+    <h2 class="hidden">Site Footer</h2>
+    <div class="footer-default">
+      <div class="row">
+        <div class="col-sm-6 col-md-6">
+          <div class="field field-name-field-tax-first-column-links">
+            <ul class="field-items"><li class="field-item"><a href="https://web.archive.org/web/20211024013718/https://www.health.govt.nz/node/492" class="">About this site</a></li><li class="field-item"><a href="https://web.archive.org/web/20211024013718/https://www.health.govt.nz/node/524" class="">Contact us</a></li><li class="field-item"><a href="https://web.archive.org/web/20211024013718/https://www.health.govt.nz/node/488" class="">Other Ministry of Health websites</a></li><li class="field-item"><a href="https://web.archive.org/web/20211024013718/https://www.health.govt.nz/node/7497" class="">Official Information Act requests</a></li><li class="field-item"><a href="https://web.archive.org/web/20211024013718/https://www.health.govt.nz/about-ministry/information-releases" class="">Information releases</a></li><li class="field-item"><a href="https://web.archive.org/web/20211024013718/https://consult.health.govt.nz/" class="">Consultations</a></li></ul>
+          </div>
+        </div>
+        <div class="col-sm-6 col-md-6">
+          <div class="field field-name-field-tax-footer-body field-type-text-long field-label-hidden"><div class="field-items"><div class="field-item even"><h3>Where to go for help</h3>
+
+<table>
+	<tbody>
+		<tr>
+			<th scope="row">Emergencies</th>
+			<td><strong>Dial <a href="tel:111">111</a></strong> (for ambulance, fire or police)</td>
+		</tr>
+		<tr>
+			<th scope="row">Healthline</th>
+			<td><strong>Dial <a href="tel:0800611116">0800 611 116</a></strong></td>
+		</tr>
+		<tr>
+			<th scope="row">Poisons</th>
+			<td><strong>Dial <a href="tel:0800764766">0800 POISON</a> </strong>(<a href="tel:0800764766">0800 764 766</a>)</td>
+		</tr>
+		<tr>
+			<th scope="row">Mental health crisis</th>
+			<td><strong><a href="/web/20211024013718/https://www.health.govt.nz/your-health/services-and-support/health-care-services/mental-health-services/crisis-assessment-teams">Emergency contact numbers</a></strong></td>
+		</tr>
+	</tbody>
+</table>
+</div></div></div>        </div>
+      </div>
+      <div class="row">
+        <div class="sub-footer">
+          <div class="column col-sm-12 col-md-3">
+            <a href="https://web.archive.org/web/20211024013718/https://www.govt.nz/">
+              <img src="/web/20211024013718im_/https://www.health.govt.nz/sites/all/themes/mohpub_bootstrap/images/nzgovtlogo_white.png" width="152" height="16" alt="govt.nz - connecting you to New Zealand central &amp; local government services" title="govt.nz - connecting you to New Zealand central &amp; local government services"/>
+            </a>
+          </div>
+          <div class="column col-sm-12 col-md-9">
+          <span class="bottom-menu-moh with-v-divider">&copy; Ministry of Health – Manatū Hauora</span><ul class="bottom-menu-list"><li class="bottom-menu-list-item with-v-divider"><a href="https://web.archive.org/web/20211024013718/https://www.health.govt.nz/sitemap" class="">Site map</a></li><li class="bottom-menu-list-item with-v-divider"><a href="https://web.archive.org/web/20211024013718/https://www.health.govt.nz/about-site/privacy-and-security" class="">Privacy &amp; security</a></li><li class="bottom-menu-list-item with-v-divider"><a href="https://web.archive.org/web/20211024013718/https://www.health.govt.nz/about-site/copyright" class="">Copyright</a></li></ul>          </div>
+        </div>
+      </div>
+    </div>
+    <div class="footer-print">&copy; Ministry of Health – Manatū Hauora</div>
+  </footer>
+  <a class="scrollToTop">Back to top <i class="fas fa-arrow-up"></i></a>
+</div>
+  <script src="https://web.archive.org/web/20211024013718js_/https://www.health.govt.nz/sites/default/files/js/js_akZOsKtodu3PdnQzY3_ElOfujkLxJcowmaWgHTBBLOE.js"></script>
+</body>
+</html>
+<!--
+     FILE ARCHIVED ON 01:37:18 Oct 24, 2021 AND RETRIEVED FROM THE
+     INTERNET ARCHIVE ON 03:23:22 Nov 07, 2021.
+     JAVASCRIPT APPENDED BY WAYBACK MACHINE, COPYRIGHT INTERNET ARCHIVE.
+
+     ALL OTHER CONTENT MAY ALSO BE PROTECTED BY COPYRIGHT (17 U.S.C.
+     SECTION 108(a)(3)).
+-->
+<!--
+playback timings (ms):
+  captures_list: 265.976
+  exclusion.robots: 0.216
+  exclusion.robots.policy: 0.209
+  RedisCDXSource: 2.985
+  esindex: 0.017
+  LoadShardBlock: 219.731 (3)
+  PetaboxLoader3.datanode: 205.913 (4)
+  CDXLines.iter: 30.735 (3)
+  load_resource: 206.108
+  PetaboxLoader3.resolve: 144.662
+-->

--- a/data/rawSite/2021-10-24.html
+++ b/data/rawSite/2021-10-24.html
@@ -1,0 +1,2510 @@
+
+<!DOCTYPE html>
+<html lang="en" dir="ltr" prefix="" class="no-js">
+<head><script src="//archive.org/includes/analytics.js?v=cf34f82" type="text/javascript"></script>
+<script type="text/javascript">window.addEventListener('DOMContentLoaded',function(){var v=archive_analytics.values;v.service='wb';v.server_name='wwwb-app200.us.archive.org';v.server_ms=394;archive_analytics.send_pageview({});});</script>
+<script type="text/javascript" src="/_static/js/bundle-playback.js?v=UfTkgsKx" charset="utf-8"></script>
+<script type="text/javascript" src="/_static/js/wombat.js?v=UHAOicsW" charset="utf-8"></script>
+<script type="text/javascript">
+  __wm.init("https://web.archive.org/web");
+  __wm.wombat("https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data","20211025040431","https://web.archive.org/","web","/_static/",
+	      "1635134671");
+</script>
+<link rel="stylesheet" type="text/css" href="/_static/css/banner-styles.css?v=omkqRugM" />
+<link rel="stylesheet" type="text/css" href="/_static/css/iconochive.css?v=qtvMKcIJ" />
+<!-- End Wayback Rewrite JS Include -->
+
+  <!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta name="format-detection" content="telephone=no"/>
+  <link rel="profile" href="http://www.w3.org/1999/xhtml/vocab"/>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+<link rel="shortcut icon" href="https://web.archive.org/web/20211025040431im_/https://www.health.govt.nz/sites/all/themes/mohpub_bootstrap/favicon.ico" type="image/vnd.microsoft.icon"/>
+<meta name="description" content="Dashboard of data and statistics about the rollout of COVID-19 vaccines in New Zealand"/>
+<meta name="generator" content="Drupal 7 (https://www.drupal.org)"/>
+<link rel="canonical" href="https://web.archive.org/web/20211025040431/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data"/>
+<link rel="shortlink" href="https://web.archive.org/web/20211025040431/https://www.health.govt.nz/node/12052"/>
+<meta property="og:site_name" content="Ministry of Health NZ"/>
+<meta property="og:type" content="article"/>
+<meta property="og:url" content="https://web.archive.org/web/20211025040431/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data"/>
+<meta property="og:title" content="COVID-19: Vaccine data"/>
+<meta property="og:description" content="Dashboard of data and statistics about the rollout of COVID-19 vaccines in New Zealand"/>
+  <title>COVID-19: Vaccine data | Ministry of Health NZ</title>
+  <link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211025040431cs_/https://www.health.govt.nz/sites/default/files/css/css_lQaZfjVpwP_oGNqdtWCSpJT1EMqXdMiU84ekLLxQnc4.css" media="all"/>
+<link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211025040431cs_/https://www.health.govt.nz/sites/default/files/css/css_jqUBpWfMaxMiP7LismdZVlyVv8azUJSE2yaH58nj0cE.css" media="all"/>
+<link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211025040431cs_/https://www.health.govt.nz/sites/default/files/css/css_Rb1wqFBC8VXCJC-BuNY53cvjjlj6UADGvqzo_f-1yN0.css" media="all"/>
+<link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211025040431cs_/https://www.health.govt.nz/sites/default/files/css/css_38_K1lHKg-98m4KKRfv57JBK0gvlKscexGt9MKoi0DE.css" media="all"/>
+<link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211025040431cs_/https://www.health.govt.nz/sites/default/files/css/css_r7NPyvpdYfAyZmk9zkK8OaFKEFj6er5ZJnam2H644DM.css" media="print"/>
+  <link rel="alternate stylesheet" type="text/css" href="/web/20211025040431cs_/https://www.health.govt.nz/sites/all/themes/mohpub_bootstrap/css/high-contrast.css" media="screen" title="High Contrast"/>
+  <script src="https://web.archive.org/web/20211025040431js_/https://www.health.govt.nz/sites/default/files/js/js_zS-CmNFGyegtLYJmqFRpxQvvQrfPIFrOMq_3T3C8sZE.js"></script>
+<script src="https://web.archive.org/web/20211025040431js_/https://www.health.govt.nz/sites/default/files/js/js_fNgZ4Okisfr70Q0yvAYsATgB0o_jD3-srhQQ-VHmlXE.js"></script>
+<script src="https://web.archive.org/web/20211025040431js_/https://www.health.govt.nz/sites/default/files/js/js_YAdPZfg12M1m7ROp3_gVJPS5sArqL0kYQgNRPoicvHE.js"></script>
+<script>(function(i,s,o,g,r,a,m){i["GoogleAnalyticsObject"]=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,"script","https://web.archive.org/web/20211025040431/https://www.google-analytics.com/analytics.js","ga");ga("create", "UA-3573389-24", {"cookieDomain":".www.health.govt.nz","siteSpeedSampleRate":15});ga("send", "pageview");</script>
+<script src="https://web.archive.org/web/20211025040431js_/https://www.health.govt.nz/sites/default/files/js/js_QAXZNPwLISRLHqyNpT4Vvr_iqD9foD6GTbEjlhIIjeo.js"></script>
+<script src="https://web.archive.org/web/20211025040431js_/https://www.health.govt.nz/sites/default/files/js/js_4VW9edmu3V8VjGJxFfXGAwkXeW2cJIa5h-6y7SgwVrk.js"></script>
+<script>    (function(h,o,t,j,a,r){
+        h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
+        h._hjSettings={hjid:930919,hjsv:6};
+        a=o.getElementsByTagName('head')[0];
+        r=o.createElement('script');r.async=1;
+        r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+        a.appendChild(r);
+    })(window,document,'https://web.archive.org/web/20211025040431/https://static.hotjar.com/c/hotjar-','.js?sv=');
+</script>
+<script>jQuery.extend(Drupal.settings, {"basePath":"\/","pathPrefix":"","ajaxPageState":{"theme":"mohpub_bootstrap","theme_token":"9ZWqUkcSlrQeLIO0Z0U7IGBe9MyNintWcB37GxywIis","js":{"sites\/all\/modules\/custom\/table_d3chart\/js\/table_d3chart.js":1,"sites\/all\/modules\/custom\/moh_d3\/moh_d3.js":1,"sites\/all\/modules\/contrib\/jquery_update\/replace\/jquery\/1.7\/jquery.min.js":1,"misc\/jquery-extend-3.4.0.js":1,"misc\/jquery-html-prefilter-3.5.0-backport.js":1,"misc\/jquery.once.js":1,"misc\/drupal.js":1,"sites\/all\/modules\/contrib\/ckeditor_accordion\/js\/ckeditor-accordion.js":1,"sites\/all\/modules\/contrib\/extlink\/extlink.js":1,"modules\/field\/modules\/text\/text.js":1,"sites\/all\/modules\/contrib\/field_group\/field_group.js":1,"sites\/all\/modules\/contrib\/google_analytics\/googleanalytics.js":1,"0":1,"sites\/all\/libraries\/c3\/c3.js":1,"sites\/all\/libraries\/d3\/d3.min.js":1,"sites\/all\/modules\/contrib\/d3\/js\/d3.js":1,"sites\/all\/libraries\/d3.helpers\/d3.helpers.js":1,"sites\/all\/libraries\/d3.c3\/d3-c3.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/assets\/ios-fix.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/affix.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/alert.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/button.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/carousel.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/collapse.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/dropdown.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/modal.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/tooltip.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/popover.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/scrollspy.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/tab.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/transition.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/jquery.cookie.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/jquery.moh.announcement.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/svgeezy.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/fitvids.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/bootstrap-tabcollapse.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/jquery.scrollTo.min.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/script.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/jquery.google_analytics.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/bootstrap-accessibility.min.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/style-switcher.js":1,"1":1},"css":{"modules\/system\/system.base.css":1,"sites\/all\/modules\/contrib\/calendar\/css\/calendar_multiday.css":1,"sites\/all\/modules\/contrib\/ckeditor_accordion\/css\/ckeditor-accordion.css":1,"modules\/field\/theme\/field.css":1,"modules\/node\/node.css":1,"sites\/all\/modules\/contrib\/extlink\/extlink.css":1,"sites\/all\/modules\/contrib\/views\/css\/views.css":1,"sites\/all\/modules\/contrib\/ckeditor\/css\/ckeditor.css":1,"sites\/all\/modules\/contrib\/ctools\/css\/ctools.css":1,"sites\/all\/modules\/contrib\/panels\/css\/panels.css":1,"sites\/all\/libraries\/c3\/c3.css":1,"sites\/all\/libraries\/d3.c3\/d3-c3.css":1,"sites\/all\/themes\/mohpub_bootstrap\/fontawesome\/css\/fontawesome.min.css":1,"sites\/all\/themes\/mohpub_bootstrap\/fontawesome\/css\/solid.min.css":1,"sites\/all\/themes\/mohpub_bootstrap\/fontawesome\/css\/brands.min.css":1,"sites\/all\/modules\/features\/site_profile\/css\/fix-rubik-multiselect-height.css":1,"sites\/all\/themes\/mohpub_bootstrap\/css\/style.css":1,"sites\/all\/themes\/mohpub_bootstrap\/css\/responsive-tables.css":1,"sites\/all\/themes\/mohpub_bootstrap\/css\/print.css":1}},"field_group":{"div":"full"},"ckeditor_accordion":{"collapseAll":1},"extlink":{"extTarget":0,"extClass":"ext","extLabel":"(link is external)","extImgClass":0,"extIconPlacement":"append","extSubdomains":0,"extExclude":"","extInclude":"","extCssExclude":"","extCssExplicit":"","extAlert":0,"extAlertText":"This link will take you to an external web site. We are not responsible for their content.","mailtoClass":"mailto","mailtoLabel":"(link sends e-mail)"},"googleanalytics":{"trackOutbound":1,"trackMailto":1,"trackDownload":1,"trackDownloadExtensions":"7z|aac|arc|arj|asf|asx|avi|bin|csv|doc|exe|flv|gif|gz|gzip|hqx|jar|jpe?g|js|mp(2|3|4|e?g)|mov(ie)?|msi|msp|pdf|phps|png|ppt|qtm?|ra(m|r)?|sea|sit|tar|tgz|torrent|txt|wav|wma|wmv|wpd|xls|xml|z|zip|docx|xlsx|pptx|pptm|ppsx|ppsm|epub"},"mohD3":{"C3Types":["line","spline","step","area","area-spline","area-step","bar","scatter","pie","donut","gauge"],"graphRender":"line","graphLegend":true,"graphDefaultColors":"#2b8cbe, #abdda4, #7f7f7f, #92cddc, #dc8b0c","graphDefaultGroupedTooltip":0,"graphDefaultGridX":0,"graphDefaultGridY":0,"graphDefaultLegendPosition":"top-right","graphDefaultTooltip":1,"graphDefaultDataLabel":0,"graphLegendStep":"5","graphInteraction":true,"graphTypes":"","graphXaxisShow":true,"graphXaxisLabel":"","graphYaxisLabel":"","graphXaxisType":"category","graphXaxisCentered":false,"graphXaxisRotation":"","graphXaxisHeight":"","graphYaxisShow":true,"graphYaxisMax":"","graphYaxisMin":"","graphYaxisInverted":false,"graphYaxisCenter":"","graphYaxisPrefix":"","graphYaxisSuffix":"","graphYaxisPosition":"","graphY2axisShow":false,"graphY2axisSource":"","graphY2axisMax":"","graphY2axisMin":"","graphGroups":"","graphRotated":false,"graphIgnoreEmpty":false,"graphLineDot":true,"graphBarRatio":"0.9","graphDot":true,"graphDotR":"2.5","graphFocus":false},"tableD3":{"show":"View table data source","hide":"Hide table data source"},"urlIsAjaxTrusted":{"\/our-work\/diseases-and-conditions\/covid-19-novel-coronavirus\/covid-19-data-and-statistics\/covid-19-vaccine-data":true},"bootstrap":{"anchorsFix":1,"anchorsSmoothScrolling":1,"formHasError":1,"popoverEnabled":1,"popoverOptions":{"animation":1,"html":0,"placement":"right","selector":"","trigger":"click","triggerAutoclose":1,"title":"","content":"","delay":0,"container":"body"},"tooltipEnabled":1,"tooltipOptions":{"animation":1,"html":0,"placement":"auto left","selector":"","trigger":"hover focus","delay":0,"container":"body"}}});</script>
+  <!-- HTML5 element support for IE6-8 -->
+  <!--[if lt IE 9]>
+    <script src="/sites/all/themes/mohpub_bootstrap/js/assets/html5shiv.js"></script>
+    <script src="/sites/all/themes/mohpub_bootstrap/js/assets/respond.min.js"></script>
+  <![endif]-->
+</head>
+<body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-12052 node-type-page node-has-intro"><!-- BEGIN WAYBACK TOOLBAR INSERT -->
+<style type="text/css">
+body {
+  margin-top:0 !important;
+  padding-top:0 !important;
+  /*min-width:800px !important;*/
+}
+</style>
+<script>__wm.rw(0);</script>
+<div id="wm-ipp-base" lang="en" style="display:none;direction:ltr;">
+<div id="wm-ipp" style="position:fixed;left:0;top:0;right:0;">
+<div id="wm-ipp-inside">
+  <div style="position:relative;">
+    <div id="wm-logo" style="float:left;width:110px;padding-top:12px;">
+      <a href="/web/" title="Wayback Machine home page"><img src="/_static/images/toolbar/wayback-toolbar-logo-200.png" srcset="/_static/images/toolbar/wayback-toolbar-logo-100.png, /_static/images/toolbar/wayback-toolbar-logo-150.png 1.5x, /_static/images/toolbar/wayback-toolbar-logo-200.png 2x" alt="Wayback Machine" style="width:100px" border="0" /></a>
+    </div>
+    <div class="r" style="float:right;">
+      <div id="wm-btns" style="text-align:right;height:25px;">
+                  <div id="wm-save-snapshot-success">success</div>
+          <div id="wm-save-snapshot-fail">fail</div>
+          <a id="wm-save-snapshot-open" href="#"
+	     title="Share via My Web Archive" >
+            <span class="iconochive-web"></span>
+          </a>
+          <a href="https://archive.org/account/login.php"
+             title="Sign In"
+             id="wm-sign-in"
+          >
+            <span class="iconochive-person"></span>
+          </a>
+          <span id="wm-save-snapshot-in-progress" class="iconochive-web"></span>
+        	<a href="http://faq.web.archive.org/" title="Get some help using the Wayback Machine" style="top:-6px;"><span class="iconochive-question" style="color:rgb(87,186,244);font-size:160%;"></span></a>
+	<a id="wm-tb-close" href="#close" onclick="__wm.h(event);return false;" style="top:-2px;" title="Close the toolbar"><span class="iconochive-remove-circle" style="color:#888888;font-size:240%;"></span></a>
+      </div>
+      <div id="wm-share">
+          <a href="/web/20211025040431/http://web.archive.org/screenshot/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data"
+             id="wm-screenshot"
+             title="screenshot">
+            <span class="wm-icon-screen-shot"></span>
+          </a>
+          <a href="#"
+            id="wm-video"
+            title="video">
+            <span class="iconochive-movies"></span>
+          </a>
+	<a id="wm-share-facebook" href="#" data-url="https://web.archive.org/web/20211025040431/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="Share on Facebook" style="margin-right:5px;" target="_blank"><span class="iconochive-facebook" style="color:#3b5998;font-size:160%;"></span></a>
+	<a id="wm-share-twitter" href="#" data-url="https://web.archive.org/web/20211025040431/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="Share on Twitter" style="margin-right:5px;" target="_blank"><span class="iconochive-twitter" style="color:#1dcaff;font-size:160%;"></span></a>
+      </div>
+    </div>
+    <table class="c" style="">
+      <tbody>
+	<tr>
+	  <td class="u" colspan="2">
+	    <form target="_top" method="get" action="/web/submit" name="wmtb" id="wmtb"><input type="text" name="url" id="wmtbURL" value="https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" onfocus="this.focus();this.select();" /><input type="hidden" name="type" value="replay" /><input type="hidden" name="date" value="20211025040431" /><input type="submit" value="Go" /></form>
+	  </td>
+	  <td class="n" rowspan="2" style="width:110px;">
+	    <table>
+	      <tbody>
+		<!-- NEXT/PREV MONTH NAV AND MONTH INDICATOR -->
+		<tr class="m">
+		  <td class="b" nowrap="nowrap"><a href="https://web.archive.org/web/20210925014632/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="25 Sep 2021"><strong>Sep</strong></a></td>
+		  <td class="c" id="displayMonthEl" title="You are here: 04:04:31 Oct 25, 2021">OCT</td>
+		  <td class="f" nowrap="nowrap">Nov</td>
+		</tr>
+		<!-- NEXT/PREV CAPTURE NAV AND DAY OF MONTH INDICATOR -->
+		<tr class="d">
+		  <td class="b" nowrap="nowrap"><a href="https://web.archive.org/web/20211024013718/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="01:37:18 Oct 24, 2021"><img src="/_static/images/toolbar/wm_tb_prv_on.png" alt="Previous capture" width="14" height="16" border="0" /></a></td>
+		  <td class="c" id="displayDayEl" style="width:34px;font-size:24px;white-space:nowrap;" title="You are here: 04:04:31 Oct 25, 2021">25</td>
+		  <td class="f" nowrap="nowrap"><a href="https://web.archive.org/web/20211026100341/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="10:03:41 Oct 26, 2021"><img src="/_static/images/toolbar/wm_tb_nxt_on.png" alt="Next capture" width="14" height="16" border="0" /></a></td>
+		</tr>
+		<!-- NEXT/PREV YEAR NAV AND YEAR INDICATOR -->
+		<tr class="y">
+		  <td class="b" nowrap="nowrap">2020</td>
+		  <td class="c" id="displayYearEl" title="You are here: 04:04:31 Oct 25, 2021">2021</td>
+		  <td class="f" nowrap="nowrap">2022</td>
+		</tr>
+	      </tbody>
+	    </table>
+	  </td>
+	</tr>
+	<tr>
+	  <td class="s">
+	    	    <div id="wm-nav-captures">
+	      	      <a class="t" href="/web/20211025040431*/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="See a list of every capture for this URL">682 captures</a>
+	      <div class="r" title="Timespan for captures of this URL">07 Apr 2021 - 06 Nov 2021</div>
+	      </div>
+	  </td>
+	  <td class="k">
+	    <a href="" id="wm-graph-anchor">
+	      <div id="wm-ipp-sparkline" title="Explore captures for this URL" style="position: relative">
+		<canvas id="wm-sparkline-canvas" width="650" height="27" border="0"></canvas>
+	      </div>
+	    </a>
+	  </td>
+	</tr>
+      </tbody>
+    </table>
+    <div style="position:absolute;bottom:0;right:2px;text-align:right;">
+      <a id="wm-expand" class="wm-btn wm-closed" href="#expand" onclick="__wm.ex(event);return false;"><span id="wm-expand-icon" class="iconochive-down-solid"></span> <span style="font-size:80%">About this capture</span></a>
+    </div>
+  </div>
+    <div id="wm-capinfo" style="border-top:1px solid #777;display:none; overflow: hidden">
+                    <div id="wm-capinfo-collected-by">
+    <div style="background-color:#666;color:#fff;font-weight:bold;text-align:center">COLLECTED BY</div>
+    <div style="padding:3px;position:relative" id="wm-collected-by-content">
+      <div style="display:inline-block;vertical-align:top;width:49%;">
+			<span class="c-logo" style="background-image:url(https://archive.org/services/img/save-page-now)"></span>
+		<div>Collection: <a style="color:#33f;" href="https://archive.org/details/save-page-now" target="_new"><span class="wm-title">Save Page Now</span></a></div>
+	      </div>
+    </div>
+    </div>
+    <div id="wm-capinfo-timestamps">
+    <div style="background-color:#666;color:#fff;font-weight:bold;text-align:center" title="Timestamps for the elements of this page">TIMESTAMPS</div>
+    <div>
+      <div id="wm-capresources" style="margin:0 5px 5px 5px;max-height:250px;overflow-y:scroll !important"></div>
+      <div id="wm-capresources-loading" style="text-align:left;margin:0 20px 5px 5px;display:none"><img src="/_static/images/loading.gif" alt="loading" /></div>
+    </div>
+    </div>
+  </div></div></div></div><div id="wm-ipp-print">The Wayback Machine - https://web.archive.org/web/20211025040431/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data</div>
+<div id="donato" style="position:relative;width:100%;">
+  <div id="donato-base">
+    <iframe id="donato-if" src="https://archive.org/includes/donate.php?as_page=1&amp;platform=wb&amp;referer=https%3A//web.archive.org/web/20211025040431/https%3A//www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data"
+	    scrolling="no" frameborder="0" style="width:100%; height:100%">
+    </iframe>
+  </div>
+</div><script type="text/javascript">
+__wm.bt(650,27,25,2,"web","https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data","20211025040431",1996,"/_static/",["/_static/css/banner-styles.css?v=omkqRugM","/_static/css/iconochive.css?v=qtvMKcIJ"], "False");
+  __wm.rw(1);
+</script>
+<!-- END WAYBACK TOOLBAR INSERT -->
+<!--googleoff: all-->
+  <div id="skip-link">
+    <a href="#skip-content" id="skipper" class="element-invisible element-focusable">Skip to main content</a>
+  </div>
+    <div id="page">
+  <header id="navbar" role="banner" class="navbar container navbar-default">
+          <ul class="menu nav navbar-nav secondary"><li class="first leaf jobs depth-1"><a href="https://web.archive.org/web/20211025040431/https://careers.health.govt.nz/" title="">Jobs</a></li>
+<li class="leaf news depth-1"><a href="/web/20211025040431/https://www.health.govt.nz/news-media" data-is-top-level="0" title="">News</a></li>
+<li class="leaf contact-us depth-1"><a href="/web/20211025040431/https://www.health.govt.nz/about-ministry/contact-us" title="">Contact us</a></li>
+<li class="leaf facebook depth-1"><a href="https://web.archive.org/web/20211025040431/https://www.facebook.com/minhealthnz/">Facebook</a></li>
+<li class="leaf twitter depth-1"><a href="https://web.archive.org/web/20211025040431/https://twitter.com/minhealthnz" data-is-top-level="0" title="">Twitter</a></li>
+<li class="last leaf youtube depth-1"><a href="https://web.archive.org/web/20211025040431/https://www.youtube.com/user/minhealthnz" data-is-top-level="0" title="">Youtube</a></li>
+</ul>        <div class="container">
+      <div class="navbar-header">
+                <a class="logo navbar-btn pull-left" href="/web/20211025040431/https://www.health.govt.nz/" title="Home">
+          <img src="/web/20211025040431im_/https://www.health.govt.nz/sites/all/themes/mohpub_bootstrap/images/mohlogo.svg" alt="Ministry of Health"/>
+        </a>
+                  <div class="region region-header-top">
+    <section id="block-apachesolr-panels-search-form" class="block block-apachesolr-panels clearfix">
+
+
+  <form action="/web/20211025040431/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" method="post" id="apachesolr-panels-search-block" accept-charset="UTF-8"><div><div class="form-item form-item-apachesolr-panels-search-form form-type-textfield form-group"> <label class="control-label" for="edit-apachesolr-panels-search-form">Search</label>
+<input title="Enter the terms you wish to search for." class="form-control form-text" type="text" id="edit-apachesolr-panels-search-form" name="apachesolr_panels_search_form" value="" size="15" maxlength="128"/></div><input type="hidden" name="form_build_id" value="form-3aRusWe4SrM5BLRwY0TqNf825KoUQz6d7LRCgP4obXY"/>
+<input type="hidden" name="form_id" value="apachesolr_panels_search_block"/>
+<div class="form-actions form-wrapper form-group" id="edit-actions"><button type="submit" id="edit-submit" name="op" value="Search" class="btn btn-primary form-submit">Search</button>
+</div></div></form>
+</section>
+  </div>
+        <!-- .btn-navbar is used as the toggle for collapsed navbar content -->
+        <button aria-expanded="false" aria-controls="megamenu" type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+                    <span class="menu-text">Menu</span><span class="sr-only">Toggle navigation</span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+
+        </button>
+      </div>
+
+              <div class="navbar-collapse collapse">
+          <nav id="megamenu" role="navigation">
+                          <h2 class="element-invisible">Main menu</h2><ul id="main-menu" class="menu nav navbar-nav yamm navbar"><li class="first dropdown"><a href="/web/20211025040431/https://www.health.govt.nz/your-health" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="megamenu-dropdown-780">Your health <b class="caret"></b></a>
+    <div id="megamenu-dropdown-780" class="dropdown-menu">
+    <div class="yamm-content">
+      <div class="row">
+                            <div class="col">
+            <h3><a href="/web/20211025040431/https://www.health.govt.nz/your-health/conditions-and-treatments?mega=Your%20health&amp;title=Conditions%20%26%20treatments" class="menu-header">Conditions &amp; treatments</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211025040431/https://www.health.govt.nz/your-health/conditions-and-treatments/mental-health/depression?mega=Your%20health&amp;title=Depression">Depression</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/diabetes?mega=Your%20health&amp;title=Diabetes">Diabetes</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/influenza?mega=Your%20health&amp;title=Influenza">Influenza</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/measles?mega=Your%20health&amp;title=Measles">Measles</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/meningococcal-disease-including-meningitis?mega=Your%20health&amp;title=Meningococcal%20disease">Meningococcal disease</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/mumps?mega=Your%20health&amp;title=Mumps">Mumps</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/respiratory-syncytial-virus-rsv?mega=Your%20health&amp;title=RSV">RSV</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/sore-throat?mega=Your%20health&amp;title=Sore%20throat">Sore throat</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/your-health/conditions-and-treatments?mega=Your%20health&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211025040431/https://www.health.govt.nz/your-health/healthy-living?mega=Your%20health&amp;title=Healthy%20living" class="menu-header">Healthy living</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211025040431/https://www.health.govt.nz/your-health/healthy-living/drinking-water?mega=Your%20health&amp;title=Drinking-water">Drinking-water</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/your-health/healthy-living/food-activity-and-sleep/green-prescriptions?mega=Your%20health&amp;title=Green%20Prescriptions">Green Prescriptions</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/your-health/healthy-living/food-activity-and-sleep/healthy-eating?mega=Your%20health&amp;title=Healthy%20eating">Healthy eating</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/your-health/healthy-living/immunisation?mega=Your%20health&amp;title=Immunisation">Immunisation</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/your-health/healthy-living/food-activity-and-sleep/physical-activity?mega=Your%20health&amp;title=Physical%20activity">Physical activity</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/your-health/healthy-living/addictions/quitting-smoking?mega=Your%20health&amp;title=Smoking">Smoking</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/your-health/healthy-living/teeth-and-gums?mega=Your%20health&amp;title=Teeth%20and%20gums">Teeth and gums</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/your-health/healthy-living?mega=Your%20health&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211025040431/https://www.health.govt.nz/your-health/pregnancy-and-kids?mega=Your%20health&amp;title=Pregnancy%20and%20kids" class="menu-header">Pregnancy and kids</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211025040431/https://www.health.govt.nz/your-health/pregnancy-and-kids/birth-and-afterwards?mega=Your%20health&amp;title=Birth%20and%20afterwards">Birth and afterwards</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/your-health/pregnancy-and-kids/first-year/helpful-advice-during-first-year/breastfeeding-perfect-you-and-your-baby?mega=Your%20health&amp;title=Breastfeeding">Breastfeeding</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/your-health/pregnancy-and-kids/pregnancy?mega=Your%20health&amp;title=Pregnancy">Pregnancy</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/your-health/pregnancy-and-kids/services-and-support-during-pregnancy?mega=Your%20health&amp;title=Services%20and%20support%20during%20pregnancy">Services and support during pregnancy</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/your-health/pregnancy-and-kids/services-and-support-you-and-your-child?mega=Your%20health&amp;title=Services%20and%20support%20for%20you%20and%20your%20child">Services and support for you and your child</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/your-health/pregnancy-and-kids/first-year?mega=Your%20health&amp;title=The%20first%20year">The first year</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/your-health/pregnancy-and-kids/under-fives?mega=Your%20health&amp;title=Under%20fives">Under fives</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/your-health/pregnancy-and-kids?mega=Your%20health&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211025040431/https://www.health.govt.nz/your-health/services-and-support?mega=Your%20health&amp;title=Services%20and%20support" class="menu-header">Services &amp; support</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211025040431/https://www.health.govt.nz/your-health/services-and-support/health-care-services/help-alcohol-and-drug-problems?mega=Your%20health&amp;title=Alcohol%20and%20drugs">Alcohol and drugs</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/your-health/services-and-support/disability-services?mega=Your%20health&amp;title=Disability%20services">Disability services</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/your-health/services-and-support/health-care-services/earthquake-support-line?mega=Your%20health&amp;title=Earthquake%20Support%20Line">Earthquake Support Line</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/your-health/services-and-support/health-care-services/healthline?mega=Your%20health&amp;title=Healthline">Healthline</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/your-health/services-and-support/health-care-services/mental-health-services?mega=Your%20health&amp;title=Mental%20health%20services">Mental health services</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/your-health/services-and-support/health-care-services/maori-health-provider-directory?mega=Your%20health&amp;title=M%C4%81ori%20health%20providers">Māori health providers</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/your-health/services-and-support/health-care-services/services-older-people/rest-home-certification-and-audits?mega=Your%20health&amp;title=Rest%20home%20certification">Rest home certification</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/your-health/services-and-support/health-care-services/hospitals-and-specialist-services/travel-assistance?mega=Your%20health&amp;title=Travel%20assistance">Travel assistance</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/your-health/services-and-support?mega=Your%20health&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                        </div>
+    </div>
+    <div class="feature-links">
+      <h3 class="sr-only">Other related resources</h3>
+      <a href="/web/20211025040431/https://www.health.govt.nz/your-health/full-a-z?mega=Your%20health&amp;title=A-Z">View the full A-Z</a>    </div>
+  </div>
+</li>
+<li class="dropdown"><a href="/web/20211025040431/https://www.health.govt.nz/new-zealand-health-system" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="megamenu-dropdown-6076">NZ health system <b class="caret"></b></a>
+    <div id="megamenu-dropdown-6076" class="dropdown-menu">
+    <div class="yamm-content">
+      <div class="row">
+                            <div class="col">
+            <h3><a href="/web/20211025040431/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people?mega=NZ%20health%20system&amp;title=Key%20organisations" class="menu-header">Key organisations</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211025040431/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/crown-entities-and-statutory-boards?mega=NZ%20health%20system&amp;title=Crown%20entities%20%26%20agencies">Crown entities &amp; agencies</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/district-health-boards?mega=NZ%20health%20system&amp;title=District%20health%20boards">District health boards</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/non-governmental-organisations?mega=NZ%20health%20system&amp;title=Non-governmental%20organisations">Non-governmental organisations</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/primary-health-organisations?mega=NZ%20health%20system&amp;title=Primary%20health%20organisations">Primary health organisations</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/public-health-units?mega=NZ%20health%20system&amp;title=Public%20health%20units">Public health units</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people?mega=NZ%20health%20system&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211025040431/https://www.health.govt.nz/new-zealand-health-system/health-system-indicators-framework?mega=NZ%20health%20system&amp;title=Health%20System%20Indicators%20framework" class="menu-header">Health System Indicators framework</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211025040431/https://www.health.govt.nz/new-zealand-health-system/health-system-indicators-framework?mega=NZ%20health%20system&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211025040431/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services?mega=NZ%20health%20system&amp;title=Eligibility%20for%20public%20health%20services" class="menu-header">Eligibility for public health services</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211025040431/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services/guide-eligibility-publicly-funded-health-services?mega=NZ%20health%20system&amp;title=Guide%20to%20eligibility">Guide to eligibility</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services/eligibility-questions-and-answers-consumers?mega=NZ%20health%20system&amp;title=Q%26A%20for%20consumers">Q&amp;A for consumers</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services/eligibility-questions-and-answers-service-providers?mega=NZ%20health%20system&amp;title=Q%26A%20for%20service%20providers">Q&amp;A for service providers</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services/reciprocal-health-agreements?mega=NZ%20health%20system&amp;title=Reciprocal%20health%20agreements">Reciprocal health agreements</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services?mega=NZ%20health%20system&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211025040431/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements?mega=NZ%20health%20system&amp;title=Claims%2C%20provider%20payments%20and%20entitlements" class="menu-header">Claims &amp; provider payments</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211025040431/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/carer-support-claims?mega=NZ%20health%20system&amp;title=Carer%20Support">Carer Support</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/high-use-health-card-payments?mega=NZ%20health%20system&amp;title=High%20Use%20Health%20Card%20payments">High Use Health Card payments</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/between-travel-settlement?mega=NZ%20health%20system&amp;title=In-Between%20Travel%20Settlement">In-Between Travel Settlement</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/maternity-claim-forms?mega=NZ%20health%20system&amp;title=Maternity%20claim%20forms">Maternity claim forms</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/national-travel-assistance?mega=NZ%20health%20system&amp;title=National%20travel%20assistance%20claims">National travel assistance claims</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements?mega=NZ%20health%20system&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                        </div>
+    </div>
+    <div class="feature-links">
+      <h3 class="sr-only">Other related resources</h3>
+      <a href="/web/20211025040431/https://www.health.govt.nz/new-zealand-health-system/overview-health-system?mega=NZ%20health%20system&amp;title=Overview">Overview of the health system</a>  <a href="/web/20211025040431/https://www.health.govt.nz/new-zealand-health-system/my-dhb?mega=NZ%20health%20system&amp;title=Mydhb">My DHB</a> <a href="/web/20211025040431/https://www.health.govt.nz/new-zealand-health-system/system-level-measures-framework?mega=NZ%20health%20system&amp;title=SLM">System level measures</a>  <a href="/web/20211025040431/https://www.health.govt.nz/publication/new-zealand-health-strategy-2016?mega=NZ%20health%20system&amp;title=HealthStrategy">NZ Health Strategy</a>    </div>
+  </div>
+</li>
+<li class="dropdown"><a href="/web/20211025040431/https://www.health.govt.nz/our-work" class="dropdown-toggle active-trail" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="megamenu-dropdown-776">Our work <b class="caret"></b></a>
+  <div id="megamenu-dropdown-776" class="dropdown-menu">
+    <div class="yamm-content">
+      <div class="row">
+                            <ul class="col list-unstyled no-menu-header">
+                                                                                <li>
+                <a href="/web/20211025040431/https://www.health.govt.nz/our-work/diseases-and-conditions/antimicrobial-resistance?mega=Our%20work&amp;title=Antimicrobial%20resistance" class="menu-header">Antimicrobial resistance</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211025040431/https://www.health.govt.nz/our-work/populations/asian-and-migrant-health?mega=Our%20work&amp;title=Asian%20and%20migrant%20health" class="menu-header">Asian and migrant health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211025040431/https://www.health.govt.nz/our-work/border-health?mega=Our%20work&amp;title=Border%20health" class="menu-header">Border health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211025040431/https://www.health.govt.nz/our-work/life-stages/breastfeeding?mega=Our%20work&amp;title=Breastfeeding" class="menu-header">Breastfeeding</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211025040431/https://www.health.govt.nz/our-work/diseases-and-conditions/cancer?mega=Our%20work&amp;title=Cancer" class="menu-header">Cancer</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211025040431/https://www.health.govt.nz/our-work/regulation-health-and-disability-system/certification-health-care-services?mega=Our%20work&amp;title=Certification%20of%20health%20care%20services" class="menu-header">Certification of health care services</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211025040431/https://www.health.govt.nz/our-work/life-stages/child-health?mega=Our%20work&amp;title=Child%20health" class="menu-header">Child health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211025040431/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus?mega=Our%20work&amp;title=COVID-19" class="menu-header">COVID-19 (novel coronavirus)</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211025040431/https://www.health.govt.nz/our-work/diseases-and-conditions/diabetes?mega=Our%20work&amp;title=Diabetes" class="menu-header">Diabetes</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211025040431/https://www.health.govt.nz/our-work/digital-health?mega=Our%20work&amp;title=Digital%20health" class="menu-header">Digital health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211025040431/https://www.health.govt.nz/our-work/disability-services?mega=Our%20work&amp;title=Disability%20services" class="menu-header">Disability services</a>                              </li>
+                                                                </ul>
+                            <ul class="col list-unstyled no-menu-header">
+                                                                                <li>
+                <a href="/web/20211025040431/https://www.health.govt.nz/our-work/diseases-and-conditions?mega=Our%20work&amp;title=Diseases%20and%20conditions" class="menu-header">Diseases and conditions</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211025040431/https://www.health.govt.nz/our-work/hospitals-and-specialist-care/emergency-departments?mega=Our%20work&amp;title=Emergency%20departments" class="menu-header">Emergency departments</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211025040431/https://www.health.govt.nz/our-work/emergency-management?mega=Our%20work&amp;title=Emergency%20management" class="menu-header">Emergency management</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211025040431/https://www.health.govt.nz/our-work/environmental-health?mega=Our%20work&amp;title=Environmental%20health" class="menu-header">Environmental health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211025040431/https://www.health.govt.nz/our-work/preventative-health-wellness/family-violence?mega=Our%20work&amp;title=Family%20violence" class="menu-header">Family violence</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211025040431/https://www.health.govt.nz/our-work/preventative-health-wellness/fluoride-and-oral-health?mega=Our%20work&amp;title=Fluoride%20and%20oral%20health" class="menu-header">Fluoride and oral health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211025040431/https://www.health.govt.nz/our-work/health-identity?mega=Our%20work&amp;title=Health%20identity" class="menu-header">Health identity</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211025040431/https://www.health.govt.nz/our-work/digital-health/digital-health-sector-architecture-standards-and-governance/health-information-standards-0?mega=Our%20work&amp;title=Health%20information%20standards" class="menu-header">Health information standards</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211025040431/https://www.health.govt.nz/our-work/life-stages/health-older-people?mega=Our%20work&amp;title=Health%20of%20older%20people" class="menu-header">Health of older people</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211025040431/https://www.health.govt.nz/our-work/health-workforce?mega=Our%20work&amp;title=Health%20workforce" class="menu-header">Health workforce</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211025040431/https://www.health.govt.nz/our-work/hospitals-and-specialist-care?mega=Our%20work&amp;title=Hospitals%20and%20specialist%20care" class="menu-header">Hospitals and specialist care</a>                              </li>
+                                                                </ul>
+                            <ul class="col list-unstyled no-menu-header">
+                                                                                <li>
+                <a href="/web/20211025040431/https://www.health.govt.nz/our-work/preventative-health-wellness/immunisation?mega=Our%20work&amp;title=Immunisation" class="menu-header">Immunisation</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211025040431/https://www.health.govt.nz/our-work/ionising-radiation-safety?mega=Our%20work&amp;title=Ionising%20radiation%20safety" class="menu-header">Ionising radiation safety</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211025040431/https://www.health.govt.nz/our-work/populations/maori-health?mega=Our%20work&amp;title=M%C4%81ori%20health" class="menu-header">Māori health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211025040431/https://www.health.govt.nz/our-work/life-stages/maternity-services?mega=Our%20work&amp;title=Maternity" class="menu-header">Maternity</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211025040431/https://www.health.govt.nz/our-work/regulation-health-and-disability-system/medicinal-cannabis-agency?mega=Our%20work&amp;title=Medicinal%20Cannabis%20Agency" class="menu-header">Medicinal cannabis</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211025040431/https://www.health.govt.nz/our-work/regulation-health-and-disability-system/medicines-control?mega=Our%20work&amp;title=Medicines%20control" class="menu-header">Medicines control</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211025040431/https://www.health.govt.nz/our-work/mental-health-and-addiction?mega=Our%20work&amp;title=Mental%20health%20and%20addiction" class="menu-header">Mental health and addiction</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211025040431/https://www.health.govt.nz/our-work/nursing?mega=Our%20work&amp;title=Nursing" class="menu-header">Nursing</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211025040431/https://www.health.govt.nz/our-work/preventative-health-wellness/nutrition?mega=Our%20work&amp;title=Nutrition" class="menu-header">Nutrition</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211025040431/https://www.health.govt.nz/our-work/preventative-health-wellness/oral-health?mega=Our%20work&amp;title=Oral%20health" class="menu-header">Oral health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211025040431/https://www.health.govt.nz/our-work/hospitals-and-specialist-care/organ-donation-and-transplantation?mega=Our%20work&amp;title=Organ%20donation%20and%20transplantation" class="menu-header">Organ donation and transplantation</a>                              </li>
+                                                                </ul>
+                            <ul class="col list-unstyled no-menu-header">
+                                                                                <li>
+                <a href="/web/20211025040431/https://www.health.govt.nz/our-work/populations/pacific-health?mega=Our%20work&amp;title=Pacific%20health" class="menu-header">Pacific health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211025040431/https://www.health.govt.nz/new-zealand-health-system/pay-equity-settlements?mega=Our%20work&amp;title=Pay%20equity%20settlements" class="menu-header">Pay equity</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211025040431/https://www.health.govt.nz/our-work/preventative-health-wellness/physical-activity?mega=Our%20work&amp;title=Physical%20activity" class="menu-header">Physical activity</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211025040431/https://www.health.govt.nz/our-work/hospitals-and-specialist-care/planned-care-services?mega=Our%20work&amp;title=Planned%20Care%20services" class="menu-header">Planned Care services</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211025040431/https://www.health.govt.nz/our-work/preventative-health-wellness?mega=Our%20work&amp;title=Preventative%20health/wellness" class="menu-header">Preventative health/wellness</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211025040431/https://www.health.govt.nz/our-work/primary-health-care?mega=Our%20work&amp;title=Primary%20health%20care" class="menu-header">Primary health care</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211025040431/https://www.health.govt.nz/our-work/public-health-workforce-development?mega=Our%20work&amp;title=Public%20health%20workforce%20development" class="menu-header">Public health workforce</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211025040431/https://www.health.govt.nz/our-work/regulation-health-and-disability-system?mega=Our%20work&amp;title=Regulation" class="menu-header">Regulation</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211025040431/https://www.health.govt.nz/our-work/preventative-health-wellness/tobacco-control?mega=Our%20work&amp;title=Tobacco%20control" class="menu-header">Tobacco control</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211025040431/https://www.health.govt.nz/our-work/regulation-health-and-disability-system/regulation-vaping-and-smokeless-tobacco-products?mega=Our%20work&amp;title=Vaping%20and%20smokeless%20tobacco%20products" class="menu-header">Vaping &amp; smokeless tobacco</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211025040431/https://www.health.govt.nz/our-work/who-code-nz?mega=Our%20work&amp;title=WHO%20Code%20in%20NZ" class="menu-header">WHO Code in NZ</a>                              </li>
+                      </ul>
+              </div>
+    </div>
+    <div class="feature-links">
+      <a href="/web/20211025040431/https://www.health.govt.nz/our-work?mega=Our%20work&amp;title=A-Z">View the full A-Z</a>    </div>
+  </div>
+</li>
+<li class="dropdown"><a href="/web/20211025040431/https://www.health.govt.nz/nz-health-statistics" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="megamenu-dropdown-778">Health statistics <b class="caret"></b></a>
+    <div id="megamenu-dropdown-778" class="dropdown-menu">
+    <div class="yamm-content">
+      <div class="row">
+                            <div class="col">
+            <h3><a href="/web/20211025040431/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets?mega=Health%20statistics&amp;title=Health%20statistics%20and%20data%20sets" class="menu-header">Statistics by topic</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211025040431/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/cancer-data-and-stats?mega=Health%20statistics&amp;title=Cancer">Cancer</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/diabetes-data-and-stats?mega=Health%20statistics&amp;title=Diabetes">Diabetes</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/mental-health-data-and-stats?mega=Health%20statistics&amp;title=Mental%20health">Mental health</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/maori-health-data-and-stats?mega=Health%20statistics&amp;title=M%C4%81ori%20health">Māori health</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/obesity-statistics?mega=Health%20statistics&amp;title=Obesity">Obesity</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/suicide-data-and-stats?mega=Health%20statistics&amp;title=Suicide">Suicide</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/tobacco-data-and-stats?mega=Health%20statistics&amp;title=Tobacco">Tobacco</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets?mega=Health%20statistics&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211025040431/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys?mega=Health%20statistics&amp;title=National%20collections%20and%20surveys" class="menu-header">About our surveys &amp; data collections</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211025040431/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/surveys/past-surveys/alcohol-and-drug-use-survey?mega=Health%20statistics&amp;title=Alcohol%20%26%20Drug%20Use%20Survey">Alcohol &amp; Drug Use Survey</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/national-collections-annual-maintenance-project?mega=Health%20statistics&amp;title=NCAMP">NCAMP</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/collections/new-zealand-cancer-registry-nzcr?mega=Health%20statistics&amp;title=NZ%20Cancer%20Registry">NZ Cancer Registry</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/surveys/new-zealand-health-survey?mega=Health%20statistics&amp;title=NZ%20Health%20Survey">NZ Health Survey</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/surveys/past-surveys/nutrition-survey?mega=Health%20statistics&amp;title=Nutrition%20Survey">Nutrition Survey</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/collections/primhd-mental-health-data?mega=Health%20statistics&amp;title=PRIMHD">PRIMHD</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys?mega=Health%20statistics&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211025040431/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology?mega=Health%20statistics&amp;title=Classification%20and%20Terminology" class="menu-header">Classification &amp; terminology</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211025040431/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology/using-icd-10-am-achi-acs/coding-queries/coding-query-database?mega=Health%20statistics&amp;title=Coding%20query%20database">Coding query database</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology/using-icd-10-am-achi-acs/courses-clinical-coding?mega=Health%20statistics&amp;title=Courses%20on%20clinical%20coding">Courses on clinical coding</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology/new-zealand-snomed-ct-national-release-centre?mega=Health%20statistics&amp;title=SNOMED%20CT">SNOMED CT</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology/using-icd-10-am-achi-acs?mega=Health%20statistics&amp;title=Using%20ICD-10-AM/ACHI/ACS">Using ICD-10-AM/ACHI/ACS</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology?mega=Health%20statistics&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211025040431/https://www.health.govt.nz/nz-health-statistics/data-references?mega=Health%20statistics&amp;title=Data%20references" class="menu-header">Data references</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211025040431/https://www.health.govt.nz/nz-health-statistics/data-references/code-tables?mega=Health%20statistics&amp;title=Code%20tables">Code tables</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/nz-health-statistics/data-references/data-dictionaries?mega=Health%20statistics&amp;title=Data%20dictionaries">Data dictionaries</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/nz-health-statistics/data-references/diagnosis-related-groups?mega=Health%20statistics&amp;title=Diagnosis-related%20groups">Diagnosis-related groups</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/nz-health-statistics/data-references/code-tables/common-code-tables/domicile-code-table?mega=Health%20statistics&amp;title=Domicile%20code%20table">Domicile code table</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/nz-health-statistics/data-references/mapping-tools?mega=Health%20statistics&amp;title=ICD%20mapping%20tools">ICD mapping tools</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/nz-health-statistics/data-references/weighted-inlier-equivalent-separations?mega=Health%20statistics&amp;title=Weighted%20Inlier%20Equivalent%20Separations">Weighted Inlier Equivalent Separations</a></li>
+                                  <li><a href="/web/20211025040431/https://www.health.govt.nz/nz-health-statistics/data-references?mega=Health%20statistics&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                        </div>
+    </div>
+    <div class="feature-links">
+      <h3 class="sr-only">Other related resources</h3>
+      <a href="/web/20211025040431/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/tier-1-health-statistics-release-calendar?mega=Health%20statistics&amp;title=Tier%201%20calendar">Release calendar for our Tier 1 statistics</a> <a href="/web/20211025040431/https://www.health.govt.nz/nz-health-statistics/about-data-collection?mega=Health%20statistics&amp;title=Enquiries">Data and survey enquiries</a>    </div>
+  </div>
+</li>
+<li class=""><a href="/web/20211025040431/https://www.health.govt.nz/publications" aria-haspopup="false">Publications</a></li>
+<li class=""><a href="/web/20211025040431/https://www.health.govt.nz/about-ministry" aria-haspopup="false">About us</a></li>
+<li class="visible-xs"><a href="/web/20211025040431/https://www.health.govt.nz/contactus" aria-haspopup="false">Contact us</a></li>
+</ul>
+                                  </nav>
+        </div>
+          </div>
+  </header>
+
+  <div class="main-container container">
+    <!-- announcement -->
+        <!-- /announcement -->
+
+    <header role="banner" id="page-header">
+
+          </header> <!-- /#page-header -->
+
+    <div class="row">
+
+      <section class="col-sm-12">
+                        <a id="main-content"></a>
+                                                                            <div class="breadcrumbs">
+            <ul><li><a href="/web/20211025040431/https://www.health.govt.nz/">Home</a></li><li><a href="/web/20211025040431/https://www.health.govt.nz/our-work">Our work</a></li><li><a href="/web/20211025040431/https://www.health.govt.nz/our-work/diseases-and-conditions">Diseases and conditions</a></li><li><a href="/web/20211025040431/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished" data-is-top-level="1" title="">COVID-19</a></li><li><a href="/web/20211025040431/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics" class="menu-node-unpublished menu-node-unpublished">Data and statistics</a></li><li><span class="current-breadcrumb">Vaccine data</span></li></ul>          </div>
+
+
+
+          <div class="region region-content">
+    <section id="block-system-main" class="block block-system clearfix">
+
+
+  <div class="bootstrap-threecol-stacked">
+
+      <div class="row"> <!-- @TODO: Add extra classes -->
+      <div class="panel-panel left col-xs-12 col-md-3 col-lg-3"><div class="panel-pane pane-block pane-menu-block-1 odd pane-top-link">
+
+        <span class="top-link"><a href="/web/20211025040431/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished active-trail" data-is-top-level="1">COVID-19</a></span>
+
+
+  <div class="pane-content">
+        <div class="menu-block-wrapper menu-block-1 menu-name-main-menu parent-mlid-1445 menu-level-2">
+  <ul class="menu nav"><li class="first collapsed menu-mlid-10163 health-advice depth-4"><a href="/web/20211025040431/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-health-advice-public" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished">Health advice</a></li>
+<li class="collapsed menu-mlid-10630 covid-19-vaccines- depth-4 section-overview hide-children"><a href="/web/20211025040431/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-vaccines" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished" data-is-top-level="1" title="">COVID-19 vaccines </a></li>
+<li class="collapsed menu-mlid-9997 health-professionals depth-4"><a href="/web/20211025040431/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-information-health-professionals" class="menu-node-unpublished menu-node-unpublished">Health professionals</a></li>
+<li class="collapsed menu-mlid-10019 specific-audiences depth-4"><a href="/web/20211025040431/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-information-specific-audiences" class="menu-node-unpublished">Specific audiences</a></li>
+<li class="expanded active-trail menu-mlid-10096 data-and-statistics depth-4"><a href="/web/20211025040431/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics" class="menu-node-unpublished menu-node-unpublished active-trail">Data and statistics</a><ul class="menu nav"><li class="first leaf menu-mlid-10062 current-cases depth-5 same-level-as-node"><a href="/web/20211025040431/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-current-cases" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Current cases</a></li>
+<li class="leaf menu-mlid-10146 case-demographics depth-5 same-level-as-node"><a href="/web/20211025040431/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-case-demographics">Case demographics</a></li>
+<li class="leaf menu-mlid-10097 source-of-cases depth-5 same-level-as-node"><a href="/web/20211025040431/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-source-cases" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Source of cases</a></li>
+<li class="leaf menu-mlid-10119 testing-for-covid-19 depth-5 same-level-as-node"><a href="/web/20211025040431/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/testing-covid-19" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Testing for COVID-19</a></li>
+<li class="leaf menu-mlid-10371 nz-covid-tracer-app-data depth-5 same-level-as-node"><a href="/web/20211025040431/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-nz-covid-tracer-app-data" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">NZ COVID Tracer app data</a></li>
+<li class="expanded active-trail active menu-mlid-10584 active vaccine-data depth-5 same-level-as-node"><a href="/web/20211025040431/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished active-trail active">Vaccine data</a><ul class="menu nav"><li class="first leaf menu-mlid-10867 covid-19-vaccination-uptake-rates-across-nz depth-6"><a href="/web/20211025040431/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-across-nz" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">COVID-19 Vaccination uptake rates across NZ</a></li>
+<li class="leaf menu-mlid-10868 covid-19-vaccination-uptake-rates---māori depth-6"><a href="/web/20211025040431/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-maori-communities-across-nz" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">COVID-19 Vaccination uptake rates - Māori</a></li>
+<li class="last leaf menu-mlid-10869 covid-19-vaccination-uptake-rates---pacific depth-6"><a href="/web/20211025040431/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-pacific-communities-across-nz" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">COVID-19 Vaccination uptake rates - Pacific</a></li>
+</ul></li>
+<li class="last leaf menu-mlid-10404 data-resources depth-5 same-level-as-node"><a href="/web/20211025040431/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-data-resources" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Data resources</a></li>
+</ul></li>
+<li class="collapsed menu-mlid-10369 response-planning depth-4"><a href="/web/20211025040431/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-response-planning" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Response planning</a></li>
+<li class="collapsed menu-mlid-10015 resources-and-tools depth-4"><a href="/web/20211025040431/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-resources-and-tools" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Resources and tools</a></li>
+<li class="last leaf menu-mlid-10004 news-and-media depth-4 section-overview hide-children"><a href="/web/20211025040431/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-news-and-media-updates" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">News and media</a></li>
+</ul></div>
+  </div>
+
+
+  </div>
+</div>      <div class="panel-panel middle col-xs-12 col-md-9 col-lg-9"><div class="panel-pane pane-page-title even">
+
+
+
+  <div class="pane-content">
+    <span id="skip-content" tabindex="-1"></span>    <h1>COVID-19: Vaccine data</h1>
+  </div>
+
+
+  </div>
+<div class="panel-pane pane-node-content odd">
+
+
+
+  <div class="pane-content">
+        <article id="node-12052" class="node node-page node-sticky view-mode-full clearfix" about="/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" typeof="sioc:Item foaf:Document">
+    <header>
+            <span property="dc:title" content="COVID-19: Vaccine data" class="rdf-meta element-hidden"></span>      </header>
+    <div class="field field-name-field-intro-text field-type-text-long field-label-hidden"><div class="field-items"><div class="field-item even"><p class="intro-text">Data and statistics about the rollout of COVID-19 vaccines in New Zealand.</p></div></div></div><div class="field field-name-body field-type-text-with-summary field-label-hidden"><div class="field-items"><div class="field-item even" property="content:encoded"><p>On this page:</p>
+
+<ul>
+	<li><a href="#daily">Daily updates</a>
+
+	<ul>
+		<li><a href="#total-vaccinations">Total vaccinations</a></li>
+		<li><a href="#ethnicity">Vaccinations by ethnicity</a></li>
+	</ul>
+	</li>
+	<li><a href="#weekly-updates">Weekly updates</a>
+	<ul>
+		<li><a href="#model">Vaccinations against plan</a></li>
+		<li><a href="#uptake">Vaccinations uptake</a></li>
+		<li><a href="#by-day">Vaccinations by day</a></li>
+		<li><a href="#location">Vaccinations by DHB</a></li>
+		<li><a href="#group">Vaccinations by group</a></li>
+		<li><a href="#by_soh">Stock on hand</a></li>
+		<li><a href="#age">Vaccinations by age</a></li>
+		<li><a href="#workforce">Trained vaccinator and active vaccinator</a></li>
+		<li><a href="#group">Vaccinations by group</a></li>
+		<li><a href="#download">Details of vaccination&nbsp;data</a></li>
+	</ul>
+	</li>
+	<li><a href="#adverse-events">Adverse events from immunisations</a></li>
+</ul>
+
+<hr/><!--daily-->
+<h2><a id="daily" name="daily"></a>COVID-19 vaccinations: daily updates</h2>
+
+<div class="well well-sm">
+<p style="margin-top: 0"><strong>Data in this section is as at 11:59pm 24 October 2021 and is updated daily.</strong></p>
+</div>
+
+<h3><a id="total-vaccinations" name="total-vaccinations"></a>Total Vaccinations</h3>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">&nbsp;</th>
+			<th scope="col" style="text-align:right">Vaccinations yesterday</th>
+			<th scope="col" style="text-align:right">Cumulative total</th>
+			<th scope="col" style="text-align:right">Eligible population vaccinated %</th>
+			<th scope="col" style="text-align:right">Total population vaccinated %</th>
+			<th scope="col" style="text-align:right">Vaccinated or booked</th>
+			<th scope="col" style="text-align:right">Eligible vaccinated or booked %</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">First dose</th>
+			<td style="text-align:right">5,335</td>
+			<td style="text-align:right">3,643,337</td>
+			<td style="text-align:right">87%</td>
+			<td style="text-align:right">73%</td>
+			<td style="text-align:right">3,663,057</td>
+			<td style="text-align:right">87%</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Second dose</th>
+			<td style="text-align:right">13,650</td>
+			<td style="text-align:right">2,980,163</td>
+			<td style="text-align:right">71%</td>
+			<td style="text-align:right">60%</td>
+			<td style="text-align:right">3,324,588</td>
+			<td style="text-align:right">79%</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total doses</strong></th>
+			<td style="text-align:right"><strong>18,985</strong></td>
+			<td style="text-align:right"><strong>6,623,500</strong></td>
+		</tr>
+	</tbody>
+</table>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Total vaccinations" class="img-responsive" height="118" src="/web/20211025040431im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/uptake_summary-251021.png" width="699"/></figure>
+
+<h5>Definitions</h5>
+
+<ul>
+	<li><strong>Cumulative total:</strong>&nbsp;All vaccinations that have been administered and entered into the COVID-19 Immunisation Register up until midnight of the night before the data is published.</li>
+	<li><strong>Eligible population vaccinated %:</strong>&nbsp;Vaccinations administered divided by HSU population estimates for the eligible population (12+).</li>
+	<li><strong>Total population vaccinated %:</strong>&nbsp;Vaccinations administered divided by HSU population estimates for the total population (0+).</li>
+	<li><strong>Vaccinated or booked:</strong>&nbsp;Count of individuals who have either received their vaccination or have booked via Book My Vaccine to receive a vaccination.</li>
+	<li><strong>Eligible vaccinated or booked %:</strong>&nbsp;Count of individuals who have either received their vaccination or have booked via Book My Vaccine to receive a vaccination divided by HSU population estimates for the eligible population (12+).</li>
+</ul>
+
+<p>HSU population estimates are available in the downloadable spreadsheet at the bottom of the page. Throughout the rest of this sheet doses per 1,000 are based on eligible (12+) population.</p>
+
+<p>Bookings are only counted if the site is using Book My Vaccine. Bookings made through other Patient Management Systems are not counted.</p>
+
+<hr/>
+<h3><a id="by_eth" name="ethnicity"></a>Cumulative vaccinations by ethnicity</h3>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">Ethnicity *</th>
+			<th scope="col" style="text-align:right">First dose administered</th>
+			<th scope="col" style="text-align:right">First doses per 1,000 people</th>
+			<th scope="col" style="text-align:right">Second dose administered</th>
+			<th scope="col" style="text-align:right">Second doses per 1,000 people</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">Māori</th>
+			<td style="text-align:right">393,632</td>
+			<td style="text-align:right">689</td>
+			<td style="text-align:right">276,650</td>
+			<td style="text-align:right">484</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Pacific Peoples</th>
+			<td style="text-align:right">237,699</td>
+			<td style="text-align:right">829</td>
+			<td style="text-align:right">184,346</td>
+			<td style="text-align:right">643</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Asian</th>
+			<td style="text-align:right">601,942</td>
+			<td style="text-align:right">&gt;950</td>
+			<td style="text-align:right">515,251</td>
+			<td style="text-align:right">861</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">European / Other</th>
+			<td style="text-align:right">2,376,596</td>
+			<td style="text-align:right">870</td>
+			<td style="text-align:right">1,977,199</td>
+			<td style="text-align:right">724</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Unknown</th>
+			<td style="text-align:right">33,468</td>
+			<td style="text-align:right">-</td>
+			<td style="text-align:right">26,717</td>
+			<td style="text-align:right">-</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total</strong></th>
+			<td style="text-align:right"><strong>3,643,337</strong></td>
+			<td style="text-align:right"><strong>866</strong></td>
+			<td style="text-align:right"><strong>2,980,163</strong></td>
+			<td style="text-align:right"><strong>708</strong></td>
+		</tr>
+	</tbody>
+</table>
+
+<p><strong>*</strong> The prioritised ethnicity classification system allocates each person to a single ethnic group, based on the ethnic groups they identify with. Where people identify with more than one group, they are assigned in this order of priority: Māori, Pacific Peoples, Asian, and European/Other. So, if a person identifies as being Māori and New Zealand European, the person is counted as Māori. See <a href="/web/20211025040431/https://www.health.govt.nz/publication/hiso-100012017-ethnicity-data-protocols">Ethnicity Data Protocols</a> for further information.</p>
+
+<p>Ethnicity breakdown by DHB of residence is available in the downloadable spreadsheet at the bottom of the page.</p>
+
+<hr/>
+<h3><a id="90pct" name="90pct"></a>Vaccinations to 90% by DHB</h3>
+
+<h4><a id="90pct all ethnicities" name="90pct all ethnicities"></a>All Ethnicities</h4>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">&nbsp;</th>
+			<th scope="col" style="text-align:right">First doses</th>
+			<th scope="col" style="text-align:right">First doses %</th>
+			<th scope="col" style="text-align:right">First doses to 90%</th>
+			<th scope="col" style="text-align:right">Second doses</th>
+			<th scope="col" style="text-align:right">Second doses %</th>
+			<th scope="col" style="text-align:right">Second doses to 90%</th>
+			<th scope="col" style="text-align:right">Population</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">Northland</th>
+			<td style="text-align:right">125,366</td>
+			<td style="text-align:right">78%</td>
+			<td style="text-align:right">19,822</td>
+			<td style="text-align:right">99,390</td>
+			<td style="text-align:right">62%</td>
+			<td style="text-align:right">45,798</td>
+			<td style="text-align:right">161,320</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waitemata</th>
+			<td style="text-align:right">474,876</td>
+			<td style="text-align:right">90%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">401,992</td>
+			<td style="text-align:right">76%</td>
+			<td style="text-align:right">71,486</td>
+			<td style="text-align:right">526,087</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Auckland</th>
+			<td style="text-align:right">394,775</td>
+			<td style="text-align:right">93%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">342,646</td>
+			<td style="text-align:right">81%</td>
+			<td style="text-align:right">38,916</td>
+			<td style="text-align:right">423,958</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Counties Manukau</th>
+			<td style="text-align:right">422,768</td>
+			<td style="text-align:right">88%</td>
+			<td style="text-align:right">11,728</td>
+			<td style="text-align:right">354,096</td>
+			<td style="text-align:right">73%</td>
+			<td style="text-align:right">80,400</td>
+			<td style="text-align:right">482,773</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waikato</th>
+			<td style="text-align:right">303,569</td>
+			<td style="text-align:right">85%</td>
+			<td style="text-align:right">17,889</td>
+			<td style="text-align:right">243,584</td>
+			<td style="text-align:right">68%</td>
+			<td style="text-align:right">77,874</td>
+			<td style="text-align:right">357,176</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Lakes</th>
+			<td style="text-align:right">74,339</td>
+			<td style="text-align:right">79%</td>
+			<td style="text-align:right">10,638</td>
+			<td style="text-align:right">58,126</td>
+			<td style="text-align:right">62%</td>
+			<td style="text-align:right">26,851</td>
+			<td style="text-align:right">94,419</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Bay of Plenty</th>
+			<td style="text-align:right">176,973</td>
+			<td style="text-align:right">82%</td>
+			<td style="text-align:right">18,274</td>
+			<td style="text-align:right">135,695</td>
+			<td style="text-align:right">63%</td>
+			<td style="text-align:right">59,552</td>
+			<td style="text-align:right">216,941</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Tairawhiti</th>
+			<td style="text-align:right">31,934</td>
+			<td style="text-align:right">76%</td>
+			<td style="text-align:right">5,834</td>
+			<td style="text-align:right">25,450</td>
+			<td style="text-align:right">61%</td>
+			<td style="text-align:right">12,318</td>
+			<td style="text-align:right">41,965</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Taranaki</th>
+			<td style="text-align:right">84,213</td>
+			<td style="text-align:right">82%</td>
+			<td style="text-align:right">7,719</td>
+			<td style="text-align:right">63,070</td>
+			<td style="text-align:right">62%</td>
+			<td style="text-align:right">28,862</td>
+			<td style="text-align:right">102,147</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hawkes Bay</th>
+			<td style="text-align:right">120,565</td>
+			<td style="text-align:right">83%</td>
+			<td style="text-align:right">10,449</td>
+			<td style="text-align:right">98,167</td>
+			<td style="text-align:right">67%</td>
+			<td style="text-align:right">32,847</td>
+			<td style="text-align:right">145,571</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">MidCentral</th>
+			<td style="text-align:right">128,938</td>
+			<td style="text-align:right">85%</td>
+			<td style="text-align:right">8,134</td>
+			<td style="text-align:right">104,765</td>
+			<td style="text-align:right">69%</td>
+			<td style="text-align:right">32,307</td>
+			<td style="text-align:right">152,302</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Whanganui</th>
+			<td style="text-align:right">45,245</td>
+			<td style="text-align:right">79%</td>
+			<td style="text-align:right">6,277</td>
+			<td style="text-align:right">37,431</td>
+			<td style="text-align:right">65%</td>
+			<td style="text-align:right">14,091</td>
+			<td style="text-align:right">57,247</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Capital and Coast</th>
+			<td style="text-align:right">247,361</td>
+			<td style="text-align:right">91%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">205,814</td>
+			<td style="text-align:right">76%</td>
+			<td style="text-align:right">38,243</td>
+			<td style="text-align:right">271,174</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hutt Valley</th>
+			<td style="text-align:right">112,876</td>
+			<td style="text-align:right">87%</td>
+			<td style="text-align:right">4,339</td>
+			<td style="text-align:right">90,958</td>
+			<td style="text-align:right">70%</td>
+			<td style="text-align:right">26,257</td>
+			<td style="text-align:right">130,239</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Wairarapa</th>
+			<td style="text-align:right">34,797</td>
+			<td style="text-align:right">84%</td>
+			<td style="text-align:right">2,487</td>
+			<td style="text-align:right">28,628</td>
+			<td style="text-align:right">69%</td>
+			<td style="text-align:right">8,656</td>
+			<td style="text-align:right">41,427</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Nelson Marlborough</th>
+			<td style="text-align:right">115,507</td>
+			<td style="text-align:right">85%</td>
+			<td style="text-align:right">6,662</td>
+			<td style="text-align:right">99,502</td>
+			<td style="text-align:right">73%</td>
+			<td style="text-align:right">22,667</td>
+			<td style="text-align:right">135,743</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">West Coast</th>
+			<td style="text-align:right">21,906</td>
+			<td style="text-align:right">78%</td>
+			<td style="text-align:right">3,209</td>
+			<td style="text-align:right">17,464</td>
+			<td style="text-align:right">63%</td>
+			<td style="text-align:right">7,651</td>
+			<td style="text-align:right">27,906</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Canterbury</th>
+			<td style="text-align:right">427,556</td>
+			<td style="text-align:right">89%</td>
+			<td style="text-align:right">7,045</td>
+			<td style="text-align:right">322,775</td>
+			<td style="text-align:right">67%</td>
+			<td style="text-align:right">111,826</td>
+			<td style="text-align:right">482,890</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">South Canterbury</th>
+			<td style="text-align:right">44,294</td>
+			<td style="text-align:right">84%</td>
+			<td style="text-align:right">3,032</td>
+			<td style="text-align:right">36,940</td>
+			<td style="text-align:right">70%</td>
+			<td style="text-align:right">10,386</td>
+			<td style="text-align:right">52,584</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Southern</th>
+			<td style="text-align:right">253,461</td>
+			<td style="text-align:right">88%</td>
+			<td style="text-align:right">5,752</td>
+			<td style="text-align:right">212,084</td>
+			<td style="text-align:right">74%</td>
+			<td style="text-align:right">47,130</td>
+			<td style="text-align:right">288,015</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Overseas / Unknown</th>
+			<td style="text-align:right">2,018</td>
+			<td style="text-align:right">12%</td>
+			<td style="text-align:right">13,438</td>
+			<td style="text-align:right">1,586</td>
+			<td style="text-align:right">9%</td>
+			<td style="text-align:right">13,870</td>
+			<td style="text-align:right">17,173</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total</strong></th>
+			<td style="text-align:right"><strong>3,643,337</strong></td>
+			<td style="text-align:right"><strong>87%</strong></td>
+			<td style="text-align:right"><strong>144,814</strong></td>
+			<td style="text-align:right"><strong>2,980,163</strong></td>
+			<td style="text-align:right"><strong>71%</strong></td>
+			<td style="text-align:right"><strong>807,988</strong></td>
+			<td style="text-align:right"><strong>4,209,057</strong></td>
+		</tr>
+	</tbody>
+</table>
+
+<p>First/second doses % are the number of first/second doses administered divided by the eligible population. First/second doses to 90% are the number of doses required to reach 90% of the eligible population. For these two measures, the national total may not be the sum of DHB measures.</p>
+
+<h4><a id="90pct Māori" name="90pct Māori">Māori</a></h4>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">&nbsp;</th>
+			<th scope="col" style="text-align:right">First doses</th>
+			<th scope="col" style="text-align:right">First doses %</th>
+			<th scope="col" style="text-align:right">First doses to 90%</th>
+			<th scope="col" style="text-align:right">Second doses</th>
+			<th scope="col" style="text-align:right">Second doses %</th>
+			<th scope="col" style="text-align:right">Second doses to 90%</th>
+			<th scope="col" style="text-align:right">Population</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">Northland</th>
+			<td style="text-align:right">32,668</td>
+			<td style="text-align:right">65%</td>
+			<td style="text-align:right">12,771</td>
+			<td style="text-align:right">22,254</td>
+			<td style="text-align:right">44%</td>
+			<td style="text-align:right">23,185</td>
+			<td style="text-align:right">50,488</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waitemata</th>
+			<td style="text-align:right">31,960</td>
+			<td style="text-align:right">78%</td>
+			<td style="text-align:right">5,042</td>
+			<td style="text-align:right">23,526</td>
+			<td style="text-align:right">57%</td>
+			<td style="text-align:right">13,476</td>
+			<td style="text-align:right">41,113</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Auckland</th>
+			<td style="text-align:right">22,375</td>
+			<td style="text-align:right">81%</td>
+			<td style="text-align:right">2,638</td>
+			<td style="text-align:right">16,979</td>
+			<td style="text-align:right">61%</td>
+			<td style="text-align:right">8,034</td>
+			<td style="text-align:right">27,792</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Counties Manukau</th>
+			<td style="text-align:right">44,670</td>
+			<td style="text-align:right">70%</td>
+			<td style="text-align:right">12,474</td>
+			<td style="text-align:right">31,075</td>
+			<td style="text-align:right">49%</td>
+			<td style="text-align:right">26,069</td>
+			<td style="text-align:right">63,493</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waikato</th>
+			<td style="text-align:right">48,399</td>
+			<td style="text-align:right">69%</td>
+			<td style="text-align:right">14,337</td>
+			<td style="text-align:right">32,673</td>
+			<td style="text-align:right">47%</td>
+			<td style="text-align:right">30,063</td>
+			<td style="text-align:right">69,707</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Lakes</th>
+			<td style="text-align:right">18,849</td>
+			<td style="text-align:right">63%</td>
+			<td style="text-align:right">8,228</td>
+			<td style="text-align:right">12,932</td>
+			<td style="text-align:right">43%</td>
+			<td style="text-align:right">14,144</td>
+			<td style="text-align:right">30,085</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Bay of Plenty</th>
+			<td style="text-align:right">29,541</td>
+			<td style="text-align:right">62%</td>
+			<td style="text-align:right">13,420</td>
+			<td style="text-align:right">19,618</td>
+			<td style="text-align:right">41%</td>
+			<td style="text-align:right">23,343</td>
+			<td style="text-align:right">47,734</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Tairawhiti</th>
+			<td style="text-align:right">12,881</td>
+			<td style="text-align:right">65%</td>
+			<td style="text-align:right">4,974</td>
+			<td style="text-align:right">9,343</td>
+			<td style="text-align:right">47%</td>
+			<td style="text-align:right">8,512</td>
+			<td style="text-align:right">19,839</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Taranaki</th>
+			<td style="text-align:right">10,399</td>
+			<td style="text-align:right">65%</td>
+			<td style="text-align:right">3,915</td>
+			<td style="text-align:right">6,622</td>
+			<td style="text-align:right">42%</td>
+			<td style="text-align:right">7,692</td>
+			<td style="text-align:right">15,904</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hawkes Bay</th>
+			<td style="text-align:right">21,973</td>
+			<td style="text-align:right">65%</td>
+			<td style="text-align:right">8,680</td>
+			<td style="text-align:right">15,464</td>
+			<td style="text-align:right">45%</td>
+			<td style="text-align:right">15,189</td>
+			<td style="text-align:right">34,059</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">MidCentral</th>
+			<td style="text-align:right">16,626</td>
+			<td style="text-align:right">69%</td>
+			<td style="text-align:right">5,176</td>
+			<td style="text-align:right">11,757</td>
+			<td style="text-align:right">49%</td>
+			<td style="text-align:right">10,046</td>
+			<td style="text-align:right">24,225</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Whanganui</th>
+			<td style="text-align:right">8,515</td>
+			<td style="text-align:right">63%</td>
+			<td style="text-align:right">3,646</td>
+			<td style="text-align:right">6,258</td>
+			<td style="text-align:right">46%</td>
+			<td style="text-align:right">5,903</td>
+			<td style="text-align:right">13,512</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Capital and Coast</th>
+			<td style="text-align:right">21,086</td>
+			<td style="text-align:right">78%</td>
+			<td style="text-align:right">3,184</td>
+			<td style="text-align:right">15,768</td>
+			<td style="text-align:right">58%</td>
+			<td style="text-align:right">8,502</td>
+			<td style="text-align:right">26,967</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hutt Valley</th>
+			<td style="text-align:right">13,536</td>
+			<td style="text-align:right">71%</td>
+			<td style="text-align:right">3,675</td>
+			<td style="text-align:right">9,620</td>
+			<td style="text-align:right">50%</td>
+			<td style="text-align:right">7,591</td>
+			<td style="text-align:right">19,123</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Wairarapa</th>
+			<td style="text-align:right">4,241</td>
+			<td style="text-align:right">67%</td>
+			<td style="text-align:right">1,431</td>
+			<td style="text-align:right">2,941</td>
+			<td style="text-align:right">47%</td>
+			<td style="text-align:right">2,731</td>
+			<td style="text-align:right">6,302</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Nelson Marlborough</th>
+			<td style="text-align:right">7,596</td>
+			<td style="text-align:right">68%</td>
+			<td style="text-align:right">2,527</td>
+			<td style="text-align:right">5,705</td>
+			<td style="text-align:right">51%</td>
+			<td style="text-align:right">4,418</td>
+			<td style="text-align:right">11,248</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">West Coast</th>
+			<td style="text-align:right">1,899</td>
+			<td style="text-align:right">69%</td>
+			<td style="text-align:right">590</td>
+			<td style="text-align:right">1,340</td>
+			<td style="text-align:right">48%</td>
+			<td style="text-align:right">1,148</td>
+			<td style="text-align:right">2,765</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Canterbury</th>
+			<td style="text-align:right">26,787</td>
+			<td style="text-align:right">72%</td>
+			<td style="text-align:right">6,485</td>
+			<td style="text-align:right">17,969</td>
+			<td style="text-align:right">49%</td>
+			<td style="text-align:right">15,303</td>
+			<td style="text-align:right">36,969</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">South Canterbury</th>
+			<td style="text-align:right">2,314</td>
+			<td style="text-align:right">68%</td>
+			<td style="text-align:right">771</td>
+			<td style="text-align:right">1,694</td>
+			<td style="text-align:right">49%</td>
+			<td style="text-align:right">1,391</td>
+			<td style="text-align:right">3,428</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Southern</th>
+			<td style="text-align:right">17,139</td>
+			<td style="text-align:right">72%</td>
+			<td style="text-align:right">4,142</td>
+			<td style="text-align:right">12,986</td>
+			<td style="text-align:right">55%</td>
+			<td style="text-align:right">8,295</td>
+			<td style="text-align:right">23,646</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Overseas / Unknown</th>
+			<td style="text-align:right">178</td>
+			<td style="text-align:right">7%</td>
+			<td style="text-align:right">2,210</td>
+			<td style="text-align:right">126</td>
+			<td style="text-align:right">5%</td>
+			<td style="text-align:right">2,262</td>
+			<td style="text-align:right">2,653</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total</strong></th>
+			<td style="text-align:right"><strong>393,632</strong></td>
+			<td style="text-align:right"><strong>69%</strong></td>
+			<td style="text-align:right"><strong>120,315</strong></td>
+			<td style="text-align:right"><strong>276,650</strong></td>
+			<td style="text-align:right"><strong>48%</strong></td>
+			<td style="text-align:right"><strong>237,297</strong></td>
+			<td style="text-align:right"><strong>571,052</strong></td>
+		</tr>
+	</tbody>
+</table>
+
+<h4><a id="90pct Pacific Peoples" name="90pct Pacific Peoples"></a>Pacific Peoples</h4>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">&nbsp;</th>
+			<th scope="col" style="text-align:right">First doses</th>
+			<th scope="col" style="text-align:right">First doses %</th>
+			<th scope="col" style="text-align:right">First doses to 90%</th>
+			<th scope="col" style="text-align:right">Second doses</th>
+			<th scope="col" style="text-align:right">Second doses %</th>
+			<th scope="col" style="text-align:right">Second doses to 90%</th>
+			<th scope="col" style="text-align:right">Population</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">Northland</th>
+			<td style="text-align:right">2,315</td>
+			<td style="text-align:right">79%</td>
+			<td style="text-align:right">326</td>
+			<td style="text-align:right">1,643</td>
+			<td style="text-align:right">56%</td>
+			<td style="text-align:right">998</td>
+			<td style="text-align:right">2,934</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waitemata</th>
+			<td style="text-align:right">31,493</td>
+			<td style="text-align:right">84%</td>
+			<td style="text-align:right">2,323</td>
+			<td style="text-align:right">24,321</td>
+			<td style="text-align:right">65%</td>
+			<td style="text-align:right">9,495</td>
+			<td style="text-align:right">37,573</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Auckland</th>
+			<td style="text-align:right">38,688</td>
+			<td style="text-align:right">83%</td>
+			<td style="text-align:right">3,491</td>
+			<td style="text-align:right">30,278</td>
+			<td style="text-align:right">65%</td>
+			<td style="text-align:right">11,901</td>
+			<td style="text-align:right">46,866</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Counties Manukau</th>
+			<td style="text-align:right">94,663</td>
+			<td style="text-align:right">81%</td>
+			<td style="text-align:right">10,185</td>
+			<td style="text-align:right">73,758</td>
+			<td style="text-align:right">63%</td>
+			<td style="text-align:right">31,090</td>
+			<td style="text-align:right">116,498</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waikato</th>
+			<td style="text-align:right">8,951</td>
+			<td style="text-align:right">84%</td>
+			<td style="text-align:right">663</td>
+			<td style="text-align:right">6,857</td>
+			<td style="text-align:right">64%</td>
+			<td style="text-align:right">2,757</td>
+			<td style="text-align:right">10,682</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Lakes</th>
+			<td style="text-align:right">1,780</td>
+			<td style="text-align:right">78%</td>
+			<td style="text-align:right">277</td>
+			<td style="text-align:right">1,348</td>
+			<td style="text-align:right">59%</td>
+			<td style="text-align:right">709</td>
+			<td style="text-align:right">2,286</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Bay of Plenty</th>
+			<td style="text-align:right">3,936</td>
+			<td style="text-align:right">&gt;95%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">2,903</td>
+			<td style="text-align:right">79%</td>
+			<td style="text-align:right">408</td>
+			<td style="text-align:right">3,679</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Tairawhiti</th>
+			<td style="text-align:right">846</td>
+			<td style="text-align:right">88%</td>
+			<td style="text-align:right">22</td>
+			<td style="text-align:right">638</td>
+			<td style="text-align:right">66%</td>
+			<td style="text-align:right">230</td>
+			<td style="text-align:right">965</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Taranaki</th>
+			<td style="text-align:right">1,019</td>
+			<td style="text-align:right">80%</td>
+			<td style="text-align:right">124</td>
+			<td style="text-align:right">736</td>
+			<td style="text-align:right">58%</td>
+			<td style="text-align:right">407</td>
+			<td style="text-align:right">1,270</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hawkes Bay</th>
+			<td style="text-align:right">4,974</td>
+			<td style="text-align:right">&gt;95%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">3,967</td>
+			<td style="text-align:right">79%</td>
+			<td style="text-align:right">551</td>
+			<td style="text-align:right">5,020</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">MidCentral</th>
+			<td style="text-align:right">3,676</td>
+			<td style="text-align:right">82%</td>
+			<td style="text-align:right">345</td>
+			<td style="text-align:right">2,774</td>
+			<td style="text-align:right">62%</td>
+			<td style="text-align:right">1,247</td>
+			<td style="text-align:right">4,468</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Whanganui</th>
+			<td style="text-align:right">1,020</td>
+			<td style="text-align:right">74%</td>
+			<td style="text-align:right">223</td>
+			<td style="text-align:right">789</td>
+			<td style="text-align:right">57%</td>
+			<td style="text-align:right">454</td>
+			<td style="text-align:right">1,381</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Capital and Coast</th>
+			<td style="text-align:right">15,349</td>
+			<td style="text-align:right">80%</td>
+			<td style="text-align:right">1,910</td>
+			<td style="text-align:right">12,040</td>
+			<td style="text-align:right">63%</td>
+			<td style="text-align:right">5,219</td>
+			<td style="text-align:right">19,177</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hutt Valley</th>
+			<td style="text-align:right">7,801</td>
+			<td style="text-align:right">79%</td>
+			<td style="text-align:right">1,104</td>
+			<td style="text-align:right">5,994</td>
+			<td style="text-align:right">61%</td>
+			<td style="text-align:right">2,911</td>
+			<td style="text-align:right">9,894</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Wairarapa</th>
+			<td style="text-align:right">672</td>
+			<td style="text-align:right">80%</td>
+			<td style="text-align:right">81</td>
+			<td style="text-align:right">529</td>
+			<td style="text-align:right">63%</td>
+			<td style="text-align:right">224</td>
+			<td style="text-align:right">837</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Nelson Marlborough</th>
+			<td style="text-align:right">3,565</td>
+			<td style="text-align:right">&gt;95%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">3,079</td>
+			<td style="text-align:right">&gt;95%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">2,115</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">West Coast</th>
+			<td style="text-align:right">224</td>
+			<td style="text-align:right">79%</td>
+			<td style="text-align:right">30</td>
+			<td style="text-align:right">167</td>
+			<td style="text-align:right">59%</td>
+			<td style="text-align:right">87</td>
+			<td style="text-align:right">282</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Canterbury</th>
+			<td style="text-align:right">10,189</td>
+			<td style="text-align:right">80%</td>
+			<td style="text-align:right">1,274</td>
+			<td style="text-align:right">7,459</td>
+			<td style="text-align:right">59%</td>
+			<td style="text-align:right">4,004</td>
+			<td style="text-align:right">12,737</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">South Canterbury</th>
+			<td style="text-align:right">759</td>
+			<td style="text-align:right">91%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">534</td>
+			<td style="text-align:right">64%</td>
+			<td style="text-align:right">219</td>
+			<td style="text-align:right">837</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Southern</th>
+			<td style="text-align:right">5,443</td>
+			<td style="text-align:right">90%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">4,245</td>
+			<td style="text-align:right">70%</td>
+			<td style="text-align:right">1,183</td>
+			<td style="text-align:right">6,031</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Overseas / Unknown</th>
+			<td style="text-align:right">336</td>
+			<td style="text-align:right">29%</td>
+			<td style="text-align:right">698</td>
+			<td style="text-align:right">287</td>
+			<td style="text-align:right">25%</td>
+			<td style="text-align:right">747</td>
+			<td style="text-align:right">1,149</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total</strong></th>
+			<td style="text-align:right"><strong>237,699</strong></td>
+			<td style="text-align:right"><strong>83%</strong></td>
+			<td style="text-align:right"><strong>20,314</strong></td>
+			<td style="text-align:right"><strong>184,346</strong></td>
+			<td style="text-align:right"><strong>64%</strong></td>
+			<td style="text-align:right"><strong>73,667</strong></td>
+			<td style="text-align:right"><strong>286,681</strong></td>
+		</tr>
+	</tbody>
+</table>
+<!--daily_end-->
+
+<hr/>
+<h2><a id="weekly-updates" name="weekly-updates"></a>COVID-19 vaccinations: weekly updates</h2>
+
+<div class="well well-sm">
+<p style="margin-top: 0"><strong>Data in this section is as at 11:59pm 19 October 2021 and is updated weekly on Wednesdays.</strong></p>
+</div>
+
+<h3><a id="model" model="" name="id="></a>Cumulative vaccinations</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccination doses administered compared to plan doses" class="img-responsive" height="830" src="/web/20211025040431im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/vaccineplanmodel_12.png" width="1780"/></figure>
+
+<p>Production plan figures are the volumes agreed with DHBs and national providers for expected vaccinations. These figures have been matched with expected supply. Detailed plans are available in the Excel file at the bottom of this page.</p>
+
+<p>The Stock received figures are the cumulative supply of doses to date.</p>
+
+<p>DHB capacity plans for the remainder of the year are undergoing review.</p>
+
+<hr/><!--
+<h3><a id="model" model="" name="id="></a>Cumulative vaccinations for last 6 weeks</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccination doses administered compared to plan doses - 6wks" class="img-responsive" height="830" src="/vaccineplanmodel_wks.png" width="1780" /></figure>
+
+<hr />
+-->
+<h3><a id="uptake" name="uptake"></a>Vaccine uptake</h3>
+
+<p>Maps and data related to uptake rates of the COVID-19 vaccine across the country are available on the pages linked below. These show&nbsp;vaccination records aggregated by area of residence for all New Zealand residents, Māori communities, and Pacific communities.</p>
+
+<ul>
+	<li><a href="/web/20211025040431/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-across-nz">COVID-19 Vaccination uptake rates across NZ</a></li>
+	<li><a href="/web/20211025040431/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-maori-communities-across-nz">COVID-19 Vaccination uptake rates within Māori communities across NZ</a></li>
+	<li><a href="/web/20211025040431/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-pacific-communities-across-nz">COVID-19 Vaccination uptake rates within Pacific communities across NZ</a></li>
+</ul>
+
+<h4><a id="uptake" name="uptake"></a>Vaccine uptake per rate ratio (unadjusted) Māori and Pacific compared with Non-Māori non-Pacific</h4>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine Uptake per 1,000 (HSU) Rate Ratio, Showing Prioritised Ethnicity, vs Non-Māori Non-Pacific, By Age Band" class="img-responsive" height="830" src="/web/20211025040431im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_mix_7.png" width="1780"/></figure>
+
+<p>In the Chart above, rate ratios tell us the rate Māori or Pacific People per population are being vaccinated compared with non-Māori non-Pacific. This comparison can be split by age group.</p>
+
+<ul>
+	<li>A rate of one means the groups being compared are being vaccinated at the same rate.</li>
+	<li>A rate over one means Māori (or Pacific) are being vaccinated at a higher rate than non-Māori non-Pacific.</li>
+	<li>A rate under one means Māori (or Pacific) are being vaccinated at a lower rate than non-Māori non-Pacific.</li>
+</ul>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<td colspan="2" style="border-top: 0 !important; border-bottom-color: #FDD6AF !important; border-right: 0 !important;">&nbsp;</td>
+			<th colspan="6" id="ac1">Māori</th>
+			<th colspan="6" id="ac8">Pacific Peoples</th>
+		</tr>
+		<tr>
+			<th id="ar1">DHB</th>
+			<th>Dose number</th>
+			<th headers="ac1" id="ac2">65+</th>
+			<th headers="ac1" id="ac3">50-64</th>
+			<th headers="ac1" id="ac4">35-49</th>
+			<th headers="ac1" id="ac5">20-34</th>
+			<th headers="ac1" id="ac6">12-19</th>
+			<th headers="ac1" id="ac7">All ages</th>
+			<th headers="ac8" id="ac9">65+</th>
+			<th headers="ac8" id="ac10">50-64</th>
+			<th headers="ac8" id="ac11">35-49</th>
+			<th headers="ac8" id="ac12">20-34</th>
+			<th headers="ac8" id="ac13">12-19</th>
+			<th headers="ac8" id="ac14">All ages</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th headers="ar1" id="ar2" rowspan="2">National</th>
+			<th headers="ar1 ar2" id="ar3">Dose 1</th>
+			<td headers="ar1 ar2 ar3 ac1 ac2" style="background-color:green; color: #FFF;"><strong>0.99</strong></td>
+			<td headers="ar1 ar2 ar3 ac1 ac3" style="background-color:mediumseagreen"><strong>0.92</strong></td>
+			<td headers="ar1 ar2 ar3 ac1 ac4" style="background-color:yellow"><strong>0.77</strong></td>
+			<td headers="ar1 ar2 ar3 ac1 ac5" style="background-color:tomato"><strong>0.64</strong></td>
+			<td headers="ar1 ar2 ar3 ac1 ac6" style="background-color:coral"><strong>0.69</strong></td>
+			<td headers="ar1 ar2 ar3 ac1 ac7" style="background-color:yellow"><strong>0.75</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac9" style="background-color:mediumseagreen"><strong>0.94</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac10" style="background-color:green; color: #FFF;"><strong>0.99</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac11" style="background-color:green; color: #FFF;"><strong>0.97</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac12" style="background-color:lightgreen"><strong>0.87</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac13" style="background-color:lightgreen"><strong>0.89</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac14" style="background-color:mediumseagreen"><strong>0.91</strong></td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar2" id="ar4">Dose 2</th>
+			<td headers="ar1 ar2 ar4 ac1 ac2" style="background-color:green; color: #FFF;"><strong>0.96</strong></td>
+			<td headers="ar1 ar2 ar4 ac1 ac3" style="background-color:lightgreen"><strong>0.87</strong></td>
+			<td headers="ar1 ar2 ar4 ac1 ac4" style="background-color:coral"><strong>0.68</strong></td>
+			<td headers="ar1 ar2 ar4 ac1 ac5" style="background-color:crimson; color: #FFF;"><strong>0.51</strong></td>
+			<td headers="ar1 ar2 ar4 ac1 ac6" style="background-color:crimson; color: #FFF;"><strong>0.57</strong></td>
+			<td headers="ar1 ar2 ar4 ac1 ac7" style="background-color:tomato"><strong>0.64</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac9" style="background-color:mediumseagreen"><strong>0.91</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac10" style="background-color:green; color: #FFF;"><strong>0.99</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac11" style="background-color:green; color: #FFF;"><strong>0.98</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac12" style="background-color:palegreen"><strong>0.82</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac13" style="background-color:lightgreen"><strong>0.85</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac14" style="background-color:palegreen"><strong>0.84</strong></td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar5" rowspan="2">Northland</th>
+			<th headers="ar1 ar5" id="ar6">Dose 1</th>
+			<td headers="ar1 ar5 ar6 ac1 ac2" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar5 ar6 ac1 ac3" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar5 ar6 ac1 ac4" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar5 ar6 ac1 ac5" style="background-color:tomato">0.64</td>
+			<td headers="ar1 ar5 ar6 ac1 ac6" style="background-color:orange">0.72</td>
+			<td headers="ar1 ar5 ar6 ac1 ac7" style="background-color:yellow">0.76</td>
+			<td headers="ar1 ar5 ar6 ac8 ac9" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar5 ar6 ac8 ac10" style="background-color:green; color: #FFF;">1.05</td>
+			<td headers="ar1 ar5 ar6 ac8 ac11" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar5 ar6 ac8 ac12" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar5 ar6 ac8 ac13" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar5 ar6 ac8 ac14" style="background-color:mediumseagreen">0.93</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar5" id="ar7">Dose 2</th>
+			<td headers="ar1 ar5 ar7 ac1 ac2" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar5 ar7 ac1 ac3" style="background-color:lightgreen">0.86</td>
+			<td headers="ar1 ar5 ar7 ac1 ac4" style="background-color:coral">0.68</td>
+			<td headers="ar1 ar5 ar7 ac1 ac5" style="background-color:crimson; color: #FFF;">0.48</td>
+			<td headers="ar1 ar5 ar7 ac1 ac6" style="background-color:crimson; color: #FFF;">0.58</td>
+			<td headers="ar1 ar5 ar7 ac1 ac7" style="background-color:tomato">0.62</td>
+			<td headers="ar1 ar5 ar7 ac8 ac9" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar5 ar7 ac8 ac10" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar5 ar7 ac8 ac11" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar5 ar7 ac8 ac12" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar5 ar7 ac8 ac13" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar5 ar7 ac8 ac14" style="background-color:yellow">0.78</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar8" rowspan="2">Auckland Metro</th>
+			<th headers="ar1 ar8" id="ar9">Dose 1</th>
+			<td headers="ar1 ar8 ar9 ac1 ac2" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar8 ar9 ac1 ac3" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar8 ar9 ac1 ac4" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar8 ar9 ac1 ac5" style="background-color:coral">0.68</td>
+			<td headers="ar1 ar8 ar9 ac1 ac6" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar8 ar9 ac1 ac7" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar8 ar9 ac8 ac9" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar8 ar9 ac8 ac10" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar8 ar9 ac8 ac11" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar8 ar9 ac8 ac12" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar8 ar9 ac8 ac13" style="background-color:palegreen">0.81</td>
+			<td headers="ar1 ar8 ar9 ac8 ac14" style="background-color:lightgreen">0.86</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar8" id="ar10">Dose 2</th>
+			<td headers="ar1 ar8 ar10 ac1 ac2" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar8 ar10 ac1 ac3" style="background-color:lightgreen">0.88</td>
+			<td headers="ar1 ar8 ar10 ac1 ac4" style="background-color:coral">0.68</td>
+			<td headers="ar1 ar8 ar10 ac1 ac5" style="background-color:crimson; color: #FFF;">0.52</td>
+			<td headers="ar1 ar8 ar10 ac1 ac6" style="background-color:crimson; color: #FFF;">0.57</td>
+			<td headers="ar1 ar8 ar10 ac1 ac7" style="background-color:coral">0.65</td>
+			<td headers="ar1 ar8 ar10 ac8 ac9" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar8 ar10 ac8 ac10" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar8 ar10 ac8 ac11" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar8 ar10 ac8 ac12" style="background-color:coral">0.65</td>
+			<td headers="ar1 ar8 ar10 ac8 ac13" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar8 ar10 ac8 ac14" style="background-color:yellow">0.77</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar11" rowspan="2">Waikato</th>
+			<th headers="ar1 ar11" id="ar12">Dose 1</th>
+			<td headers="ar1 ar11 ar12 ac1 ac2" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar11 ar12 ac1 ac3" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar11 ar12 ac1 ac4" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar11 ar12 ac1 ac5" style="background-color:coral">0.66</td>
+			<td headers="ar1 ar11 ar12 ac1 ac6" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar11 ar12 ac1 ac7" style="background-color:yellow">0.76</td>
+			<td headers="ar1 ar11 ar12 ac8 ac9" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar11 ar12 ac8 ac10" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar11 ar12 ac8 ac11" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar11 ar12 ac8 ac12" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar11 ar12 ac8 ac13" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar11 ar12 ac8 ac14" style="background-color:mediumseagreen">0.93</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar11" id="ar13">Dose 2</th>
+			<td headers="ar1 ar11 ar13 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar11 ar13 ac1 ac3" style="background-color:lightgreen">0.87</td>
+			<td headers="ar1 ar11 ar13 ac1 ac4" style="background-color:coral">0.68</td>
+			<td headers="ar1 ar11 ar13 ac1 ac5" style="background-color:crimson; color: #FFF;">0.50</td>
+			<td headers="ar1 ar11 ar13 ac1 ac6" style="background-color:crimson; color: #FFF;">0.56</td>
+			<td headers="ar1 ar11 ar13 ac1 ac7" style="background-color:tomato">0.63</td>
+			<td headers="ar1 ar11 ar13 ac8 ac9" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar11 ar13 ac8 ac10" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar11 ar13 ac8 ac11" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar11 ar13 ac8 ac12" style="background-color:lightgreen">0.86</td>
+			<td headers="ar1 ar11 ar13 ac8 ac13" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar11 ar13 ac8 ac14" style="background-color:lightgreen">0.87</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar14" rowspan="2">Bay of Plenty</th>
+			<th headers="ar1 ar14" id="ar15">Dose 1</th>
+			<td headers="ar1 ar14 ar15 ac1 ac2" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar14 ar15 ac1 ac3" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar14 ar15 ac1 ac4" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar14 ar15 ac1 ac5" style="background-color:crimson; color: #FFF;">0.55</td>
+			<td headers="ar1 ar14 ar15 ac1 ac6" style="background-color:tomato">0.62</td>
+			<td headers="ar1 ar14 ar15 ac1 ac7" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar14 ar15 ac8 ac9" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar14 ar15 ac8 ac10" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar14 ar15 ac8 ac11" style="background-color:green; color: #FFF;">1.44</td>
+			<td headers="ar1 ar14 ar15 ac8 ac12" style="background-color:green; color: #FFF;">1.50</td>
+			<td headers="ar1 ar14 ar15 ac8 ac13" style="background-color:lightgreen">0.87</td>
+			<td headers="ar1 ar14 ar15 ac8 ac14" style="background-color:green; color: #FFF;">1.20</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar14" id="ar16">Dose 2</th>
+			<td headers="ar1 ar14 ar16 ac1 ac2" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar14 ar16 ac1 ac3" style="background-color:palegreen">0.84</td>
+			<td headers="ar1 ar14 ar16 ac1 ac4" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar14 ar16 ac1 ac5" style="background-color:crimson; color: #FFF;">0.46</td>
+			<td headers="ar1 ar14 ar16 ac1 ac6" style="background-color:crimson; color: #FFF;">0.54</td>
+			<td headers="ar1 ar14 ar16 ac1 ac7" style="background-color:crimson; color: #FFF;">0.59</td>
+			<td headers="ar1 ar14 ar16 ac8 ac9" style="background-color:lightgreen">0.88</td>
+			<td headers="ar1 ar14 ar16 ac8 ac10" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar14 ar16 ac8 ac11" style="background-color:green; color: #FFF;">1.64</td>
+			<td headers="ar1 ar14 ar16 ac8 ac12" style="background-color:green; color: #FFF;">1.91</td>
+			<td headers="ar1 ar14 ar16 ac8 ac13" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar14 ar16 ac8 ac14" style="background-color:green; color: #FFF;">1.13</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar17" rowspan="2">Tairawhiti</th>
+			<th headers="ar1 ar17" id="ar18">Dose 1</th>
+			<td headers="ar1 ar17 ar18 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar17 ar18 ac1 ac3" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar17 ar18 ac1 ac4" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar17 ar18 ac1 ac5" style="background-color:tomato">0.60</td>
+			<td headers="ar1 ar17 ar18 ac1 ac6" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar17 ar18 ac1 ac7" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar17 ar18 ac8 ac9" style="background-color:green; color: #FFF;">1.05</td>
+			<td headers="ar1 ar17 ar18 ac8 ac10" style="background-color:green; color: #FFF;">1.07</td>
+			<td headers="ar1 ar17 ar18 ac8 ac11" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar17 ar18 ac8 ac12" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar17 ar18 ac8 ac13" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar17 ar18 ac8 ac14" style="background-color:green; color: #FFF;">0.99</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar17" id="ar19">Dose 2</th>
+			<td headers="ar1 ar17 ar19 ac1 ac2" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar17 ar19 ac1 ac3" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar17 ar19 ac1 ac4" style="background-color:coral">0.69</td>
+			<td headers="ar1 ar17 ar19 ac1 ac5" style="background-color:crimson; color: #FFF;">0.49</td>
+			<td headers="ar1 ar17 ar19 ac1 ac6" style="background-color:crimson; color: #FFF;">0.55</td>
+			<td headers="ar1 ar17 ar19 ac1 ac7" style="background-color:tomato">0.64</td>
+			<td headers="ar1 ar17 ar19 ac8 ac9" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar17 ar19 ac8 ac10" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar17 ar19 ac8 ac11" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar17 ar19 ac8 ac12" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar17 ar19 ac8 ac13" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar17 ar19 ac8 ac14" style="background-color:lightgreen">0.88</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar20" rowspan="2">Lakes</th>
+			<th headers="ar1 ar20" id="ar21">Dose 1</th>
+			<td headers="ar1 ar20 ar21 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar20 ar21 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar20 ar21 ac1 ac4" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar20 ar21 ac1 ac5" style="background-color:crimson; color: #FFF;">0.56</td>
+			<td headers="ar1 ar20 ar21 ac1 ac6" style="background-color:tomato">0.64</td>
+			<td headers="ar1 ar20 ar21 ac1 ac7" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar20 ar21 ac8 ac9" style="background-color:green; color: #FFF;">1.06</td>
+			<td headers="ar1 ar20 ar21 ac8 ac10" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar20 ar21 ac8 ac11" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar20 ar21 ac8 ac12" style="background-color:palegreen">0.81</td>
+			<td headers="ar1 ar20 ar21 ac8 ac13" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar20 ar21 ac8 ac14" style="background-color:lightgreen">0.89</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar20" id="ar22">Dose 2</th>
+			<td headers="ar1 ar20 ar22 ac1 ac2" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar20 ar22 ac1 ac3" style="background-color:palegreen">0.84</td>
+			<td headers="ar1 ar20 ar22 ac1 ac4" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar20 ar22 ac1 ac5" style="background-color:crimson; color: #FFF;">0.45</td>
+			<td headers="ar1 ar20 ar22 ac1 ac6" style="background-color:crimson; color: #FFF;">0.54</td>
+			<td headers="ar1 ar20 ar22 ac1 ac7" style="background-color:tomato">0.60</td>
+			<td headers="ar1 ar20 ar22 ac8 ac9" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar20 ar22 ac8 ac10" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar20 ar22 ac8 ac11" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar20 ar22 ac8 ac12" style="background-color:lightgreen">0.87</td>
+			<td headers="ar1 ar20 ar22 ac8 ac13" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar20 ar22 ac8 ac14" style="background-color:palegreen">0.84</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar23" rowspan="2">Taranaki</th>
+			<th headers="ar1 ar23" id="ar24">Dose 1</th>
+			<td headers="ar1 ar23 ar24 ac1 ac2" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar23 ar24 ac1 ac3" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar23 ar24 ac1 ac4" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar23 ar24 ac1 ac5" style="background-color:coral">0.65</td>
+			<td headers="ar1 ar23 ar24 ac1 ac6" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar23 ar24 ac1 ac7" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar23 ar24 ac8 ac9" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar23 ar24 ac8 ac10" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar23 ar24 ac8 ac11" style="background-color:green; color: #FFF;">1.05</td>
+			<td headers="ar1 ar23 ar24 ac8 ac12" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar23 ar24 ac8 ac13" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar23 ar24 ac8 ac14" style="background-color:mediumseagreen">0.93</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar23" id="ar25">Dose 2</th>
+			<td headers="ar1 ar23 ar25 ac1 ac2" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar23 ar25 ac1 ac3" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar23 ar25 ac1 ac4" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar23 ar25 ac1 ac5" style="background-color:crimson; color: #FFF;">0.52</td>
+			<td headers="ar1 ar23 ar25 ac1 ac6" style="background-color:crimson; color: #FFF;">0.54</td>
+			<td headers="ar1 ar23 ar25 ac1 ac7" style="background-color:tomato">0.62</td>
+			<td headers="ar1 ar23 ar25 ac8 ac9" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar23 ar25 ac8 ac10" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar23 ar25 ac8 ac11" style="background-color:green; color: #FFF;">1.23</td>
+			<td headers="ar1 ar23 ar25 ac8 ac12" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar23 ar25 ac8 ac13" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar23 ar25 ac8 ac14" style="background-color:lightgreen">0.88</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar26" rowspan="2">Whanganui</th>
+			<th headers="ar1 ar26" id="ar27">Dose 1</th>
+			<td headers="ar1 ar26 ar27 ac1 ac2" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar26 ar27 ac1 ac3" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar26 ar27 ac1 ac4" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar26 ar27 ac1 ac5" style="background-color:tomato">0.63</td>
+			<td headers="ar1 ar26 ar27 ac1 ac6" style="background-color:coral">0.68</td>
+			<td headers="ar1 ar26 ar27 ac1 ac7" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar26 ar27 ac8 ac9" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar26 ar27 ac8 ac10" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar26 ar27 ac8 ac11" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar26 ar27 ac8 ac12" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar26 ar27 ac8 ac13" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar26 ar27 ac8 ac14" style="background-color:lightgreen">0.86</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar26" id="ar28">Dose 2</th>
+			<td headers="ar1 ar26 ar28 ac1 ac2" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar26 ar28 ac1 ac3" style="background-color:lightgreen">0.88</td>
+			<td headers="ar1 ar26 ar28 ac1 ac4" style="background-color:coral">0.69</td>
+			<td headers="ar1 ar26 ar28 ac1 ac5" style="background-color:crimson; color: #FFF;">0.49</td>
+			<td headers="ar1 ar26 ar28 ac1 ac6" style="background-color:crimson; color: #FFF;">0.59</td>
+			<td headers="ar1 ar26 ar28 ac1 ac7" style="background-color:tomato">0.63</td>
+			<td headers="ar1 ar26 ar28 ac8 ac9" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar26 ar28 ac8 ac10" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar26 ar28 ac8 ac11" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar26 ar28 ac8 ac12" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar26 ar28 ac8 ac13" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar26 ar28 ac8 ac14" style="background-color:yellow">0.77</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar29" rowspan="2">Hawke&#39;s Bay</th>
+			<th headers="ar1 ar29" id="ar30">Dose 1</th>
+			<td headers="ar1 ar29 ar30 ac1 ac2" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar29 ar30 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar29 ar30 ac1 ac4" style="background-color:yellow">0.77</td>
+			<td headers="ar1 ar29 ar30 ac1 ac5" style="background-color:crimson; color: #FFF;">0.58</td>
+			<td headers="ar1 ar29 ar30 ac1 ac6" style="background-color:coral">0.69</td>
+			<td headers="ar1 ar29 ar30 ac1 ac7" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar29 ar30 ac8 ac9" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar29 ar30 ac8 ac10" style="background-color:green; color: #FFF;">1.05</td>
+			<td headers="ar1 ar29 ar30 ac8 ac11" style="background-color:green; color: #FFF;">1.41</td>
+			<td headers="ar1 ar29 ar30 ac8 ac12" style="background-color:green; color: #FFF;">1.33</td>
+			<td headers="ar1 ar29 ar30 ac8 ac13" style="background-color:lightgreen">0.88</td>
+			<td headers="ar1 ar29 ar30 ac8 ac14" style="background-color:green; color: #FFF;">1.15</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar29" id="ar31">Dose 2</th>
+			<td headers="ar1 ar29 ar31 ac1 ac2" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar29 ar31 ac1 ac3" style="background-color:palegreen">0.84</td>
+			<td headers="ar1 ar29 ar31 ac1 ac4" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar29 ar31 ac1 ac5" style="background-color:crimson; color: #FFF;">0.48</td>
+			<td headers="ar1 ar29 ar31 ac1 ac6" style="background-color:crimson; color: #FFF;">0.57</td>
+			<td headers="ar1 ar29 ar31 ac1 ac7" style="background-color:tomato">0.61</td>
+			<td headers="ar1 ar29 ar31 ac8 ac9" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar29 ar31 ac8 ac10" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar29 ar31 ac8 ac11" style="background-color:green; color: #FFF;">1.52</td>
+			<td headers="ar1 ar29 ar31 ac8 ac12" style="background-color:green; color: #FFF;">1.56</td>
+			<td headers="ar1 ar29 ar31 ac8 ac13" style="background-color:lightgreen">0.86</td>
+			<td headers="ar1 ar29 ar31 ac8 ac14" style="background-color:green; color: #FFF;">1.10</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar32" rowspan="2">MidCentral</th>
+			<th headers="ar1 ar32" id="ar33">Dose 1</th>
+			<td headers="ar1 ar32 ar33 ac1 ac2" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar32 ar33 ac1 ac3" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar32 ar33 ac1 ac4" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar32 ar33 ac1 ac5" style="background-color:coral">0.69</td>
+			<td headers="ar1 ar32 ar33 ac1 ac6" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar32 ar33 ac1 ac7" style="background-color:yellow">0.76</td>
+			<td headers="ar1 ar32 ar33 ac8 ac9" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar32 ar33 ac8 ac10" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar32 ar33 ac8 ac11" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar32 ar33 ac8 ac12" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar32 ar33 ac8 ac13" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar32 ar33 ac8 ac14" style="background-color:mediumseagreen">0.93</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar32" id="ar34">Dose 2</th>
+			<td headers="ar1 ar32 ar34 ac1 ac2" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar32 ar34 ac1 ac3" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar32 ar34 ac1 ac4" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar32 ar34 ac1 ac5" style="background-color:crimson; color: #FFF;">0.58</td>
+			<td headers="ar1 ar32 ar34 ac1 ac6" style="background-color:tomato">0.60</td>
+			<td headers="ar1 ar32 ar34 ac1 ac7" style="background-color:coral">0.66</td>
+			<td headers="ar1 ar32 ar34 ac8 ac9" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar32 ar34 ac8 ac10" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar32 ar34 ac8 ac11" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar32 ar34 ac8 ac12" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar32 ar34 ac8 ac13" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar32 ar34 ac8 ac14" style="background-color:palegreen">0.84</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar35" rowspan="2">Wairarapa</th>
+			<th headers="ar1 ar35" id="ar36">Dose 1</th>
+			<td headers="ar1 ar35 ar36 ac1 ac2" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar35 ar36 ac1 ac3" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar35 ar36 ac1 ac4" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar35 ar36 ac1 ac5" style="background-color:coral">0.68</td>
+			<td headers="ar1 ar35 ar36 ac1 ac6" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar35 ar36 ac1 ac7" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar35 ar36 ac8 ac9" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar35 ar36 ac8 ac10" style="background-color:green; color: #FFF;">1.07</td>
+			<td headers="ar1 ar35 ar36 ac8 ac11" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar35 ar36 ac8 ac12" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar35 ar36 ac8 ac13" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar35 ar36 ac8 ac14" style="background-color:mediumseagreen">0.92</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar35" id="ar37">Dose 2</th>
+			<td headers="ar1 ar35 ar37 ac1 ac2" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar35 ar37 ac1 ac3" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar35 ar37 ac1 ac4" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar35 ar37 ac1 ac5" style="background-color:crimson; color: #FFF;">0.54</td>
+			<td headers="ar1 ar35 ar37 ac1 ac6" style="background-color:crimson; color: #FFF;">0.59</td>
+			<td headers="ar1 ar35 ar37 ac1 ac7" style="background-color:tomato">0.62</td>
+			<td headers="ar1 ar35 ar37 ac8 ac9" style="background-color:green; color: #FFF;">1.06</td>
+			<td headers="ar1 ar35 ar37 ac8 ac10" style="background-color:green; color: #FFF;">1.06</td>
+			<td headers="ar1 ar35 ar37 ac8 ac11" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar35 ar37 ac8 ac12" style="background-color:green; color: #FFF;">1.06</td>
+			<td headers="ar1 ar35 ar37 ac8 ac13" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar35 ar37 ac8 ac14" style="background-color:lightgreen">0.85</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar38" rowspan="2">Capital &amp; Coast and Hutt Valley</th>
+			<th headers="ar1 ar38" id="ar39">Dose 1</th>
+			<td headers="ar1 ar38 ar39 ac1 ac2" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar38 ar39 ac1 ac3" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar38 ar39 ac1 ac4" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar38 ar39 ac1 ac5" style="background-color:orange">0.72</td>
+			<td headers="ar1 ar38 ar39 ac1 ac6" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar38 ar39 ac1 ac7" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar38 ar39 ac8 ac9" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar38 ar39 ac8 ac10" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar38 ar39 ac8 ac11" style="background-color:lightgreen">0.88</td>
+			<td headers="ar1 ar38 ar39 ac8 ac12" style="background-color:yellow">0.76</td>
+			<td headers="ar1 ar38 ar39 ac8 ac13" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar38 ar39 ac8 ac14" style="background-color:lightgreen">0.85</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar38" id="ar40">Dose 2</th>
+			<td headers="ar1 ar38 ar40 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar38 ar40 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar38 ar40 ac1 ac4" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar38 ar40 ac1 ac5" style="background-color:tomato">0.63</td>
+			<td headers="ar1 ar38 ar40 ac1 ac6" style="background-color:tomato">0.62</td>
+			<td headers="ar1 ar38 ar40 ac1 ac7" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar38 ar40 ac8 ac9" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar38 ar40 ac8 ac10" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar38 ar40 ac8 ac11" style="background-color:lightgreen">0.87</td>
+			<td headers="ar1 ar38 ar40 ac8 ac12" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar38 ar40 ac8 ac13" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar38 ar40 ac8 ac14" style="background-color:palegreen">0.80</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar41" rowspan="2">Nelson Marlborough</th>
+			<th headers="ar1 ar41" id="ar42">Dose 1</th>
+			<td headers="ar1 ar41 ar42 ac1 ac2" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar41 ar42 ac1 ac3" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar41 ar42 ac1 ac4" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar41 ar42 ac1 ac5" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar41 ar42 ac1 ac6" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar41 ar42 ac1 ac7" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar41 ar42 ac8 ac9" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar41 ar42 ac8 ac10" style="background-color:green; color: #FFF;">1.27</td>
+			<td headers="ar1 ar41 ar42 ac8 ac11" style="background-color:green; color: #FFF;">2.48</td>
+			<td headers="ar1 ar41 ar42 ac8 ac12" style="background-color:green; color: #FFF;">2.97</td>
+			<td headers="ar1 ar41 ar42 ac8 ac13" style="background-color:green; color: #FFF;">1.07</td>
+			<td headers="ar1 ar41 ar42 ac8 ac14" style="background-color:green; color: #FFF;">1.97</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar41" id="ar43">Dose 2</th>
+			<td headers="ar1 ar41 ar43 ac1 ac2" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar41 ar43 ac1 ac3" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar41 ar43 ac1 ac4" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar41 ar43 ac1 ac5" style="background-color:crimson; color: #FFF;">0.54</td>
+			<td headers="ar1 ar41 ar43 ac1 ac6" style="background-color:coral">0.66</td>
+			<td headers="ar1 ar41 ar43 ac1 ac7" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar41 ar43 ac8 ac9" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar41 ar43 ac8 ac10" style="background-color:green; color: #FFF;">1.25</td>
+			<td headers="ar1 ar41 ar43 ac8 ac11" style="background-color:green; color: #FFF;">2.65</td>
+			<td headers="ar1 ar41 ar43 ac8 ac12" style="background-color:green; color: #FFF;">3.65</td>
+			<td headers="ar1 ar41 ar43 ac8 ac13" style="background-color:green; color: #FFF;">1.05</td>
+			<td headers="ar1 ar41 ar43 ac8 ac14" style="background-color:green; color: #FFF;">1.96</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar44" rowspan="2">West Coast</th>
+			<th headers="ar1 ar44" id="ar45">Dose 1</th>
+			<td headers="ar1 ar44 ar45 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar44 ar45 ac1 ac3" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar44 ar45 ac1 ac4" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar44 ar45 ac1 ac5" style="background-color:yellow">0.77</td>
+			<td headers="ar1 ar44 ar45 ac1 ac6" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar44 ar45 ac1 ac7" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar44 ar45 ac8 ac9" style="background-color:green; color: #FFF;">1.34</td>
+			<td headers="ar1 ar44 ar45 ac8 ac10" style="background-color:green; color: #FFF;">1.05</td>
+			<td headers="ar1 ar44 ar45 ac8 ac11" style="background-color:green; color: #FFF;">1.07</td>
+			<td headers="ar1 ar44 ar45 ac8 ac12" style="background-color:green; color: #FFF;">1.27</td>
+			<td headers="ar1 ar44 ar45 ac8 ac13" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar44 ar45 ac8 ac14" style="background-color:green; color: #FFF;">0.99</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar44" id="ar46">Dose 2</th>
+			<td headers="ar1 ar44 ar46 ac1 ac2" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar44 ar46 ac1 ac3" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar44 ar46 ac1 ac4" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar44 ar46 ac1 ac5" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar44 ar46 ac1 ac6" style="background-color:lightgreen">0.88</td>
+			<td headers="ar1 ar44 ar46 ac1 ac7" style="background-color:yellow">0.76</td>
+			<td headers="ar1 ar44 ar46 ac8 ac9" style="background-color:green; color: #FFF;">1.35</td>
+			<td headers="ar1 ar44 ar46 ac8 ac10" style="background-color:green; color: #FFF;">1.07</td>
+			<td headers="ar1 ar44 ar46 ac8 ac11" style="background-color:green; color: #FFF;">1.07</td>
+			<td headers="ar1 ar44 ar46 ac8 ac12" style="background-color:green; color: #FFF;">1.58</td>
+			<td headers="ar1 ar44 ar46 ac8 ac13" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar44 ar46 ac8 ac14" style="background-color:mediumseagreen">0.92</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar47" rowspan="2">Canterbury</th>
+			<th headers="ar1 ar47" id="ar48">Dose 1</th>
+			<td headers="ar1 ar47 ar48 ac1 ac2" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar47 ar48 ac1 ac3" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar47 ar48 ac1 ac4" style="background-color:palegreen">0.81</td>
+			<td headers="ar1 ar47 ar48 ac1 ac5" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar47 ar48 ac1 ac6" style="background-color:yellow">0.76</td>
+			<td headers="ar1 ar47 ar48 ac1 ac7" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar47 ar48 ac8 ac9" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar47 ar48 ac8 ac10" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar47 ar48 ac8 ac11" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar47 ar48 ac8 ac12" style="background-color:palegreen">0.84</td>
+			<td headers="ar1 ar47 ar48 ac8 ac13" style="background-color:lightgreen">0.88</td>
+			<td headers="ar1 ar47 ar48 ac8 ac14" style="background-color:lightgreen">0.88</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar47" id="ar49">Dose 2</th>
+			<td headers="ar1 ar47 ar49 ac1 ac2" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar47 ar49 ac1 ac3" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar47 ar49 ac1 ac4" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar47 ar49 ac1 ac5" style="background-color:coral">0.68</td>
+			<td headers="ar1 ar47 ar49 ac1 ac6" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar47 ar49 ac1 ac7" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar47 ar49 ac8 ac9" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar47 ar49 ac8 ac10" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar47 ar49 ac8 ac11" style="background-color:green; color: #FFF;">1.10</td>
+			<td headers="ar1 ar47 ar49 ac8 ac12" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar47 ar49 ac8 ac13" style="background-color:green; color: #FFF;">1.10</td>
+			<td headers="ar1 ar47 ar49 ac8 ac14" style="background-color:lightgreen">0.87</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar50" rowspan="2">South Canterbury</th>
+			<th headers="ar1 ar50" id="ar51">Dose 1</th>
+			<td headers="ar1 ar50 ar51 ac1 ac2" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar50 ar51 ac1 ac3" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar50 ar51 ac1 ac4" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar50 ar51 ac1 ac5" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar50 ar51 ac1 ac6" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar50 ar51 ac1 ac7" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar50 ar51 ac8 ac9" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar50 ar51 ac8 ac10" style="background-color:green; color: #FFF;">1.10</td>
+			<td headers="ar1 ar50 ar51 ac8 ac11" style="background-color:green; color: #FFF;">1.19</td>
+			<td headers="ar1 ar50 ar51 ac8 ac12" style="background-color:green; color: #FFF;">1.21</td>
+			<td headers="ar1 ar50 ar51 ac8 ac13" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar50 ar51 ac8 ac14" style="background-color:green; color: #FFF;">1.05</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar50" id="ar52">Dose 2</th>
+			<td headers="ar1 ar50 ar52 ac1 ac2" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar50 ar52 ac1 ac3" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar50 ar52 ac1 ac4" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar50 ar52 ac1 ac5" style="background-color:tomato">0.64</td>
+			<td headers="ar1 ar50 ar52 ac1 ac6" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar50 ar52 ac1 ac7" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar50 ar52 ac8 ac9" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar50 ar52 ac8 ac10" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar50 ar52 ac8 ac11" style="background-color:green; color: #FFF;">1.15</td>
+			<td headers="ar1 ar50 ar52 ac8 ac12" style="background-color:green; color: #FFF;">1.17</td>
+			<td headers="ar1 ar50 ar52 ac8 ac13" style="background-color:green; color: #FFF;">1.07</td>
+			<td headers="ar1 ar50 ar52 ac8 ac14" style="background-color:lightgreen">0.87</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar53" rowspan="2">Southern</th>
+			<th headers="ar1 ar53" id="ar54">Dose 1</th>
+			<td headers="ar1 ar53 ar54 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar53 ar54 ac1 ac3" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar53 ar54 ac1 ac4" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar53 ar54 ac1 ac5" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar53 ar54 ac1 ac6" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar53 ar54 ac1 ac7" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar53 ar54 ac8 ac9" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar53 ar54 ac8 ac10" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar53 ar54 ac8 ac11" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar53 ar54 ac8 ac12" style="background-color:green; color: #FFF;">1.09</td>
+			<td headers="ar1 ar53 ar54 ac8 ac13" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar53 ar54 ac8 ac14" style="background-color:green; color: #FFF;">1.01</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar53" id="ar55">Dose 2</th>
+			<td headers="ar1 ar53 ar55 ac1 ac2" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar53 ar55 ac1 ac3" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar53 ar55 ac1 ac4" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar53 ar55 ac1 ac5" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar53 ar55 ac1 ac6" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar53 ar55 ac1 ac7" style="background-color:orange">0.72</td>
+			<td headers="ar1 ar53 ar55 ac8 ac9" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar53 ar55 ac8 ac10" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar53 ar55 ac8 ac11" style="background-color:green; color: #FFF;">1.11</td>
+			<td headers="ar1 ar53 ar55 ac8 ac12" style="background-color:green; color: #FFF;">1.07</td>
+			<td headers="ar1 ar53 ar55 ac8 ac13" style="background-color:lightgreen">0.86</td>
+			<td headers="ar1 ar53 ar55 ac8 ac14" style="background-color:mediumseagreen">0.92</td>
+		</tr>
+	</tbody>
+</table>
+
+<p>This table shows the rate of doses administered (per 1,000 population) to Māori or Pacific Peoples, relative to the rate of doses for Non-Māori and Non-Pacific groups. Less than one means the group is receiving a lower proportion of doses than would be expected if equity is being achieved. More than one means they are receiving a higher proportion of doses than would be expected if equity is being achieved. Exactly one means doses administered are in line with their proportion of population.</p>
+
+<ul>
+	<li><a download="" href="/web/20211025040431/https://www.health.govt.nz/system/files/documents/pages/rateratioexplainer_1.docx">Rate Ratio Explainer (Word, 434 KB)</a></li>
+</ul>
+
+<p>At all ages the size (weightings) of the age groups becomes a major contributing factor to comparative ratios, which is why the all ages (12+) figure may not appear to be in line with the age splits.</p>
+
+<h4><a id="uptake" name="uptake"></a>Vaccine uptake per 1,000 people by ethnicity</h4>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine uptake per 1,000 people by ethnicity" class="img-responsive" height="830" src="/web/20211025040431im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_eth_7.png" width="1780"/></figure>
+
+<h4><a id="uptake" name="uptake"></a>Vaccine uptake per 1,000 people by age band</h4>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine uptake per 1,000 people by age band" class="img-responsive" height="1030" src="/web/20211025040431im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_age_8.png" width="1780"/></figure>
+
+<h4><a id="uptake" name="location"></a>Vaccine uptake per 1,000 people by DHB of residence</h4>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine uptake per 1,000 people by DHB of residence" class="img-responsive" height="1030" src="/web/20211025040431im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_dhb_3.png" width="1780"/></figure>
+<!--
+<hr />
+<h3><a id="by_dhb_plan" name="dhb_plan"></a>Cumulative vaccination plan for DHBs</h3>
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">DHB of service</th>
+			<th scope="col" style="text-align:right">Actuals to Sunday 17 October</th>
+			<th scope="col" style="text-align:right">DHB Plan to Sunday 17 October</th>
+			<th scope="col" style="text-align:right">Variance</th>
+			<th scope="col" style="text-align:right">% of Plan</th>
+			<th scope="col" style="text-align:right">Week to date</th>
+		</tr>
+	</thead>
+	<tbody> --><!--plan--><!--
+<tr><td nowrap="nowrap">Auckland Metro</td><td>190621</td><td>205515</td><td>-14894</td><td>93%</td><td>9913</td></tr>
+<tr><td nowrap="nowrap">Bay of Plenty</td><td>22841</td><td>14255</td><td>8586</td><td>160%</td><td>1843</td></tr>
+<tr><td nowrap="nowrap">Canterbury</td><td>50558</td><td>39266</td><td>11292</td><td>129%</td><td>2769</td></tr>
+<tr><td nowrap="nowrap">Capital & Coast and Hutt Valley</td><td>48758</td><td>39742</td><td>9016</td><td>123%</td><td>1796</td></tr>
+<tr><td nowrap="nowrap">Hawke's Bay</td><td>15319</td><td>18205</td><td>-2886</td><td>84%</td><td>1351</td></tr>
+<tr><td nowrap="nowrap">Lakes</td><td>13437</td><td>12810</td><td>627</td><td>105%</td><td>731</td></tr>
+<tr><td nowrap="nowrap">MidCentral</td><td>10708</td><td>7237</td><td>3471</td><td>148%</td><td>1191</td></tr>
+<tr><td nowrap="nowrap">Nelson Marlborough</td><td>30198</td><td>18574</td><td>11624</td><td>163%</td><td>1285</td></tr>
+<tr><td nowrap="nowrap">Northland</td><td>21469</td><td>24762</td><td>-3293</td><td>87%</td><td>1257</td></tr>
+<tr><td nowrap="nowrap">South Canterbury</td><td>8106</td><td>8033</td><td>73</td><td>101%</td><td>389</td></tr>
+<tr><td nowrap="nowrap">Southern</td><td>35234</td><td>34594</td><td>640</td><td>102%</td><td>1794</td></tr>
+<tr><td nowrap="nowrap">Tairāwhiti</td><td>4579</td><td>4928</td><td>-349</td><td>93%</td><td>290</td></tr>
+<tr><td nowrap="nowrap">Taranaki</td><td>5619</td><td>5297</td><td>322</td><td>106%</td><td>168</td></tr>
+<tr><td nowrap="nowrap">Waikato</td><td>36070</td><td>32842</td><td>3228</td><td>110%</td><td>1905</td></tr>
+<tr><td nowrap="nowrap">Wairarapa</td><td>4516</td><td>4960</td><td>-444</td><td>91%</td><td>468</td></tr>
+<tr><td nowrap="nowrap">West Coast</td><td>3533</td><td>3300</td><td>233</td><td>107%</td><td>336</td></tr>
+<tr><td nowrap="nowrap">Whanganui</td><td>6982</td><td>4711</td><td>2271</td><td>148%</td><td>612</td></tr>
+<tr><td nowrap="nowrap">Other Sites</td><td>24890</td><td>14575</td><td>10315</td><td>171%</td><td>613</td></tr>
+<tr><td nowrap="nowrap">Total</td><td>533438</td><td>493606</td><td>39832</td><td>108%</td><td>28711</td></tr>
+!--plan_end--><!--	</tbody>
+</table>
+
+
+<p>The information provided in this table is based on cumulative DHB plans to the last week ending on Sunday. The final column shows vaccinations administered since Sunday by DHB of service to reconcile total actuals in this table to other total numbers shown.   On-going, and as we roll-out the vaccination programme, we anticipate that there could be a potential variance of up to ten percent (plus or minus) between DHB Plans and actual vaccination numbers. This is on the basis that, for example, an unplanned significant event could affect roll-out implementation or some DHBs might exceed their planned vaccination numbers.
+</p>
+-->
+
+<hr/>
+<h3><a id="by_dhb" name="location"></a>Cumulative vaccinations by DHB</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Cumulative vaccinations for DHBs" class="img-responsive" height="830" src="/web/20211025040431im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/dhbstacked_11.png" width="1780"/></figure>
+
+<hr/>
+<h3><a id="by-day" name="by-day"></a>Vaccinations by day</h3>
+
+<figure class="image-captioned img-responsive"><img alt="Vaccination doses administered per day" class="img-responsive" height="830" src="/web/20211025040431im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/vaccinebyday_11.png" width="1780"/></figure>
+
+<p>This chart shows the count of vaccinations administered on a given day from the COVID-19 Immunisation Register. Note some records are entered in the register at a later date than the immunisation was received. This means that the figures for a given date may move for some time after that date.</p>
+
+<hr/>
+<h3><a id="group" name="group"></a>Vaccinations by group by week</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccinations by group" class="img-responsive" height="830" src="/web/20211025040431im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/vaccinebygroupwk_11.png" width="1780"/></figure>
+
+<hr/>
+<h3><a id="group_d" name="group_d"></a>Cumulative vaccinations by group</h3>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">Priority Group</th>
+			<th scope="col" style="text-align:right">First dose administered</th>
+			<th scope="col" style="text-align:right">Second dose administered</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">Group 1</th>
+			<td style="text-align:right">66,654</td>
+			<td style="text-align:right">64,835</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Group 2</th>
+			<td style="text-align:right">634,957</td>
+			<td style="text-align:right">595,136</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Group 3</th>
+			<td style="text-align:right">790,330</td>
+			<td style="text-align:right">734,465</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Group 4</th>
+			<td style="text-align:right">2,101,547</td>
+			<td style="text-align:right">1,443,270</td>
+		</tr>
+	</tbody>
+</table>
+
+<p>For definitions of the groups and further detail see the downloadable spreadsheet at the bottom of the page.</p>
+
+<hr/>
+<h3><a id="by_soh" name="stockonhand"></a>Vaccine available for distribution at week end</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine available for distribution at week end" class="img-responsive" height="830" src="/web/20211025040431im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/stockonhand_12.png" width="1780"/></figure>
+
+<p>Vaccine available for distribution is stock (in doses) held at central warehouses. It does not include stock in transit or available at sites ready for use.</p>
+
+<hr/>
+<h3><a id="by_eth" name="ethnicity"></a>Total cumulative doses per 1,000 people by ethnicity</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Total cumulative doses per 1,000 people by ethnicity" class="img-responsive" height="830" src="/web/20211025040431im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/ethnicity_11.png" width="1780"/></figure>
+
+<p>This chart shows both first and second doses. As a result this chart may exceed 1,000 doses per 1,000 people.</p>
+
+<p><strong>*</strong> The prioritised ethnicity classification system allocates each person to a single ethnic group, based on the ethnic groups they identify with. Where people identify with more than one group, they are assigned in this order of priority: Māori, Pacific Peoples, Asian, and European/Other. So, if a person identifies as being Māori and New Zealand European, the person is counted as Māori. See <a href="/web/20211025040431/https://www.health.govt.nz/publication/hiso-100012017-ethnicity-data-protocols">Ethnicity Data Protocols</a> for further information.</p>
+
+<p>Ethnicity breakdown by DHB of residence is available in the downloadable spreadsheet at the bottom of the page.</p>
+
+<hr/>
+<h3><a id="by_age" name="age"></a>Cumulative vaccinations by age</h3>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">Age</th>
+			<th scope="col" style="text-align:right">First dose administered</th>
+			<th scope="col" style="text-align:right">First doses per 1,000 people</th>
+			<th scope="col" style="text-align:right">Fully vaccinated</th>
+			<th scope="col" style="text-align:right">Fully vaccinated per 1,000 people</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">12 - 19 years</th>
+			<td style="text-align:right">389,918</td>
+			<td style="text-align:right">776</td>
+			<td style="text-align:right">247,401</td>
+			<td style="text-align:right">492</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">20 - 34 years</th>
+			<td style="text-align:right">819,368</td>
+			<td style="text-align:right">792</td>
+			<td style="text-align:right">542,717</td>
+			<td style="text-align:right">525</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">35 - 49 years</th>
+			<td style="text-align:right">810,315</td>
+			<td style="text-align:right">847</td>
+			<td style="text-align:right">620,812</td>
+			<td style="text-align:right">649</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">50 - 64 years</th>
+			<td style="text-align:right">828,152</td>
+			<td style="text-align:right">893</td>
+			<td style="text-align:right">722,868</td>
+			<td style="text-align:right">779</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">65 and over</th>
+			<td style="text-align:right">745,735</td>
+			<td style="text-align:right">946</td>
+			<td style="text-align:right">703,908</td>
+			<td style="text-align:right">893</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total</strong></th>
+			<td style="text-align:right"><strong>3,593,488</strong></td>
+			<td style="text-align:right"><strong>854</strong></td>
+			<td style="text-align:right"><strong>2,837,706</strong></td>
+			<td style="text-align:right"><strong>674</strong></td>
+		</tr>
+	</tbody>
+</table>
+
+<p>Age breakdown by ethnicity and gender is available in the downloadable spreadsheet at the bottom of the page.</p>
+
+<hr/>
+<h3><a id="workforce" name="workforce"></a>Trained vaccinators and active vaccinators</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Trained vaccinators and active vaccinators" class="img-responsive" height="830" src="/web/20211025040431im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/workforce_11.png" width="1780"/></figure>
+
+<p><strong>Trained vaccinators</strong> are individuals who have completed the COVID-19 training. Many trained people are only able to offer a small number of hours to the COVID-19 vaccination programme.</p>
+
+<p><strong>Active vaccinators</strong> are trained individuals who are actively vaccinating. The number of active vaccinators does not reflect the hours worked vaccinating. For example, one vaccinator may work 40 hours in a week at one DHB and will show as 1 vaccinator in the headcount. In another DHB, 4 vaccinators may work 10 hours each (total 40 hours), but will show as 4 vaccinators in the headcount for that week.</p>
+
+<p>Both counts of trained and active vaccinators are cumulative. The difference between the two is due to a number of factors. This includes: individuals being trained in anticipation of future sites being opened (the largest factor); rostering; leave or non-availability; local health priorities; sites opening and closing.</p>
+
+<hr/>
+<h3><a id="usage" name="usage"></a>Wastage of vaccine stock</h3>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">&nbsp;</th>
+			<th scope="col">Wastage</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">New Zealand</th>
+			<td>0.27%</td>
+		</tr>
+	</tbody>
+</table>
+
+<p>Wastage is vials that have been reported as wasted since 13 July in the Inventory portal by DHBs or central warehouses divided by vials used over the same time frame.</p>
+
+<h3><a id="download" name="download"></a>Details of vaccination data</h3>
+
+<p>Download a spreadsheet containing key vaccination data. This includes HSU based population estimates for calculating vaccine uptake rates.</p>
+
+<p><a download="" href="/web/20211025040431/https://www.health.govt.nz/system/files/documents/pages/covid_vaccinations_19_10_2021.xlsx">COVID-19 vaccination data through 19 Oct 2021 (Excel, 359 KB)</a></p>
+
+<p>This spreadsheet is based on the information made available at the time of publishing and may be subject to changes. Please take note of any notes and caveats on each sheet.</p>
+
+<p>The below attachments provide some analysis on our progress on equity. The two PDF files are high level summaries of overall progress. The Excel documents are interactive and provides the ability to delve further into those overall numbers. NB: These Excel workbooks use features that are non-compatible with versions of MS Office 2016 and earlier.</p>
+
+<ul>
+	<li><a download="" href="/web/20211025040431/https://www.health.govt.nz/system/files/documents/pages/211017_-_cvip_equity_-_rate_ratios_by_ethicity_ageband_and_dhb.pdf">Covid-19 Vaccine Rate Ratios by Ethnicity, Ageband and DHB (PDF, 642 KB)</a></li>
+	<li><a download="" href="/web/20211025040431/https://www.health.govt.nz/system/files/documents/pages/211017_-_cvip_equity_-_uptake_by_ethicity_ageband_and_dhb.pdf">Covid-19 Vaccine Uptake by Ethnicity, Ageband and DHB (PDF, 551 KB)</a></li>
+	<li><a download="" href="/web/20211025040431/https://www.health.govt.nz/system/files/documents/pages/211017_-_cvip_equity_-_level_1_ethnicity_uptake_and_rate_ratios.xlsx">Covid-19 Vaccine Equity - Level 1 Ethnicity Uptake and Rate Ratios (Excel, 152 KB)</a></li>
+	<li><a download="" href="/web/20211025040431/https://www.health.govt.nz/system/files/documents/pages/211017_-_cvip_equity_-_level_2_ethnicity_uptake_and_rate_ratios.xlsx">Covid-19 Vaccine Equity - Level 2 Ethnicity Uptake and Rate Ratios (Excel, 378 KB)</a></li>
+	<li><a download="" href="/web/20211025040431/https://www.health.govt.nz/system/files/documents/pages/211017_-_cvip_equity_-_rate_ratios_and_uptake_over_time.xlsx">Rate Ratios and Uptake Over Time (Excel, 972 KB)</a></li>
+</ul>
+
+<hr/>
+<h3><a id="adverse-events" name="adverse-events"></a>Adverse events following&nbsp;immunisations (AEFI)</h3>
+
+<p>Like all medicines, the COVID-19 vaccine may cause side effects in some people. These are common, are usually mild, don&rsquo;t last long and won&rsquo;t stop people from having the second dose or going about daily life. Serious allergic reactions do occur but are extremely rare.</p>
+
+<p>Suspected AEFI to COVID-19 vaccines are reported to the <a href="https://web.archive.org/web/20211025040431/https://nzphvc.otago.ac.nz/">Centre for Adverse Reactions Monitoring</a> (CARM).&nbsp;<a href="https://web.archive.org/web/20211025040431/https://www.medsafe.govt.nz/">Medsafe</a> is closely monitoring the AEFI reported from the use of the COVID-19 vaccine and will report regularly on their findings.&nbsp;</p>
+
+<p><a href="https://web.archive.org/web/20211025040431/https://www.medsafe.govt.nz/COVID-19/vaccine-report-overview.asp">View Medsafe data on COVID-19 vaccine adverse effects following immunisation</a></p>
+</div></div></div>    </article>
+  </div>
+
+
+  </div>
+<div class="panel-pane pane-node-links even">
+
+
+
+  <div class="pane-content">
+          </div>
+
+
+  </div>
+
+<div class="panel-pane pane-views pane-sub-pages even">
+
+        <h2 class="pane-title h3">In this section</h2>
+
+
+  <div class="pane-content">
+        <div class="view view-sub-pages view-id-sub_pages view-display-id-block view-dom-id-7f441262cb4bea211b9322edaf1d48ed">
+
+
+
+      <div class="view-content">
+      <div class="item-list">    <ul>          <li class="views-row views-row-1 views-row-odd views-row-first">
+  <div class="views-field views-field-title">        <div class="field-content">
+<div class="views-field views-field-title">
+  <h3 class="field-content">
+    <a href="/web/20211025040431/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-across-nz">COVID-19 Vaccination uptake rates across NZ</a>  </h3>
+</div></div>  </div>
+  <span class="views-field views-field-body">        <span class="field-content">This page provides information related to uptake rates of the COVID-19 vaccine across the country.
+</span>  </span>
+  <span class="views-field views-field-view-node">        <span class="field-content"><a href="/web/20211025040431/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-across-nz">Read more</a></span>  </span></li>
+          <li class="views-row views-row-2 views-row-even">
+  <div class="views-field views-field-title">        <div class="field-content">
+<div class="views-field views-field-title">
+  <h3 class="field-content">
+    <a href="/web/20211025040431/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-maori-communities-across-nz">COVID-19 Vaccination uptake rates within Māori communities across NZ</a>  </h3>
+</div></div>  </div>
+  <span class="views-field views-field-body">        <span class="field-content">This page provides information related to uptake rates of the COVID-19 vaccine within Māori communities across New Zealand.
+</span>  </span>
+  <span class="views-field views-field-view-node">        <span class="field-content"><a href="/web/20211025040431/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-maori-communities-across-nz">Read more</a></span>  </span></li>
+          <li class="views-row views-row-3 views-row-odd views-row-last">
+  <div class="views-field views-field-title">        <div class="field-content">
+<div class="views-field views-field-title">
+  <h3 class="field-content">
+    <a href="/web/20211025040431/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-pacific-communities-across-nz">COVID-19 Vaccination uptake rates within Pacific communities across NZ</a>  </h3>
+</div></div>  </div>
+  <span class="views-field views-field-body">        <span class="field-content">This page provides information related to uptake rates of the COVID-19 vaccine within Pacific communities across New Zealand.
+</span>  </span>
+  <span class="views-field views-field-view-node">        <span class="field-content"><a href="/web/20211025040431/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-pacific-communities-across-nz">Read more</a></span>  </span></li>
+      </ul></div>    </div>
+
+
+
+
+
+
+</div>  </div>
+
+
+  </div>
+</div>          </div>
+
+  </div>
+
+</section>
+  </div>
+      </section>
+
+
+    </div>
+    <div id="content-footer-wrapper" class="clearfix">
+      <div id="content-footer" class="clearfix">
+                  <p class="page_updated">Page last updated: <span class="date">25 October 2021</span></p>                  <div class="region region-content-footer">
+    <section id="block-moh-tools-page-tools" class="block block-moh-tools clearfix">
+  <a href="#" data-placement="top" data-title="Share this content." data-html="true" data-content="<p>Share this page on some of the most popular social networking and content sites on the internet.</p><div class='service-links'><ul><li><a href='https://twitter.com/share?url=https%3A//www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data&amp;text=COVID-19%3A%20Vaccine%20data' title='Share this on Twitter' class='service-links-twitter' rel='nofollow'><img typeof='foaf:Image' class='img-responsive' src='https://www.health.govt.nz/sites/all/modules/contrib/service_links/images/twitter.png' alt='Twitter' /> Twitter</a></li>
+<li><a href='https://www.facebook.com/sharer.php?u=https%3A//www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data&amp;t=COVID-19%3A%20Vaccine%20data' title='Share on Facebook' class='service-links-facebook' rel='nofollow'><img typeof='foaf:Image' class='img-responsive' src='https://www.health.govt.nz/sites/all/modules/contrib/service_links/images/facebook.png' alt='Facebook' /> Facebook</a></li>
+</ul></div>" class="share-this-content"><i class="fa fa-share"></i> Share</a><a href="#" title="print this page" class="print"><i class="fa fa-print"></i> Print</a><a href="https://web.archive.org/web/20211025040431/https://www.health.govt.nz/forward?path=node/12052" title="Email this page" class="email"><i class="fa fa-envelope"></i> Email</a><a href="/web/20211025040431/https://www.health.govt.nz/feedback?ref=https%3A//www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="Feedback" class="rss"><i class="fa fa-comment"></i> Feedback</a></section>
+
+  </div>
+      </div>
+    </div>
+
+  </div>
+  <footer class="footer container">
+    <h2 class="hidden">Site Footer</h2>
+    <div class="footer-default">
+      <div class="row">
+        <div class="col-sm-6 col-md-6">
+          <div class="field field-name-field-tax-first-column-links">
+            <ul class="field-items"><li class="field-item"><a href="https://web.archive.org/web/20211025040431/https://www.health.govt.nz/node/492" class="">About this site</a></li><li class="field-item"><a href="https://web.archive.org/web/20211025040431/https://www.health.govt.nz/node/524" class="">Contact us</a></li><li class="field-item"><a href="https://web.archive.org/web/20211025040431/https://www.health.govt.nz/node/488" class="">Other Ministry of Health websites</a></li><li class="field-item"><a href="https://web.archive.org/web/20211025040431/https://www.health.govt.nz/node/7497" class="">Official Information Act requests</a></li><li class="field-item"><a href="https://web.archive.org/web/20211025040431/https://www.health.govt.nz/about-ministry/information-releases" class="">Information releases</a></li><li class="field-item"><a href="https://web.archive.org/web/20211025040431/https://consult.health.govt.nz/" class="">Consultations</a></li></ul>
+          </div>
+        </div>
+        <div class="col-sm-6 col-md-6">
+          <div class="field field-name-field-tax-footer-body field-type-text-long field-label-hidden"><div class="field-items"><div class="field-item even"><h3>Where to go for help</h3>
+
+<table>
+	<tbody>
+		<tr>
+			<th scope="row">Emergencies</th>
+			<td><strong>Dial <a href="tel:111">111</a></strong> (for ambulance, fire or police)</td>
+		</tr>
+		<tr>
+			<th scope="row">Healthline</th>
+			<td><strong>Dial <a href="tel:0800611116">0800 611 116</a></strong></td>
+		</tr>
+		<tr>
+			<th scope="row">Poisons</th>
+			<td><strong>Dial <a href="tel:0800764766">0800 POISON</a> </strong>(<a href="tel:0800764766">0800 764 766</a>)</td>
+		</tr>
+		<tr>
+			<th scope="row">Mental health crisis</th>
+			<td><strong><a href="/web/20211025040431/https://www.health.govt.nz/your-health/services-and-support/health-care-services/mental-health-services/crisis-assessment-teams">Emergency contact numbers</a></strong></td>
+		</tr>
+	</tbody>
+</table>
+</div></div></div>        </div>
+      </div>
+      <div class="row">
+        <div class="sub-footer">
+          <div class="column col-sm-12 col-md-3">
+            <a href="https://web.archive.org/web/20211025040431/https://www.govt.nz/">
+              <img src="/web/20211025040431im_/https://www.health.govt.nz/sites/all/themes/mohpub_bootstrap/images/nzgovtlogo_white.png" width="152" height="16" alt="govt.nz - connecting you to New Zealand central &amp; local government services" title="govt.nz - connecting you to New Zealand central &amp; local government services"/>
+            </a>
+          </div>
+          <div class="column col-sm-12 col-md-9">
+          <span class="bottom-menu-moh with-v-divider">&copy; Ministry of Health – Manatū Hauora</span><ul class="bottom-menu-list"><li class="bottom-menu-list-item with-v-divider"><a href="https://web.archive.org/web/20211025040431/https://www.health.govt.nz/sitemap" class="">Site map</a></li><li class="bottom-menu-list-item with-v-divider"><a href="https://web.archive.org/web/20211025040431/https://www.health.govt.nz/about-site/privacy-and-security" class="">Privacy &amp; security</a></li><li class="bottom-menu-list-item with-v-divider"><a href="https://web.archive.org/web/20211025040431/https://www.health.govt.nz/about-site/copyright" class="">Copyright</a></li></ul>          </div>
+        </div>
+      </div>
+    </div>
+    <div class="footer-print">&copy; Ministry of Health – Manatū Hauora</div>
+  </footer>
+  <a class="scrollToTop">Back to top <i class="fas fa-arrow-up"></i></a>
+</div>
+  <script src="https://web.archive.org/web/20211025040431js_/https://www.health.govt.nz/sites/default/files/js/js_akZOsKtodu3PdnQzY3_ElOfujkLxJcowmaWgHTBBLOE.js"></script>
+</body>
+</html>
+<!--
+     FILE ARCHIVED ON 04:04:31 Oct 25, 2021 AND RETRIEVED FROM THE
+     INTERNET ARCHIVE ON 03:24:43 Nov 07, 2021.
+     JAVASCRIPT APPENDED BY WAYBACK MACHINE, COPYRIGHT INTERNET ARCHIVE.
+
+     ALL OTHER CONTENT MAY ALSO BE PROTECTED BY COPYRIGHT (17 U.S.C.
+     SECTION 108(a)(3)).
+-->
+<!--
+playback timings (ms):
+  captures_list: 262.718
+  exclusion.robots: 0.201
+  exclusion.robots.policy: 0.193
+  RedisCDXSource: 28.184
+  esindex: 0.009
+  LoadShardBlock: 186.797 (3)
+  PetaboxLoader3.datanode: 220.148 (4)
+  CDXLines.iter: 25.17 (3)
+  load_resource: 111.957
+  PetaboxLoader3.resolve: 55.987
+-->

--- a/data/rawSite/2021-10-25.html
+++ b/data/rawSite/2021-10-25.html
@@ -1,0 +1,2510 @@
+
+<!DOCTYPE html>
+<html lang="en" dir="ltr" prefix="" class="no-js">
+<head><script src="//archive.org/includes/analytics.js?v=cf34f82" type="text/javascript"></script>
+<script type="text/javascript">window.addEventListener('DOMContentLoaded',function(){var v=archive_analytics.values;v.service='wb';v.server_name='wwwb-app214.us.archive.org';v.server_ms=201;archive_analytics.send_pageview({});});</script>
+<script type="text/javascript" src="/_static/js/bundle-playback.js?v=UfTkgsKx" charset="utf-8"></script>
+<script type="text/javascript" src="/_static/js/wombat.js?v=UHAOicsW" charset="utf-8"></script>
+<script type="text/javascript">
+  __wm.init("https://web.archive.org/web");
+  __wm.wombat("https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data","20211026003402","https://web.archive.org/","web","/_static/",
+	      "1635208442");
+</script>
+<link rel="stylesheet" type="text/css" href="/_static/css/banner-styles.css?v=omkqRugM" />
+<link rel="stylesheet" type="text/css" href="/_static/css/iconochive.css?v=qtvMKcIJ" />
+<!-- End Wayback Rewrite JS Include -->
+
+  <!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta name="format-detection" content="telephone=no"/>
+  <link rel="profile" href="http://www.w3.org/1999/xhtml/vocab"/>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+<link rel="shortcut icon" href="https://web.archive.org/web/20211026003402im_/https://www.health.govt.nz/sites/all/themes/mohpub_bootstrap/favicon.ico" type="image/vnd.microsoft.icon"/>
+<meta name="description" content="Dashboard of data and statistics about the rollout of COVID-19 vaccines in New Zealand"/>
+<meta name="generator" content="Drupal 7 (https://www.drupal.org)"/>
+<link rel="canonical" href="https://web.archive.org/web/20211026003402/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data"/>
+<link rel="shortlink" href="https://web.archive.org/web/20211026003402/https://www.health.govt.nz/node/12052"/>
+<meta property="og:site_name" content="Ministry of Health NZ"/>
+<meta property="og:type" content="article"/>
+<meta property="og:url" content="https://web.archive.org/web/20211026003402/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data"/>
+<meta property="og:title" content="COVID-19: Vaccine data"/>
+<meta property="og:description" content="Dashboard of data and statistics about the rollout of COVID-19 vaccines in New Zealand"/>
+  <title>COVID-19: Vaccine data | Ministry of Health NZ</title>
+  <link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211026003402cs_/https://www.health.govt.nz/sites/default/files/css/css_lQaZfjVpwP_oGNqdtWCSpJT1EMqXdMiU84ekLLxQnc4.css" media="all"/>
+<link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211026003402cs_/https://www.health.govt.nz/sites/default/files/css/css_jqUBpWfMaxMiP7LismdZVlyVv8azUJSE2yaH58nj0cE.css" media="all"/>
+<link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211026003402cs_/https://www.health.govt.nz/sites/default/files/css/css_Rb1wqFBC8VXCJC-BuNY53cvjjlj6UADGvqzo_f-1yN0.css" media="all"/>
+<link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211026003402cs_/https://www.health.govt.nz/sites/default/files/css/css_38_K1lHKg-98m4KKRfv57JBK0gvlKscexGt9MKoi0DE.css" media="all"/>
+<link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211026003402cs_/https://www.health.govt.nz/sites/default/files/css/css_r7NPyvpdYfAyZmk9zkK8OaFKEFj6er5ZJnam2H644DM.css" media="print"/>
+  <link rel="alternate stylesheet" type="text/css" href="/web/20211026003402cs_/https://www.health.govt.nz/sites/all/themes/mohpub_bootstrap/css/high-contrast.css" media="screen" title="High Contrast"/>
+  <script src="https://web.archive.org/web/20211026003402js_/https://www.health.govt.nz/sites/default/files/js/js_zS-CmNFGyegtLYJmqFRpxQvvQrfPIFrOMq_3T3C8sZE.js"></script>
+<script src="https://web.archive.org/web/20211026003402js_/https://www.health.govt.nz/sites/default/files/js/js_fNgZ4Okisfr70Q0yvAYsATgB0o_jD3-srhQQ-VHmlXE.js"></script>
+<script src="https://web.archive.org/web/20211026003402js_/https://www.health.govt.nz/sites/default/files/js/js_YAdPZfg12M1m7ROp3_gVJPS5sArqL0kYQgNRPoicvHE.js"></script>
+<script>(function(i,s,o,g,r,a,m){i["GoogleAnalyticsObject"]=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,"script","https://web.archive.org/web/20211026003402/https://www.google-analytics.com/analytics.js","ga");ga("create", "UA-3573389-24", {"cookieDomain":".www.health.govt.nz","siteSpeedSampleRate":15});ga("send", "pageview");</script>
+<script src="https://web.archive.org/web/20211026003402js_/https://www.health.govt.nz/sites/default/files/js/js_QAXZNPwLISRLHqyNpT4Vvr_iqD9foD6GTbEjlhIIjeo.js"></script>
+<script src="https://web.archive.org/web/20211026003402js_/https://www.health.govt.nz/sites/default/files/js/js_4VW9edmu3V8VjGJxFfXGAwkXeW2cJIa5h-6y7SgwVrk.js"></script>
+<script>    (function(h,o,t,j,a,r){
+        h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
+        h._hjSettings={hjid:930919,hjsv:6};
+        a=o.getElementsByTagName('head')[0];
+        r=o.createElement('script');r.async=1;
+        r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+        a.appendChild(r);
+    })(window,document,'https://web.archive.org/web/20211026003402/https://static.hotjar.com/c/hotjar-','.js?sv=');
+</script>
+<script>jQuery.extend(Drupal.settings, {"basePath":"\/","pathPrefix":"","ajaxPageState":{"theme":"mohpub_bootstrap","theme_token":"laVwum3hoZ2S3iVPpvWQbDXf6PZfJgYE96RTwBuQokY","js":{"sites\/all\/modules\/custom\/table_d3chart\/js\/table_d3chart.js":1,"sites\/all\/modules\/custom\/moh_d3\/moh_d3.js":1,"sites\/all\/modules\/contrib\/jquery_update\/replace\/jquery\/1.7\/jquery.min.js":1,"misc\/jquery-extend-3.4.0.js":1,"misc\/jquery-html-prefilter-3.5.0-backport.js":1,"misc\/jquery.once.js":1,"misc\/drupal.js":1,"sites\/all\/modules\/contrib\/ckeditor_accordion\/js\/ckeditor-accordion.js":1,"sites\/all\/modules\/contrib\/extlink\/extlink.js":1,"modules\/field\/modules\/text\/text.js":1,"sites\/all\/modules\/contrib\/field_group\/field_group.js":1,"sites\/all\/modules\/contrib\/google_analytics\/googleanalytics.js":1,"0":1,"sites\/all\/libraries\/c3\/c3.js":1,"sites\/all\/libraries\/d3\/d3.min.js":1,"sites\/all\/modules\/contrib\/d3\/js\/d3.js":1,"sites\/all\/libraries\/d3.helpers\/d3.helpers.js":1,"sites\/all\/libraries\/d3.c3\/d3-c3.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/assets\/ios-fix.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/affix.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/alert.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/button.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/carousel.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/collapse.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/dropdown.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/modal.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/tooltip.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/popover.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/scrollspy.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/tab.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/transition.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/jquery.cookie.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/jquery.moh.announcement.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/svgeezy.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/fitvids.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/bootstrap-tabcollapse.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/jquery.scrollTo.min.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/script.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/jquery.google_analytics.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/bootstrap-accessibility.min.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/style-switcher.js":1,"1":1},"css":{"modules\/system\/system.base.css":1,"sites\/all\/modules\/contrib\/calendar\/css\/calendar_multiday.css":1,"sites\/all\/modules\/contrib\/ckeditor_accordion\/css\/ckeditor-accordion.css":1,"modules\/field\/theme\/field.css":1,"modules\/node\/node.css":1,"sites\/all\/modules\/contrib\/extlink\/extlink.css":1,"sites\/all\/modules\/contrib\/views\/css\/views.css":1,"sites\/all\/modules\/contrib\/ckeditor\/css\/ckeditor.css":1,"sites\/all\/modules\/contrib\/ctools\/css\/ctools.css":1,"sites\/all\/modules\/contrib\/panels\/css\/panels.css":1,"sites\/all\/libraries\/c3\/c3.css":1,"sites\/all\/libraries\/d3.c3\/d3-c3.css":1,"sites\/all\/themes\/mohpub_bootstrap\/fontawesome\/css\/fontawesome.min.css":1,"sites\/all\/themes\/mohpub_bootstrap\/fontawesome\/css\/solid.min.css":1,"sites\/all\/themes\/mohpub_bootstrap\/fontawesome\/css\/brands.min.css":1,"sites\/all\/modules\/features\/site_profile\/css\/fix-rubik-multiselect-height.css":1,"sites\/all\/themes\/mohpub_bootstrap\/css\/style.css":1,"sites\/all\/themes\/mohpub_bootstrap\/css\/responsive-tables.css":1,"sites\/all\/themes\/mohpub_bootstrap\/css\/print.css":1}},"field_group":{"div":"full"},"ckeditor_accordion":{"collapseAll":1},"extlink":{"extTarget":0,"extClass":"ext","extLabel":"(link is external)","extImgClass":0,"extIconPlacement":"append","extSubdomains":0,"extExclude":"","extInclude":"","extCssExclude":"","extCssExplicit":"","extAlert":0,"extAlertText":"This link will take you to an external web site. We are not responsible for their content.","mailtoClass":"mailto","mailtoLabel":"(link sends e-mail)"},"googleanalytics":{"trackOutbound":1,"trackMailto":1,"trackDownload":1,"trackDownloadExtensions":"7z|aac|arc|arj|asf|asx|avi|bin|csv|doc|exe|flv|gif|gz|gzip|hqx|jar|jpe?g|js|mp(2|3|4|e?g)|mov(ie)?|msi|msp|pdf|phps|png|ppt|qtm?|ra(m|r)?|sea|sit|tar|tgz|torrent|txt|wav|wma|wmv|wpd|xls|xml|z|zip|docx|xlsx|pptx|pptm|ppsx|ppsm|epub"},"mohD3":{"C3Types":["line","spline","step","area","area-spline","area-step","bar","scatter","pie","donut","gauge"],"graphRender":"line","graphLegend":true,"graphDefaultColors":"#2b8cbe, #abdda4, #7f7f7f, #92cddc, #dc8b0c","graphDefaultGroupedTooltip":0,"graphDefaultGridX":0,"graphDefaultGridY":0,"graphDefaultLegendPosition":"top-right","graphDefaultTooltip":1,"graphDefaultDataLabel":0,"graphLegendStep":"5","graphInteraction":true,"graphTypes":"","graphXaxisShow":true,"graphXaxisLabel":"","graphYaxisLabel":"","graphXaxisType":"category","graphXaxisCentered":false,"graphXaxisRotation":"","graphXaxisHeight":"","graphYaxisShow":true,"graphYaxisMax":"","graphYaxisMin":"","graphYaxisInverted":false,"graphYaxisCenter":"","graphYaxisPrefix":"","graphYaxisSuffix":"","graphYaxisPosition":"","graphY2axisShow":false,"graphY2axisSource":"","graphY2axisMax":"","graphY2axisMin":"","graphGroups":"","graphRotated":false,"graphIgnoreEmpty":false,"graphLineDot":true,"graphBarRatio":"0.9","graphDot":true,"graphDotR":"2.5","graphFocus":false},"tableD3":{"show":"View table data source","hide":"Hide table data source"},"urlIsAjaxTrusted":{"\/our-work\/diseases-and-conditions\/covid-19-novel-coronavirus\/covid-19-data-and-statistics\/covid-19-vaccine-data":true},"bootstrap":{"anchorsFix":1,"anchorsSmoothScrolling":1,"formHasError":1,"popoverEnabled":1,"popoverOptions":{"animation":1,"html":0,"placement":"right","selector":"","trigger":"click","triggerAutoclose":1,"title":"","content":"","delay":0,"container":"body"},"tooltipEnabled":1,"tooltipOptions":{"animation":1,"html":0,"placement":"auto left","selector":"","trigger":"hover focus","delay":0,"container":"body"}}});</script>
+  <!-- HTML5 element support for IE6-8 -->
+  <!--[if lt IE 9]>
+    <script src="/sites/all/themes/mohpub_bootstrap/js/assets/html5shiv.js"></script>
+    <script src="/sites/all/themes/mohpub_bootstrap/js/assets/respond.min.js"></script>
+  <![endif]-->
+</head>
+<body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-12052 node-type-page node-has-intro"><!-- BEGIN WAYBACK TOOLBAR INSERT -->
+<style type="text/css">
+body {
+  margin-top:0 !important;
+  padding-top:0 !important;
+  /*min-width:800px !important;*/
+}
+</style>
+<script>__wm.rw(0);</script>
+<div id="wm-ipp-base" lang="en" style="display:none;direction:ltr;">
+<div id="wm-ipp" style="position:fixed;left:0;top:0;right:0;">
+<div id="wm-ipp-inside">
+  <div style="position:relative;">
+    <div id="wm-logo" style="float:left;width:110px;padding-top:12px;">
+      <a href="/web/" title="Wayback Machine home page"><img src="/_static/images/toolbar/wayback-toolbar-logo-200.png" srcset="/_static/images/toolbar/wayback-toolbar-logo-100.png, /_static/images/toolbar/wayback-toolbar-logo-150.png 1.5x, /_static/images/toolbar/wayback-toolbar-logo-200.png 2x" alt="Wayback Machine" style="width:100px" border="0" /></a>
+    </div>
+    <div class="r" style="float:right;">
+      <div id="wm-btns" style="text-align:right;height:25px;">
+                  <div id="wm-save-snapshot-success">success</div>
+          <div id="wm-save-snapshot-fail">fail</div>
+          <a id="wm-save-snapshot-open" href="#"
+	     title="Share via My Web Archive" >
+            <span class="iconochive-web"></span>
+          </a>
+          <a href="https://archive.org/account/login.php"
+             title="Sign In"
+             id="wm-sign-in"
+          >
+            <span class="iconochive-person"></span>
+          </a>
+          <span id="wm-save-snapshot-in-progress" class="iconochive-web"></span>
+        	<a href="http://faq.web.archive.org/" title="Get some help using the Wayback Machine" style="top:-6px;"><span class="iconochive-question" style="color:rgb(87,186,244);font-size:160%;"></span></a>
+	<a id="wm-tb-close" href="#close" onclick="__wm.h(event);return false;" style="top:-2px;" title="Close the toolbar"><span class="iconochive-remove-circle" style="color:#888888;font-size:240%;"></span></a>
+      </div>
+      <div id="wm-share">
+          <a href="/web/20211026003402/http://web.archive.org/screenshot/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data"
+             id="wm-screenshot"
+             title="screenshot">
+            <span class="wm-icon-screen-shot"></span>
+          </a>
+          <a href="#"
+            id="wm-video"
+            title="video">
+            <span class="iconochive-movies"></span>
+          </a>
+	<a id="wm-share-facebook" href="#" data-url="https://web.archive.org/web/20211026003402/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="Share on Facebook" style="margin-right:5px;" target="_blank"><span class="iconochive-facebook" style="color:#3b5998;font-size:160%;"></span></a>
+	<a id="wm-share-twitter" href="#" data-url="https://web.archive.org/web/20211026003402/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="Share on Twitter" style="margin-right:5px;" target="_blank"><span class="iconochive-twitter" style="color:#1dcaff;font-size:160%;"></span></a>
+      </div>
+    </div>
+    <table class="c" style="">
+      <tbody>
+	<tr>
+	  <td class="u" colspan="2">
+	    <form target="_top" method="get" action="/web/submit" name="wmtb" id="wmtb"><input type="text" name="url" id="wmtbURL" value="https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" onfocus="this.focus();this.select();" /><input type="hidden" name="type" value="replay" /><input type="hidden" name="date" value="20211026003402" /><input type="submit" value="Go" /></form>
+	  </td>
+	  <td class="n" rowspan="2" style="width:110px;">
+	    <table>
+	      <tbody>
+		<!-- NEXT/PREV MONTH NAV AND MONTH INDICATOR -->
+		<tr class="m">
+		  <td class="b" nowrap="nowrap"><a href="https://web.archive.org/web/20210925014632/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="25 Sep 2021"><strong>Sep</strong></a></td>
+		  <td class="c" id="displayMonthEl" title="You are here: 00:34:02 Oct 26, 2021">OCT</td>
+		  <td class="f" nowrap="nowrap">Nov</td>
+		</tr>
+		<!-- NEXT/PREV CAPTURE NAV AND DAY OF MONTH INDICATOR -->
+		<tr class="d">
+		  <td class="b" nowrap="nowrap"><a href="https://web.archive.org/web/20211024013718/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="01:37:18 Oct 24, 2021"><img src="/_static/images/toolbar/wm_tb_prv_on.png" alt="Previous capture" width="14" height="16" border="0" /></a></td>
+		  <td class="c" id="displayDayEl" style="width:34px;font-size:24px;white-space:nowrap;" title="You are here: 00:34:02 Oct 26, 2021">26</td>
+		  <td class="f" nowrap="nowrap"><a href="https://web.archive.org/web/20211027061824/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="06:18:24 Oct 27, 2021"><img src="/_static/images/toolbar/wm_tb_nxt_on.png" alt="Next capture" width="14" height="16" border="0" /></a></td>
+		</tr>
+		<!-- NEXT/PREV YEAR NAV AND YEAR INDICATOR -->
+		<tr class="y">
+		  <td class="b" nowrap="nowrap">2020</td>
+		  <td class="c" id="displayYearEl" title="You are here: 00:34:02 Oct 26, 2021">2021</td>
+		  <td class="f" nowrap="nowrap">2022</td>
+		</tr>
+	      </tbody>
+	    </table>
+	  </td>
+	</tr>
+	<tr>
+	  <td class="s">
+	    	    <div id="wm-nav-captures">
+	      	      <a class="t" href="/web/20211026003402*/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="See a list of every capture for this URL">682 captures</a>
+	      <div class="r" title="Timespan for captures of this URL">07 Apr 2021 - 06 Nov 2021</div>
+	      </div>
+	  </td>
+	  <td class="k">
+	    <a href="" id="wm-graph-anchor">
+	      <div id="wm-ipp-sparkline" title="Explore captures for this URL" style="position: relative">
+		<canvas id="wm-sparkline-canvas" width="650" height="27" border="0"></canvas>
+	      </div>
+	    </a>
+	  </td>
+	</tr>
+      </tbody>
+    </table>
+    <div style="position:absolute;bottom:0;right:2px;text-align:right;">
+      <a id="wm-expand" class="wm-btn wm-closed" href="#expand" onclick="__wm.ex(event);return false;"><span id="wm-expand-icon" class="iconochive-down-solid"></span> <span style="font-size:80%">About this capture</span></a>
+    </div>
+  </div>
+    <div id="wm-capinfo" style="border-top:1px solid #777;display:none; overflow: hidden">
+                    <div id="wm-capinfo-collected-by">
+    <div style="background-color:#666;color:#fff;font-weight:bold;text-align:center">COLLECTED BY</div>
+    <div style="padding:3px;position:relative" id="wm-collected-by-content">
+      <div style="display:inline-block;vertical-align:top;width:49%;">
+			<span class="c-logo" style="background-image:url(https://archive.org/services/img/save-page-now)"></span>
+		<div>Collection: <a style="color:#33f;" href="https://archive.org/details/save-page-now" target="_new"><span class="wm-title">Save Page Now</span></a></div>
+	      </div>
+    </div>
+    </div>
+    <div id="wm-capinfo-timestamps">
+    <div style="background-color:#666;color:#fff;font-weight:bold;text-align:center" title="Timestamps for the elements of this page">TIMESTAMPS</div>
+    <div>
+      <div id="wm-capresources" style="margin:0 5px 5px 5px;max-height:250px;overflow-y:scroll !important"></div>
+      <div id="wm-capresources-loading" style="text-align:left;margin:0 20px 5px 5px;display:none"><img src="/_static/images/loading.gif" alt="loading" /></div>
+    </div>
+    </div>
+  </div></div></div></div><div id="wm-ipp-print">The Wayback Machine - https://web.archive.org/web/20211026003402/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data</div>
+<div id="donato" style="position:relative;width:100%;">
+  <div id="donato-base">
+    <iframe id="donato-if" src="https://archive.org/includes/donate.php?as_page=1&amp;platform=wb&amp;referer=https%3A//web.archive.org/web/20211026003402/https%3A//www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data"
+	    scrolling="no" frameborder="0" style="width:100%; height:100%">
+    </iframe>
+  </div>
+</div><script type="text/javascript">
+__wm.bt(650,27,25,2,"web","https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data","20211026003402",1996,"/_static/",["/_static/css/banner-styles.css?v=omkqRugM","/_static/css/iconochive.css?v=qtvMKcIJ"], "False");
+  __wm.rw(1);
+</script>
+<!-- END WAYBACK TOOLBAR INSERT -->
+<!--googleoff: all-->
+  <div id="skip-link">
+    <a href="#skip-content" id="skipper" class="element-invisible element-focusable">Skip to main content</a>
+  </div>
+    <div id="page">
+  <header id="navbar" role="banner" class="navbar container navbar-default">
+          <ul class="menu nav navbar-nav secondary"><li class="first leaf jobs depth-1"><a href="https://web.archive.org/web/20211026003402/https://careers.health.govt.nz/" title="">Jobs</a></li>
+<li class="leaf news depth-1"><a href="/web/20211026003402/https://www.health.govt.nz/news-media" data-is-top-level="0" title="">News</a></li>
+<li class="leaf contact-us depth-1"><a href="/web/20211026003402/https://www.health.govt.nz/about-ministry/contact-us" title="">Contact us</a></li>
+<li class="leaf facebook depth-1"><a href="https://web.archive.org/web/20211026003402/https://www.facebook.com/minhealthnz/">Facebook</a></li>
+<li class="leaf twitter depth-1"><a href="https://web.archive.org/web/20211026003402/https://twitter.com/minhealthnz" data-is-top-level="0" title="">Twitter</a></li>
+<li class="last leaf youtube depth-1"><a href="https://web.archive.org/web/20211026003402/https://www.youtube.com/user/minhealthnz" data-is-top-level="0" title="">Youtube</a></li>
+</ul>        <div class="container">
+      <div class="navbar-header">
+                <a class="logo navbar-btn pull-left" href="/web/20211026003402/https://www.health.govt.nz/" title="Home">
+          <img src="/web/20211026003402im_/https://www.health.govt.nz/sites/all/themes/mohpub_bootstrap/images/mohlogo.svg" alt="Ministry of Health"/>
+        </a>
+                  <div class="region region-header-top">
+    <section id="block-apachesolr-panels-search-form" class="block block-apachesolr-panels clearfix">
+
+
+  <form action="/web/20211026003402/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" method="post" id="apachesolr-panels-search-block" accept-charset="UTF-8"><div><div class="form-item form-item-apachesolr-panels-search-form form-type-textfield form-group"> <label class="control-label" for="edit-apachesolr-panels-search-form">Search</label>
+<input title="Enter the terms you wish to search for." class="form-control form-text" type="text" id="edit-apachesolr-panels-search-form" name="apachesolr_panels_search_form" value="" size="15" maxlength="128"/></div><input type="hidden" name="form_build_id" value="form-c8oXjDTjaZk6MVZMyRZdH4LWEpGXEX-_MddlKA1nM7Q"/>
+<input type="hidden" name="form_id" value="apachesolr_panels_search_block"/>
+<div class="form-actions form-wrapper form-group" id="edit-actions"><button type="submit" id="edit-submit" name="op" value="Search" class="btn btn-primary form-submit">Search</button>
+</div></div></form>
+</section>
+  </div>
+        <!-- .btn-navbar is used as the toggle for collapsed navbar content -->
+        <button aria-expanded="false" aria-controls="megamenu" type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+                    <span class="menu-text">Menu</span><span class="sr-only">Toggle navigation</span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+
+        </button>
+      </div>
+
+              <div class="navbar-collapse collapse">
+          <nav id="megamenu" role="navigation">
+                          <h2 class="element-invisible">Main menu</h2><ul id="main-menu" class="menu nav navbar-nav yamm navbar"><li class="first dropdown"><a href="/web/20211026003402/https://www.health.govt.nz/your-health" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="megamenu-dropdown-780">Your health <b class="caret"></b></a>
+    <div id="megamenu-dropdown-780" class="dropdown-menu">
+    <div class="yamm-content">
+      <div class="row">
+                            <div class="col">
+            <h3><a href="/web/20211026003402/https://www.health.govt.nz/your-health/conditions-and-treatments?mega=Your%20health&amp;title=Conditions%20%26%20treatments" class="menu-header">Conditions &amp; treatments</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211026003402/https://www.health.govt.nz/your-health/conditions-and-treatments/mental-health/depression?mega=Your%20health&amp;title=Depression">Depression</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/diabetes?mega=Your%20health&amp;title=Diabetes">Diabetes</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/influenza?mega=Your%20health&amp;title=Influenza">Influenza</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/measles?mega=Your%20health&amp;title=Measles">Measles</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/meningococcal-disease-including-meningitis?mega=Your%20health&amp;title=Meningococcal%20disease">Meningococcal disease</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/mumps?mega=Your%20health&amp;title=Mumps">Mumps</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/respiratory-syncytial-virus-rsv?mega=Your%20health&amp;title=RSV">RSV</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/sore-throat?mega=Your%20health&amp;title=Sore%20throat">Sore throat</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/your-health/conditions-and-treatments?mega=Your%20health&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211026003402/https://www.health.govt.nz/your-health/healthy-living?mega=Your%20health&amp;title=Healthy%20living" class="menu-header">Healthy living</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211026003402/https://www.health.govt.nz/your-health/healthy-living/drinking-water?mega=Your%20health&amp;title=Drinking-water">Drinking-water</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/your-health/healthy-living/food-activity-and-sleep/green-prescriptions?mega=Your%20health&amp;title=Green%20Prescriptions">Green Prescriptions</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/your-health/healthy-living/food-activity-and-sleep/healthy-eating?mega=Your%20health&amp;title=Healthy%20eating">Healthy eating</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/your-health/healthy-living/immunisation?mega=Your%20health&amp;title=Immunisation">Immunisation</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/your-health/healthy-living/food-activity-and-sleep/physical-activity?mega=Your%20health&amp;title=Physical%20activity">Physical activity</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/your-health/healthy-living/addictions/quitting-smoking?mega=Your%20health&amp;title=Smoking">Smoking</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/your-health/healthy-living/teeth-and-gums?mega=Your%20health&amp;title=Teeth%20and%20gums">Teeth and gums</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/your-health/healthy-living?mega=Your%20health&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211026003402/https://www.health.govt.nz/your-health/pregnancy-and-kids?mega=Your%20health&amp;title=Pregnancy%20and%20kids" class="menu-header">Pregnancy and kids</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211026003402/https://www.health.govt.nz/your-health/pregnancy-and-kids/birth-and-afterwards?mega=Your%20health&amp;title=Birth%20and%20afterwards">Birth and afterwards</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/your-health/pregnancy-and-kids/first-year/helpful-advice-during-first-year/breastfeeding-perfect-you-and-your-baby?mega=Your%20health&amp;title=Breastfeeding">Breastfeeding</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/your-health/pregnancy-and-kids/pregnancy?mega=Your%20health&amp;title=Pregnancy">Pregnancy</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/your-health/pregnancy-and-kids/services-and-support-during-pregnancy?mega=Your%20health&amp;title=Services%20and%20support%20during%20pregnancy">Services and support during pregnancy</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/your-health/pregnancy-and-kids/services-and-support-you-and-your-child?mega=Your%20health&amp;title=Services%20and%20support%20for%20you%20and%20your%20child">Services and support for you and your child</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/your-health/pregnancy-and-kids/first-year?mega=Your%20health&amp;title=The%20first%20year">The first year</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/your-health/pregnancy-and-kids/under-fives?mega=Your%20health&amp;title=Under%20fives">Under fives</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/your-health/pregnancy-and-kids?mega=Your%20health&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211026003402/https://www.health.govt.nz/your-health/services-and-support?mega=Your%20health&amp;title=Services%20and%20support" class="menu-header">Services &amp; support</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211026003402/https://www.health.govt.nz/your-health/services-and-support/health-care-services/help-alcohol-and-drug-problems?mega=Your%20health&amp;title=Alcohol%20and%20drugs">Alcohol and drugs</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/your-health/services-and-support/disability-services?mega=Your%20health&amp;title=Disability%20services">Disability services</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/your-health/services-and-support/health-care-services/earthquake-support-line?mega=Your%20health&amp;title=Earthquake%20Support%20Line">Earthquake Support Line</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/your-health/services-and-support/health-care-services/healthline?mega=Your%20health&amp;title=Healthline">Healthline</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/your-health/services-and-support/health-care-services/mental-health-services?mega=Your%20health&amp;title=Mental%20health%20services">Mental health services</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/your-health/services-and-support/health-care-services/maori-health-provider-directory?mega=Your%20health&amp;title=M%C4%81ori%20health%20providers">Māori health providers</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/your-health/services-and-support/health-care-services/services-older-people/rest-home-certification-and-audits?mega=Your%20health&amp;title=Rest%20home%20certification">Rest home certification</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/your-health/services-and-support/health-care-services/hospitals-and-specialist-services/travel-assistance?mega=Your%20health&amp;title=Travel%20assistance">Travel assistance</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/your-health/services-and-support?mega=Your%20health&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                        </div>
+    </div>
+    <div class="feature-links">
+      <h3 class="sr-only">Other related resources</h3>
+      <a href="/web/20211026003402/https://www.health.govt.nz/your-health/full-a-z?mega=Your%20health&amp;title=A-Z">View the full A-Z</a>    </div>
+  </div>
+</li>
+<li class="dropdown"><a href="/web/20211026003402/https://www.health.govt.nz/new-zealand-health-system" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="megamenu-dropdown-6076">NZ health system <b class="caret"></b></a>
+    <div id="megamenu-dropdown-6076" class="dropdown-menu">
+    <div class="yamm-content">
+      <div class="row">
+                            <div class="col">
+            <h3><a href="/web/20211026003402/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people?mega=NZ%20health%20system&amp;title=Key%20organisations" class="menu-header">Key organisations</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211026003402/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/crown-entities-and-statutory-boards?mega=NZ%20health%20system&amp;title=Crown%20entities%20%26%20agencies">Crown entities &amp; agencies</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/district-health-boards?mega=NZ%20health%20system&amp;title=District%20health%20boards">District health boards</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/non-governmental-organisations?mega=NZ%20health%20system&amp;title=Non-governmental%20organisations">Non-governmental organisations</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/primary-health-organisations?mega=NZ%20health%20system&amp;title=Primary%20health%20organisations">Primary health organisations</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/public-health-units?mega=NZ%20health%20system&amp;title=Public%20health%20units">Public health units</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people?mega=NZ%20health%20system&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211026003402/https://www.health.govt.nz/new-zealand-health-system/health-system-indicators-framework?mega=NZ%20health%20system&amp;title=Health%20System%20Indicators%20framework" class="menu-header">Health System Indicators framework</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211026003402/https://www.health.govt.nz/new-zealand-health-system/health-system-indicators-framework?mega=NZ%20health%20system&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211026003402/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services?mega=NZ%20health%20system&amp;title=Eligibility%20for%20public%20health%20services" class="menu-header">Eligibility for public health services</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211026003402/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services/guide-eligibility-publicly-funded-health-services?mega=NZ%20health%20system&amp;title=Guide%20to%20eligibility">Guide to eligibility</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services/eligibility-questions-and-answers-consumers?mega=NZ%20health%20system&amp;title=Q%26A%20for%20consumers">Q&amp;A for consumers</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services/eligibility-questions-and-answers-service-providers?mega=NZ%20health%20system&amp;title=Q%26A%20for%20service%20providers">Q&amp;A for service providers</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services/reciprocal-health-agreements?mega=NZ%20health%20system&amp;title=Reciprocal%20health%20agreements">Reciprocal health agreements</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services?mega=NZ%20health%20system&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211026003402/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements?mega=NZ%20health%20system&amp;title=Claims%2C%20provider%20payments%20and%20entitlements" class="menu-header">Claims &amp; provider payments</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211026003402/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/carer-support-claims?mega=NZ%20health%20system&amp;title=Carer%20Support">Carer Support</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/high-use-health-card-payments?mega=NZ%20health%20system&amp;title=High%20Use%20Health%20Card%20payments">High Use Health Card payments</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/between-travel-settlement?mega=NZ%20health%20system&amp;title=In-Between%20Travel%20Settlement">In-Between Travel Settlement</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/maternity-claim-forms?mega=NZ%20health%20system&amp;title=Maternity%20claim%20forms">Maternity claim forms</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/national-travel-assistance?mega=NZ%20health%20system&amp;title=National%20travel%20assistance%20claims">National travel assistance claims</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements?mega=NZ%20health%20system&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                        </div>
+    </div>
+    <div class="feature-links">
+      <h3 class="sr-only">Other related resources</h3>
+      <a href="/web/20211026003402/https://www.health.govt.nz/new-zealand-health-system/overview-health-system?mega=NZ%20health%20system&amp;title=Overview">Overview of the health system</a>  <a href="/web/20211026003402/https://www.health.govt.nz/new-zealand-health-system/my-dhb?mega=NZ%20health%20system&amp;title=Mydhb">My DHB</a> <a href="/web/20211026003402/https://www.health.govt.nz/new-zealand-health-system/system-level-measures-framework?mega=NZ%20health%20system&amp;title=SLM">System level measures</a>  <a href="/web/20211026003402/https://www.health.govt.nz/publication/new-zealand-health-strategy-2016?mega=NZ%20health%20system&amp;title=HealthStrategy">NZ Health Strategy</a>    </div>
+  </div>
+</li>
+<li class="dropdown"><a href="/web/20211026003402/https://www.health.govt.nz/our-work" class="dropdown-toggle active-trail" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="megamenu-dropdown-776">Our work <b class="caret"></b></a>
+  <div id="megamenu-dropdown-776" class="dropdown-menu">
+    <div class="yamm-content">
+      <div class="row">
+                            <ul class="col list-unstyled no-menu-header">
+                                                                                <li>
+                <a href="/web/20211026003402/https://www.health.govt.nz/our-work/diseases-and-conditions/antimicrobial-resistance?mega=Our%20work&amp;title=Antimicrobial%20resistance" class="menu-header">Antimicrobial resistance</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211026003402/https://www.health.govt.nz/our-work/populations/asian-and-migrant-health?mega=Our%20work&amp;title=Asian%20and%20migrant%20health" class="menu-header">Asian and migrant health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211026003402/https://www.health.govt.nz/our-work/border-health?mega=Our%20work&amp;title=Border%20health" class="menu-header">Border health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211026003402/https://www.health.govt.nz/our-work/life-stages/breastfeeding?mega=Our%20work&amp;title=Breastfeeding" class="menu-header">Breastfeeding</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211026003402/https://www.health.govt.nz/our-work/diseases-and-conditions/cancer?mega=Our%20work&amp;title=Cancer" class="menu-header">Cancer</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211026003402/https://www.health.govt.nz/our-work/regulation-health-and-disability-system/certification-health-care-services?mega=Our%20work&amp;title=Certification%20of%20health%20care%20services" class="menu-header">Certification of health care services</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211026003402/https://www.health.govt.nz/our-work/life-stages/child-health?mega=Our%20work&amp;title=Child%20health" class="menu-header">Child health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211026003402/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus?mega=Our%20work&amp;title=COVID-19" class="menu-header">COVID-19 (novel coronavirus)</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211026003402/https://www.health.govt.nz/our-work/diseases-and-conditions/diabetes?mega=Our%20work&amp;title=Diabetes" class="menu-header">Diabetes</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211026003402/https://www.health.govt.nz/our-work/digital-health?mega=Our%20work&amp;title=Digital%20health" class="menu-header">Digital health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211026003402/https://www.health.govt.nz/our-work/disability-services?mega=Our%20work&amp;title=Disability%20services" class="menu-header">Disability services</a>                              </li>
+                                                                </ul>
+                            <ul class="col list-unstyled no-menu-header">
+                                                                                <li>
+                <a href="/web/20211026003402/https://www.health.govt.nz/our-work/diseases-and-conditions?mega=Our%20work&amp;title=Diseases%20and%20conditions" class="menu-header">Diseases and conditions</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211026003402/https://www.health.govt.nz/our-work/hospitals-and-specialist-care/emergency-departments?mega=Our%20work&amp;title=Emergency%20departments" class="menu-header">Emergency departments</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211026003402/https://www.health.govt.nz/our-work/emergency-management?mega=Our%20work&amp;title=Emergency%20management" class="menu-header">Emergency management</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211026003402/https://www.health.govt.nz/our-work/environmental-health?mega=Our%20work&amp;title=Environmental%20health" class="menu-header">Environmental health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211026003402/https://www.health.govt.nz/our-work/preventative-health-wellness/family-violence?mega=Our%20work&amp;title=Family%20violence" class="menu-header">Family violence</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211026003402/https://www.health.govt.nz/our-work/preventative-health-wellness/fluoride-and-oral-health?mega=Our%20work&amp;title=Fluoride%20and%20oral%20health" class="menu-header">Fluoride and oral health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211026003402/https://www.health.govt.nz/our-work/health-identity?mega=Our%20work&amp;title=Health%20identity" class="menu-header">Health identity</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211026003402/https://www.health.govt.nz/our-work/digital-health/digital-health-sector-architecture-standards-and-governance/health-information-standards-0?mega=Our%20work&amp;title=Health%20information%20standards" class="menu-header">Health information standards</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211026003402/https://www.health.govt.nz/our-work/life-stages/health-older-people?mega=Our%20work&amp;title=Health%20of%20older%20people" class="menu-header">Health of older people</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211026003402/https://www.health.govt.nz/our-work/health-workforce?mega=Our%20work&amp;title=Health%20workforce" class="menu-header">Health workforce</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211026003402/https://www.health.govt.nz/our-work/hospitals-and-specialist-care?mega=Our%20work&amp;title=Hospitals%20and%20specialist%20care" class="menu-header">Hospitals and specialist care</a>                              </li>
+                                                                </ul>
+                            <ul class="col list-unstyled no-menu-header">
+                                                                                <li>
+                <a href="/web/20211026003402/https://www.health.govt.nz/our-work/preventative-health-wellness/immunisation?mega=Our%20work&amp;title=Immunisation" class="menu-header">Immunisation</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211026003402/https://www.health.govt.nz/our-work/ionising-radiation-safety?mega=Our%20work&amp;title=Ionising%20radiation%20safety" class="menu-header">Ionising radiation safety</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211026003402/https://www.health.govt.nz/our-work/populations/maori-health?mega=Our%20work&amp;title=M%C4%81ori%20health" class="menu-header">Māori health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211026003402/https://www.health.govt.nz/our-work/life-stages/maternity-services?mega=Our%20work&amp;title=Maternity" class="menu-header">Maternity</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211026003402/https://www.health.govt.nz/our-work/regulation-health-and-disability-system/medicinal-cannabis-agency?mega=Our%20work&amp;title=Medicinal%20Cannabis%20Agency" class="menu-header">Medicinal cannabis</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211026003402/https://www.health.govt.nz/our-work/regulation-health-and-disability-system/medicines-control?mega=Our%20work&amp;title=Medicines%20control" class="menu-header">Medicines control</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211026003402/https://www.health.govt.nz/our-work/mental-health-and-addiction?mega=Our%20work&amp;title=Mental%20health%20and%20addiction" class="menu-header">Mental health and addiction</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211026003402/https://www.health.govt.nz/our-work/nursing?mega=Our%20work&amp;title=Nursing" class="menu-header">Nursing</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211026003402/https://www.health.govt.nz/our-work/preventative-health-wellness/nutrition?mega=Our%20work&amp;title=Nutrition" class="menu-header">Nutrition</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211026003402/https://www.health.govt.nz/our-work/preventative-health-wellness/oral-health?mega=Our%20work&amp;title=Oral%20health" class="menu-header">Oral health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211026003402/https://www.health.govt.nz/our-work/hospitals-and-specialist-care/organ-donation-and-transplantation?mega=Our%20work&amp;title=Organ%20donation%20and%20transplantation" class="menu-header">Organ donation and transplantation</a>                              </li>
+                                                                </ul>
+                            <ul class="col list-unstyled no-menu-header">
+                                                                                <li>
+                <a href="/web/20211026003402/https://www.health.govt.nz/our-work/populations/pacific-health?mega=Our%20work&amp;title=Pacific%20health" class="menu-header">Pacific health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211026003402/https://www.health.govt.nz/new-zealand-health-system/pay-equity-settlements?mega=Our%20work&amp;title=Pay%20equity%20settlements" class="menu-header">Pay equity</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211026003402/https://www.health.govt.nz/our-work/preventative-health-wellness/physical-activity?mega=Our%20work&amp;title=Physical%20activity" class="menu-header">Physical activity</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211026003402/https://www.health.govt.nz/our-work/hospitals-and-specialist-care/planned-care-services?mega=Our%20work&amp;title=Planned%20Care%20services" class="menu-header">Planned Care services</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211026003402/https://www.health.govt.nz/our-work/preventative-health-wellness?mega=Our%20work&amp;title=Preventative%20health/wellness" class="menu-header">Preventative health/wellness</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211026003402/https://www.health.govt.nz/our-work/primary-health-care?mega=Our%20work&amp;title=Primary%20health%20care" class="menu-header">Primary health care</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211026003402/https://www.health.govt.nz/our-work/public-health-workforce-development?mega=Our%20work&amp;title=Public%20health%20workforce%20development" class="menu-header">Public health workforce</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211026003402/https://www.health.govt.nz/our-work/regulation-health-and-disability-system?mega=Our%20work&amp;title=Regulation" class="menu-header">Regulation</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211026003402/https://www.health.govt.nz/our-work/preventative-health-wellness/tobacco-control?mega=Our%20work&amp;title=Tobacco%20control" class="menu-header">Tobacco control</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211026003402/https://www.health.govt.nz/our-work/regulation-health-and-disability-system/regulation-vaping-and-smokeless-tobacco-products?mega=Our%20work&amp;title=Vaping%20and%20smokeless%20tobacco%20products" class="menu-header">Vaping &amp; smokeless tobacco</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211026003402/https://www.health.govt.nz/our-work/who-code-nz?mega=Our%20work&amp;title=WHO%20Code%20in%20NZ" class="menu-header">WHO Code in NZ</a>                              </li>
+                      </ul>
+              </div>
+    </div>
+    <div class="feature-links">
+      <a href="/web/20211026003402/https://www.health.govt.nz/our-work?mega=Our%20work&amp;title=A-Z">View the full A-Z</a>    </div>
+  </div>
+</li>
+<li class="dropdown"><a href="/web/20211026003402/https://www.health.govt.nz/nz-health-statistics" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="megamenu-dropdown-778">Health statistics <b class="caret"></b></a>
+    <div id="megamenu-dropdown-778" class="dropdown-menu">
+    <div class="yamm-content">
+      <div class="row">
+                            <div class="col">
+            <h3><a href="/web/20211026003402/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets?mega=Health%20statistics&amp;title=Health%20statistics%20and%20data%20sets" class="menu-header">Statistics by topic</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211026003402/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/cancer-data-and-stats?mega=Health%20statistics&amp;title=Cancer">Cancer</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/diabetes-data-and-stats?mega=Health%20statistics&amp;title=Diabetes">Diabetes</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/mental-health-data-and-stats?mega=Health%20statistics&amp;title=Mental%20health">Mental health</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/maori-health-data-and-stats?mega=Health%20statistics&amp;title=M%C4%81ori%20health">Māori health</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/obesity-statistics?mega=Health%20statistics&amp;title=Obesity">Obesity</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/suicide-data-and-stats?mega=Health%20statistics&amp;title=Suicide">Suicide</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/tobacco-data-and-stats?mega=Health%20statistics&amp;title=Tobacco">Tobacco</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets?mega=Health%20statistics&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211026003402/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys?mega=Health%20statistics&amp;title=National%20collections%20and%20surveys" class="menu-header">About our surveys &amp; data collections</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211026003402/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/surveys/past-surveys/alcohol-and-drug-use-survey?mega=Health%20statistics&amp;title=Alcohol%20%26%20Drug%20Use%20Survey">Alcohol &amp; Drug Use Survey</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/national-collections-annual-maintenance-project?mega=Health%20statistics&amp;title=NCAMP">NCAMP</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/collections/new-zealand-cancer-registry-nzcr?mega=Health%20statistics&amp;title=NZ%20Cancer%20Registry">NZ Cancer Registry</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/surveys/new-zealand-health-survey?mega=Health%20statistics&amp;title=NZ%20Health%20Survey">NZ Health Survey</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/surveys/past-surveys/nutrition-survey?mega=Health%20statistics&amp;title=Nutrition%20Survey">Nutrition Survey</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/collections/primhd-mental-health-data?mega=Health%20statistics&amp;title=PRIMHD">PRIMHD</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys?mega=Health%20statistics&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211026003402/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology?mega=Health%20statistics&amp;title=Classification%20and%20Terminology" class="menu-header">Classification &amp; terminology</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211026003402/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology/using-icd-10-am-achi-acs/coding-queries/coding-query-database?mega=Health%20statistics&amp;title=Coding%20query%20database">Coding query database</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology/using-icd-10-am-achi-acs/courses-clinical-coding?mega=Health%20statistics&amp;title=Courses%20on%20clinical%20coding">Courses on clinical coding</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology/new-zealand-snomed-ct-national-release-centre?mega=Health%20statistics&amp;title=SNOMED%20CT">SNOMED CT</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology/using-icd-10-am-achi-acs?mega=Health%20statistics&amp;title=Using%20ICD-10-AM/ACHI/ACS">Using ICD-10-AM/ACHI/ACS</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology?mega=Health%20statistics&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211026003402/https://www.health.govt.nz/nz-health-statistics/data-references?mega=Health%20statistics&amp;title=Data%20references" class="menu-header">Data references</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211026003402/https://www.health.govt.nz/nz-health-statistics/data-references/code-tables?mega=Health%20statistics&amp;title=Code%20tables">Code tables</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/nz-health-statistics/data-references/data-dictionaries?mega=Health%20statistics&amp;title=Data%20dictionaries">Data dictionaries</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/nz-health-statistics/data-references/diagnosis-related-groups?mega=Health%20statistics&amp;title=Diagnosis-related%20groups">Diagnosis-related groups</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/nz-health-statistics/data-references/code-tables/common-code-tables/domicile-code-table?mega=Health%20statistics&amp;title=Domicile%20code%20table">Domicile code table</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/nz-health-statistics/data-references/mapping-tools?mega=Health%20statistics&amp;title=ICD%20mapping%20tools">ICD mapping tools</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/nz-health-statistics/data-references/weighted-inlier-equivalent-separations?mega=Health%20statistics&amp;title=Weighted%20Inlier%20Equivalent%20Separations">Weighted Inlier Equivalent Separations</a></li>
+                                  <li><a href="/web/20211026003402/https://www.health.govt.nz/nz-health-statistics/data-references?mega=Health%20statistics&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                        </div>
+    </div>
+    <div class="feature-links">
+      <h3 class="sr-only">Other related resources</h3>
+      <a href="/web/20211026003402/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/tier-1-health-statistics-release-calendar?mega=Health%20statistics&amp;title=Tier%201%20calendar">Release calendar for our Tier 1 statistics</a> <a href="/web/20211026003402/https://www.health.govt.nz/nz-health-statistics/about-data-collection?mega=Health%20statistics&amp;title=Enquiries">Data and survey enquiries</a>    </div>
+  </div>
+</li>
+<li class=""><a href="/web/20211026003402/https://www.health.govt.nz/publications" aria-haspopup="false">Publications</a></li>
+<li class=""><a href="/web/20211026003402/https://www.health.govt.nz/about-ministry" aria-haspopup="false">About us</a></li>
+<li class="visible-xs"><a href="/web/20211026003402/https://www.health.govt.nz/contactus" aria-haspopup="false">Contact us</a></li>
+</ul>
+                                  </nav>
+        </div>
+          </div>
+  </header>
+
+  <div class="main-container container">
+    <!-- announcement -->
+        <!-- /announcement -->
+
+    <header role="banner" id="page-header">
+
+          </header> <!-- /#page-header -->
+
+    <div class="row">
+
+      <section class="col-sm-12">
+                        <a id="main-content"></a>
+                                                                            <div class="breadcrumbs">
+            <ul><li><a href="/web/20211026003402/https://www.health.govt.nz/">Home</a></li><li><a href="/web/20211026003402/https://www.health.govt.nz/our-work">Our work</a></li><li><a href="/web/20211026003402/https://www.health.govt.nz/our-work/diseases-and-conditions">Diseases and conditions</a></li><li><a href="/web/20211026003402/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished" data-is-top-level="1" title="">COVID-19</a></li><li><a href="/web/20211026003402/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics" class="menu-node-unpublished menu-node-unpublished">Data and statistics</a></li><li><span class="current-breadcrumb">Vaccine data</span></li></ul>          </div>
+
+
+
+          <div class="region region-content">
+    <section id="block-system-main" class="block block-system clearfix">
+
+
+  <div class="bootstrap-threecol-stacked">
+
+      <div class="row"> <!-- @TODO: Add extra classes -->
+      <div class="panel-panel left col-xs-12 col-md-3 col-lg-3"><div class="panel-pane pane-block pane-menu-block-1 odd pane-top-link">
+
+        <span class="top-link"><a href="/web/20211026003402/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished active-trail" data-is-top-level="1">COVID-19</a></span>
+
+
+  <div class="pane-content">
+        <div class="menu-block-wrapper menu-block-1 menu-name-main-menu parent-mlid-1445 menu-level-2">
+  <ul class="menu nav"><li class="first collapsed menu-mlid-10163 health-advice depth-4"><a href="/web/20211026003402/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-health-advice-public" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished">Health advice</a></li>
+<li class="collapsed menu-mlid-10630 covid-19-vaccines- depth-4 section-overview hide-children"><a href="/web/20211026003402/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-vaccines" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished" data-is-top-level="1" title="">COVID-19 vaccines </a></li>
+<li class="collapsed menu-mlid-9997 health-professionals depth-4"><a href="/web/20211026003402/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-information-health-professionals" class="menu-node-unpublished menu-node-unpublished">Health professionals</a></li>
+<li class="collapsed menu-mlid-10019 specific-audiences depth-4"><a href="/web/20211026003402/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-information-specific-audiences" class="menu-node-unpublished">Specific audiences</a></li>
+<li class="expanded active-trail menu-mlid-10096 data-and-statistics depth-4"><a href="/web/20211026003402/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics" class="menu-node-unpublished menu-node-unpublished active-trail">Data and statistics</a><ul class="menu nav"><li class="first leaf menu-mlid-10062 current-cases depth-5 same-level-as-node"><a href="/web/20211026003402/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-current-cases" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Current cases</a></li>
+<li class="leaf menu-mlid-10146 case-demographics depth-5 same-level-as-node"><a href="/web/20211026003402/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-case-demographics">Case demographics</a></li>
+<li class="leaf menu-mlid-10097 source-of-cases depth-5 same-level-as-node"><a href="/web/20211026003402/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-source-cases" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Source of cases</a></li>
+<li class="leaf menu-mlid-10119 testing-for-covid-19 depth-5 same-level-as-node"><a href="/web/20211026003402/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/testing-covid-19" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Testing for COVID-19</a></li>
+<li class="leaf menu-mlid-10371 nz-covid-tracer-app-data depth-5 same-level-as-node"><a href="/web/20211026003402/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-nz-covid-tracer-app-data" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">NZ COVID Tracer app data</a></li>
+<li class="expanded active-trail active menu-mlid-10584 active vaccine-data depth-5 same-level-as-node"><a href="/web/20211026003402/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished active-trail active">Vaccine data</a><ul class="menu nav"><li class="first leaf menu-mlid-10867 covid-19-vaccination-uptake-rates-across-nz depth-6"><a href="/web/20211026003402/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-across-nz" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">COVID-19 Vaccination uptake rates across NZ</a></li>
+<li class="leaf menu-mlid-10868 covid-19-vaccination-uptake-rates---māori depth-6"><a href="/web/20211026003402/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-maori-communities-across-nz" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">COVID-19 Vaccination uptake rates - Māori</a></li>
+<li class="last leaf menu-mlid-10869 covid-19-vaccination-uptake-rates---pacific depth-6"><a href="/web/20211026003402/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-pacific-communities-across-nz" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">COVID-19 Vaccination uptake rates - Pacific</a></li>
+</ul></li>
+<li class="last leaf menu-mlid-10404 data-resources depth-5 same-level-as-node"><a href="/web/20211026003402/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-data-resources" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Data resources</a></li>
+</ul></li>
+<li class="collapsed menu-mlid-10369 response-planning depth-4"><a href="/web/20211026003402/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-response-planning" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Response planning</a></li>
+<li class="collapsed menu-mlid-10015 resources-and-tools depth-4"><a href="/web/20211026003402/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-resources-and-tools" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Resources and tools</a></li>
+<li class="last leaf menu-mlid-10004 news-and-media depth-4 section-overview hide-children"><a href="/web/20211026003402/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-news-and-media-updates" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">News and media</a></li>
+</ul></div>
+  </div>
+
+
+  </div>
+</div>      <div class="panel-panel middle col-xs-12 col-md-9 col-lg-9"><div class="panel-pane pane-page-title even">
+
+
+
+  <div class="pane-content">
+    <span id="skip-content" tabindex="-1"></span>    <h1>COVID-19: Vaccine data</h1>
+  </div>
+
+
+  </div>
+<div class="panel-pane pane-node-content odd">
+
+
+
+  <div class="pane-content">
+        <article id="node-12052" class="node node-page node-sticky view-mode-full clearfix" about="/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" typeof="sioc:Item foaf:Document">
+    <header>
+            <span property="dc:title" content="COVID-19: Vaccine data" class="rdf-meta element-hidden"></span>      </header>
+    <div class="field field-name-field-intro-text field-type-text-long field-label-hidden"><div class="field-items"><div class="field-item even"><p class="intro-text">Data and statistics about the rollout of COVID-19 vaccines in New Zealand.</p></div></div></div><div class="field field-name-body field-type-text-with-summary field-label-hidden"><div class="field-items"><div class="field-item even" property="content:encoded"><p>On this page:</p>
+
+<ul>
+	<li><a href="#daily">Daily updates</a>
+
+	<ul>
+		<li><a href="#total-vaccinations">Total vaccinations</a></li>
+		<li><a href="#ethnicity">Vaccinations by ethnicity</a></li>
+	</ul>
+	</li>
+	<li><a href="#weekly-updates">Weekly updates</a>
+	<ul>
+		<li><a href="#model">Vaccinations against plan</a></li>
+		<li><a href="#uptake">Vaccinations uptake</a></li>
+		<li><a href="#by-day">Vaccinations by day</a></li>
+		<li><a href="#location">Vaccinations by DHB</a></li>
+		<li><a href="#group">Vaccinations by group</a></li>
+		<li><a href="#by_soh">Stock on hand</a></li>
+		<li><a href="#age">Vaccinations by age</a></li>
+		<li><a href="#workforce">Trained vaccinator and active vaccinator</a></li>
+		<li><a href="#group">Vaccinations by group</a></li>
+		<li><a href="#download">Details of vaccination&nbsp;data</a></li>
+	</ul>
+	</li>
+	<li><a href="#adverse-events">Adverse events from immunisations</a></li>
+</ul>
+
+<hr/><!--daily-->
+<h2><a id="daily" name="daily"></a>COVID-19 vaccinations: daily updates</h2>
+
+<div class="well well-sm">
+<p style="margin-top: 0"><strong>Data in this section is as at 11:59pm 25 October 2021 and is updated daily.</strong></p>
+</div>
+
+<h3><a id="total-vaccinations" name="total-vaccinations"></a>Total Vaccinations</h3>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">&nbsp;</th>
+			<th scope="col" style="text-align:right">Vaccinations yesterday</th>
+			<th scope="col" style="text-align:right">Cumulative total</th>
+			<th scope="col" style="text-align:right">Eligible population vaccinated %</th>
+			<th scope="col" style="text-align:right">Total population vaccinated %</th>
+			<th scope="col" style="text-align:right">Vaccinated or booked</th>
+			<th scope="col" style="text-align:right">Eligible vaccinated or booked %</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">First dose</th>
+			<td style="text-align:right">3,492</td>
+			<td style="text-align:right">3,646,869</td>
+			<td style="text-align:right">87%</td>
+			<td style="text-align:right">73%</td>
+			<td style="text-align:right">3,666,955</td>
+			<td style="text-align:right">87%</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Second dose</th>
+			<td style="text-align:right">7,168</td>
+			<td style="text-align:right">2,987,389</td>
+			<td style="text-align:right">71%</td>
+			<td style="text-align:right">60%</td>
+			<td style="text-align:right">3,328,792</td>
+			<td style="text-align:right">79%</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total doses</strong></th>
+			<td style="text-align:right"><strong>10,660</strong></td>
+			<td style="text-align:right"><strong>6,634,258</strong></td>
+		</tr>
+	</tbody>
+</table>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Total vaccinations" class="img-responsive" height="900" src="/web/20211026003402im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_summary_16.png" width="5340"/></figure>
+
+<h5>Definitions</h5>
+
+<ul>
+	<li><strong>Cumulative total:</strong>&nbsp;All vaccinations that have been administered and entered into the COVID-19 Immunisation Register up until midnight of the night before the data is published.</li>
+	<li><strong>Eligible population vaccinated %:</strong>&nbsp;Vaccinations administered divided by HSU population estimates for the eligible population (12+).</li>
+	<li><strong>Total population vaccinated %:</strong>&nbsp;Vaccinations administered divided by HSU population estimates for the total population (0+).</li>
+	<li><strong>Vaccinated or booked:</strong>&nbsp;Count of individuals who have either received their vaccination or have booked via Book My Vaccine to receive a vaccination.</li>
+	<li><strong>Eligible vaccinated or booked %:</strong>&nbsp;Count of individuals who have either received their vaccination or have booked via Book My Vaccine to receive a vaccination divided by HSU population estimates for the eligible population (12+).</li>
+</ul>
+
+<p>HSU population estimates are available in the downloadable spreadsheet at the bottom of the page. Throughout the rest of this sheet doses per 1,000 are based on eligible (12+) population.</p>
+
+<p>Bookings are only counted if the site is using Book My Vaccine. Bookings made through other Patient Management Systems are not counted.</p>
+
+<hr/>
+<h3><a id="by_eth" name="ethnicity"></a>Cumulative vaccinations by ethnicity</h3>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">Ethnicity *</th>
+			<th scope="col" style="text-align:right">First dose administered</th>
+			<th scope="col" style="text-align:right">First doses per 1,000 people</th>
+			<th scope="col" style="text-align:right">Second dose administered</th>
+			<th scope="col" style="text-align:right">Second doses per 1,000 people</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">Māori</th>
+			<td style="text-align:right">394,513</td>
+			<td style="text-align:right">691</td>
+			<td style="text-align:right">277,596</td>
+			<td style="text-align:right">486</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Pacific Peoples</th>
+			<td style="text-align:right">238,227</td>
+			<td style="text-align:right">831</td>
+			<td style="text-align:right">185,272</td>
+			<td style="text-align:right">646</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Asian</th>
+			<td style="text-align:right">602,316</td>
+			<td style="text-align:right">&gt;950</td>
+			<td style="text-align:right">516,612</td>
+			<td style="text-align:right">863</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">European / Other</th>
+			<td style="text-align:right">2,378,321</td>
+			<td style="text-align:right">871</td>
+			<td style="text-align:right">1,981,131</td>
+			<td style="text-align:right">725</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Unknown</th>
+			<td style="text-align:right">33,492</td>
+			<td style="text-align:right">-</td>
+			<td style="text-align:right">26,778</td>
+			<td style="text-align:right">-</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total</strong></th>
+			<td style="text-align:right"><strong>3,646,869</strong></td>
+			<td style="text-align:right"><strong>866</strong></td>
+			<td style="text-align:right"><strong>2,987,389</strong></td>
+			<td style="text-align:right"><strong>710</strong></td>
+		</tr>
+	</tbody>
+</table>
+
+<p><strong>*</strong> The prioritised ethnicity classification system allocates each person to a single ethnic group, based on the ethnic groups they identify with. Where people identify with more than one group, they are assigned in this order of priority: Māori, Pacific Peoples, Asian, and European/Other. So, if a person identifies as being Māori and New Zealand European, the person is counted as Māori. See <a href="/web/20211026003402/https://www.health.govt.nz/publication/hiso-100012017-ethnicity-data-protocols">Ethnicity Data Protocols</a> for further information.</p>
+
+<p>Ethnicity breakdown by DHB of residence is available in the downloadable spreadsheet at the bottom of the page.</p>
+
+<hr/>
+<h3><a id="90pct" name="90pct"></a>Vaccinations to 90% by DHB</h3>
+
+<h4><a id="90pct all ethnicities" name="90pct all ethnicities"></a>All Ethnicities</h4>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">&nbsp;</th>
+			<th scope="col" style="text-align:right">First doses</th>
+			<th scope="col" style="text-align:right">First doses %</th>
+			<th scope="col" style="text-align:right">First doses to 90%</th>
+			<th scope="col" style="text-align:right">Second doses</th>
+			<th scope="col" style="text-align:right">Second doses %</th>
+			<th scope="col" style="text-align:right">Second doses to 90%</th>
+			<th scope="col" style="text-align:right">Population</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">Northland</th>
+			<td style="text-align:right">125,549</td>
+			<td style="text-align:right">78%</td>
+			<td style="text-align:right">19,639</td>
+			<td style="text-align:right">99,525</td>
+			<td style="text-align:right">62%</td>
+			<td style="text-align:right">45,663</td>
+			<td style="text-align:right">161,320</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waitemata</th>
+			<td style="text-align:right">475,288</td>
+			<td style="text-align:right">90%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">403,225</td>
+			<td style="text-align:right">77%</td>
+			<td style="text-align:right">70,253</td>
+			<td style="text-align:right">526,087</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Auckland</th>
+			<td style="text-align:right">395,070</td>
+			<td style="text-align:right">93%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">343,631</td>
+			<td style="text-align:right">81%</td>
+			<td style="text-align:right">37,931</td>
+			<td style="text-align:right">423,958</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Counties Manukau</th>
+			<td style="text-align:right">423,476</td>
+			<td style="text-align:right">88%</td>
+			<td style="text-align:right">11,020</td>
+			<td style="text-align:right">355,419</td>
+			<td style="text-align:right">74%</td>
+			<td style="text-align:right">79,077</td>
+			<td style="text-align:right">482,773</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waikato</th>
+			<td style="text-align:right">303,882</td>
+			<td style="text-align:right">85%</td>
+			<td style="text-align:right">17,576</td>
+			<td style="text-align:right">243,990</td>
+			<td style="text-align:right">68%</td>
+			<td style="text-align:right">77,468</td>
+			<td style="text-align:right">357,176</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Lakes</th>
+			<td style="text-align:right">74,378</td>
+			<td style="text-align:right">79%</td>
+			<td style="text-align:right">10,599</td>
+			<td style="text-align:right">58,176</td>
+			<td style="text-align:right">62%</td>
+			<td style="text-align:right">26,801</td>
+			<td style="text-align:right">94,419</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Bay of Plenty</th>
+			<td style="text-align:right">177,197</td>
+			<td style="text-align:right">82%</td>
+			<td style="text-align:right">18,050</td>
+			<td style="text-align:right">136,449</td>
+			<td style="text-align:right">63%</td>
+			<td style="text-align:right">58,798</td>
+			<td style="text-align:right">216,941</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Tairawhiti</th>
+			<td style="text-align:right">31,992</td>
+			<td style="text-align:right">76%</td>
+			<td style="text-align:right">5,776</td>
+			<td style="text-align:right">25,536</td>
+			<td style="text-align:right">61%</td>
+			<td style="text-align:right">12,232</td>
+			<td style="text-align:right">41,965</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Taranaki</th>
+			<td style="text-align:right">84,318</td>
+			<td style="text-align:right">83%</td>
+			<td style="text-align:right">7,614</td>
+			<td style="text-align:right">63,283</td>
+			<td style="text-align:right">62%</td>
+			<td style="text-align:right">28,649</td>
+			<td style="text-align:right">102,147</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hawkes Bay</th>
+			<td style="text-align:right">120,676</td>
+			<td style="text-align:right">83%</td>
+			<td style="text-align:right">10,338</td>
+			<td style="text-align:right">98,275</td>
+			<td style="text-align:right">68%</td>
+			<td style="text-align:right">32,739</td>
+			<td style="text-align:right">145,571</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">MidCentral</th>
+			<td style="text-align:right">129,085</td>
+			<td style="text-align:right">85%</td>
+			<td style="text-align:right">7,987</td>
+			<td style="text-align:right">104,889</td>
+			<td style="text-align:right">69%</td>
+			<td style="text-align:right">32,183</td>
+			<td style="text-align:right">152,302</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Whanganui</th>
+			<td style="text-align:right">45,281</td>
+			<td style="text-align:right">79%</td>
+			<td style="text-align:right">6,241</td>
+			<td style="text-align:right">37,454</td>
+			<td style="text-align:right">65%</td>
+			<td style="text-align:right">14,068</td>
+			<td style="text-align:right">57,247</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Capital and Coast</th>
+			<td style="text-align:right">247,452</td>
+			<td style="text-align:right">91%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">206,021</td>
+			<td style="text-align:right">76%</td>
+			<td style="text-align:right">38,036</td>
+			<td style="text-align:right">271,174</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hutt Valley</th>
+			<td style="text-align:right">112,960</td>
+			<td style="text-align:right">87%</td>
+			<td style="text-align:right">4,255</td>
+			<td style="text-align:right">91,128</td>
+			<td style="text-align:right">70%</td>
+			<td style="text-align:right">26,087</td>
+			<td style="text-align:right">130,239</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Wairarapa</th>
+			<td style="text-align:right">34,817</td>
+			<td style="text-align:right">84%</td>
+			<td style="text-align:right">2,467</td>
+			<td style="text-align:right">28,656</td>
+			<td style="text-align:right">69%</td>
+			<td style="text-align:right">8,628</td>
+			<td style="text-align:right">41,427</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Nelson Marlborough</th>
+			<td style="text-align:right">115,720</td>
+			<td style="text-align:right">85%</td>
+			<td style="text-align:right">6,449</td>
+			<td style="text-align:right">99,728</td>
+			<td style="text-align:right">73%</td>
+			<td style="text-align:right">22,441</td>
+			<td style="text-align:right">135,743</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">West Coast</th>
+			<td style="text-align:right">21,911</td>
+			<td style="text-align:right">79%</td>
+			<td style="text-align:right">3,204</td>
+			<td style="text-align:right">17,471</td>
+			<td style="text-align:right">63%</td>
+			<td style="text-align:right">7,644</td>
+			<td style="text-align:right">27,906</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Canterbury</th>
+			<td style="text-align:right">427,948</td>
+			<td style="text-align:right">89%</td>
+			<td style="text-align:right">6,653</td>
+			<td style="text-align:right">323,698</td>
+			<td style="text-align:right">67%</td>
+			<td style="text-align:right">110,903</td>
+			<td style="text-align:right">482,890</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">South Canterbury</th>
+			<td style="text-align:right">44,293</td>
+			<td style="text-align:right">84%</td>
+			<td style="text-align:right">3,033</td>
+			<td style="text-align:right">36,942</td>
+			<td style="text-align:right">70%</td>
+			<td style="text-align:right">10,384</td>
+			<td style="text-align:right">52,584</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Southern</th>
+			<td style="text-align:right">253,558</td>
+			<td style="text-align:right">88%</td>
+			<td style="text-align:right">5,656</td>
+			<td style="text-align:right">212,301</td>
+			<td style="text-align:right">74%</td>
+			<td style="text-align:right">46,912</td>
+			<td style="text-align:right">288,015</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Overseas / Unknown</th>
+			<td style="text-align:right">2,018</td>
+			<td style="text-align:right">12%</td>
+			<td style="text-align:right">13,438</td>
+			<td style="text-align:right">1,592</td>
+			<td style="text-align:right">9%</td>
+			<td style="text-align:right">13,864</td>
+			<td style="text-align:right">17,173</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total</strong></th>
+			<td style="text-align:right"><strong>3,646,869</strong></td>
+			<td style="text-align:right"><strong>87%</strong></td>
+			<td style="text-align:right"><strong>141,282</strong></td>
+			<td style="text-align:right"><strong>2,987,389</strong></td>
+			<td style="text-align:right"><strong>71%</strong></td>
+			<td style="text-align:right"><strong>800,762</strong></td>
+			<td style="text-align:right"><strong>4,209,057</strong></td>
+		</tr>
+	</tbody>
+</table>
+
+<p>First/second doses % are the number of first/second doses administered divided by the eligible population. First/second doses to 90% are the number of doses required to reach 90% of the eligible population. For these two measures, the national total may not be the sum of DHB measures.</p>
+
+<h4><a id="90pct Māori" name="90pct Māori">Māori</a></h4>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">&nbsp;</th>
+			<th scope="col" style="text-align:right">First doses</th>
+			<th scope="col" style="text-align:right">First doses %</th>
+			<th scope="col" style="text-align:right">First doses to 90%</th>
+			<th scope="col" style="text-align:right">Second doses</th>
+			<th scope="col" style="text-align:right">Second doses %</th>
+			<th scope="col" style="text-align:right">Second doses to 90%</th>
+			<th scope="col" style="text-align:right">Population</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">Northland</th>
+			<td style="text-align:right">32,758</td>
+			<td style="text-align:right">65%</td>
+			<td style="text-align:right">12,681</td>
+			<td style="text-align:right">22,307</td>
+			<td style="text-align:right">44%</td>
+			<td style="text-align:right">23,132.0</td>
+			<td style="text-align:right">50,488</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waitemata</th>
+			<td style="text-align:right">32,023</td>
+			<td style="text-align:right">78%</td>
+			<td style="text-align:right">4,979</td>
+			<td style="text-align:right">23,611</td>
+			<td style="text-align:right">57%</td>
+			<td style="text-align:right">13,391.0</td>
+			<td style="text-align:right">41,113</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Auckland</th>
+			<td style="text-align:right">22,409</td>
+			<td style="text-align:right">81%</td>
+			<td style="text-align:right">2,604</td>
+			<td style="text-align:right">17,056</td>
+			<td style="text-align:right">61%</td>
+			<td style="text-align:right">7,957.0</td>
+			<td style="text-align:right">27,792</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Counties Manukau</th>
+			<td style="text-align:right">44,881</td>
+			<td style="text-align:right">71%</td>
+			<td style="text-align:right">12,263</td>
+			<td style="text-align:right">31,297</td>
+			<td style="text-align:right">49%</td>
+			<td style="text-align:right">25,847.0</td>
+			<td style="text-align:right">63,493</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waikato</th>
+			<td style="text-align:right">48,506</td>
+			<td style="text-align:right">70%</td>
+			<td style="text-align:right">14,230</td>
+			<td style="text-align:right">32,760</td>
+			<td style="text-align:right">47%</td>
+			<td style="text-align:right">29,976.0</td>
+			<td style="text-align:right">69,707</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Lakes</th>
+			<td style="text-align:right">18,872</td>
+			<td style="text-align:right">63%</td>
+			<td style="text-align:right">8,204</td>
+			<td style="text-align:right">12,944</td>
+			<td style="text-align:right">43%</td>
+			<td style="text-align:right">14,132.0</td>
+			<td style="text-align:right">30,085</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Bay of Plenty</th>
+			<td style="text-align:right">29,591</td>
+			<td style="text-align:right">62%</td>
+			<td style="text-align:right">13,370</td>
+			<td style="text-align:right">19,736</td>
+			<td style="text-align:right">41%</td>
+			<td style="text-align:right">23,225.0</td>
+			<td style="text-align:right">47,734</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Tairawhiti</th>
+			<td style="text-align:right">12,912</td>
+			<td style="text-align:right">65%</td>
+			<td style="text-align:right">4,943</td>
+			<td style="text-align:right">9,371</td>
+			<td style="text-align:right">47%</td>
+			<td style="text-align:right">8,484.0</td>
+			<td style="text-align:right">19,839</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Taranaki</th>
+			<td style="text-align:right">10,424</td>
+			<td style="text-align:right">66%</td>
+			<td style="text-align:right">3,890</td>
+			<td style="text-align:right">6,641</td>
+			<td style="text-align:right">42%</td>
+			<td style="text-align:right">7,673.0</td>
+			<td style="text-align:right">15,904</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hawkes Bay</th>
+			<td style="text-align:right">22,021</td>
+			<td style="text-align:right">65%</td>
+			<td style="text-align:right">8,632</td>
+			<td style="text-align:right">15,497</td>
+			<td style="text-align:right">46%</td>
+			<td style="text-align:right">15,156.0</td>
+			<td style="text-align:right">34,059</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">MidCentral</th>
+			<td style="text-align:right">16,653</td>
+			<td style="text-align:right">69%</td>
+			<td style="text-align:right">5,150</td>
+			<td style="text-align:right">11,775</td>
+			<td style="text-align:right">49%</td>
+			<td style="text-align:right">10,028.0</td>
+			<td style="text-align:right">24,225</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Whanganui</th>
+			<td style="text-align:right">8,528</td>
+			<td style="text-align:right">63%</td>
+			<td style="text-align:right">3,633</td>
+			<td style="text-align:right">6,265</td>
+			<td style="text-align:right">46%</td>
+			<td style="text-align:right">5,896.0</td>
+			<td style="text-align:right">13,512</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Capital and Coast</th>
+			<td style="text-align:right">21,106</td>
+			<td style="text-align:right">78%</td>
+			<td style="text-align:right">3,164</td>
+			<td style="text-align:right">15,795</td>
+			<td style="text-align:right">59%</td>
+			<td style="text-align:right">8,475.0</td>
+			<td style="text-align:right">26,967</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hutt Valley</th>
+			<td style="text-align:right">13,557</td>
+			<td style="text-align:right">71%</td>
+			<td style="text-align:right">3,654</td>
+			<td style="text-align:right">9,654</td>
+			<td style="text-align:right">50%</td>
+			<td style="text-align:right">7,557.0</td>
+			<td style="text-align:right">19,123</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Wairarapa</th>
+			<td style="text-align:right">4,249</td>
+			<td style="text-align:right">67%</td>
+			<td style="text-align:right">1,423</td>
+			<td style="text-align:right">2,953</td>
+			<td style="text-align:right">47%</td>
+			<td style="text-align:right">2,719.0</td>
+			<td style="text-align:right">6,302</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Nelson Marlborough</th>
+			<td style="text-align:right">7,627</td>
+			<td style="text-align:right">68%</td>
+			<td style="text-align:right">2,496</td>
+			<td style="text-align:right">5,730</td>
+			<td style="text-align:right">51%</td>
+			<td style="text-align:right">4,393.0</td>
+			<td style="text-align:right">11,248</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">West Coast</th>
+			<td style="text-align:right">1,900</td>
+			<td style="text-align:right">69%</td>
+			<td style="text-align:right">588</td>
+			<td style="text-align:right">1,340</td>
+			<td style="text-align:right">48%</td>
+			<td style="text-align:right">1,148.0</td>
+			<td style="text-align:right">2,765</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Canterbury</th>
+			<td style="text-align:right">26,853</td>
+			<td style="text-align:right">73%</td>
+			<td style="text-align:right">6,419</td>
+			<td style="text-align:right">18,048</td>
+			<td style="text-align:right">49%</td>
+			<td style="text-align:right">15,224.0</td>
+			<td style="text-align:right">36,969</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">South Canterbury</th>
+			<td style="text-align:right">2,315</td>
+			<td style="text-align:right">68%</td>
+			<td style="text-align:right">770</td>
+			<td style="text-align:right">1,694</td>
+			<td style="text-align:right">49%</td>
+			<td style="text-align:right">1,391.0</td>
+			<td style="text-align:right">3,428</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Southern</th>
+			<td style="text-align:right">17,150</td>
+			<td style="text-align:right">73%</td>
+			<td style="text-align:right">4,131</td>
+			<td style="text-align:right">12,996</td>
+			<td style="text-align:right">55%</td>
+			<td style="text-align:right">8,285.0</td>
+			<td style="text-align:right">23,646</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Overseas / Unknown</th>
+			<td style="text-align:right">178</td>
+			<td style="text-align:right">7%</td>
+			<td style="text-align:right">2,210</td>
+			<td style="text-align:right">126</td>
+			<td style="text-align:right">5%</td>
+			<td style="text-align:right">2,262.0</td>
+			<td style="text-align:right">2,653</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total</strong></th>
+			<td style="text-align:right"><strong>394,513</strong></td>
+			<td style="text-align:right"><strong>69%</strong></td>
+			<td style="text-align:right"><strong>119,434</strong></td>
+			<td style="text-align:right"><strong>277,596</strong></td>
+			<td style="text-align:right"><strong>49%</strong></td>
+			<td style="text-align:right"><strong>236,351.0</strong></td>
+			<td style="text-align:right"><strong>571,052</strong></td>
+		</tr>
+	</tbody>
+</table>
+
+<h4><a id="90pct Pacific Peoples" name="90pct Pacific Peoples"></a>Pacific Peoples</h4>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">&nbsp;</th>
+			<th scope="col" style="text-align:right">First doses</th>
+			<th scope="col" style="text-align:right">First doses %</th>
+			<th scope="col" style="text-align:right">First doses to 90%</th>
+			<th scope="col" style="text-align:right">Second doses</th>
+			<th scope="col" style="text-align:right">Second doses %</th>
+			<th scope="col" style="text-align:right">Second doses to 90%</th>
+			<th scope="col" style="text-align:right">Population</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">Northland</th>
+			<td style="text-align:right">2,321</td>
+			<td style="text-align:right">79%</td>
+			<td style="text-align:right">320</td>
+			<td style="text-align:right">1,645</td>
+			<td style="text-align:right">56%</td>
+			<td style="text-align:right">996</td>
+			<td style="text-align:right">2,934</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waitemata</th>
+			<td style="text-align:right">31,541</td>
+			<td style="text-align:right">84%</td>
+			<td style="text-align:right">2,275</td>
+			<td style="text-align:right">24,448</td>
+			<td style="text-align:right">65%</td>
+			<td style="text-align:right">9,368</td>
+			<td style="text-align:right">37,573</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Auckland</th>
+			<td style="text-align:right">38,792</td>
+			<td style="text-align:right">83%</td>
+			<td style="text-align:right">3,387</td>
+			<td style="text-align:right">30,444</td>
+			<td style="text-align:right">65%</td>
+			<td style="text-align:right">11,735</td>
+			<td style="text-align:right">46,866</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Counties Manukau</th>
+			<td style="text-align:right">94,954</td>
+			<td style="text-align:right">82%</td>
+			<td style="text-align:right">9,894</td>
+			<td style="text-align:right">74,277</td>
+			<td style="text-align:right">64%</td>
+			<td style="text-align:right">30,571</td>
+			<td style="text-align:right">116,498</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waikato</th>
+			<td style="text-align:right">8,960</td>
+			<td style="text-align:right">84%</td>
+			<td style="text-align:right">654</td>
+			<td style="text-align:right">6,874</td>
+			<td style="text-align:right">64%</td>
+			<td style="text-align:right">2,740</td>
+			<td style="text-align:right">10,682</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Lakes</th>
+			<td style="text-align:right">1,780</td>
+			<td style="text-align:right">78%</td>
+			<td style="text-align:right">277</td>
+			<td style="text-align:right">1,351</td>
+			<td style="text-align:right">59%</td>
+			<td style="text-align:right">706</td>
+			<td style="text-align:right">2,286</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Bay of Plenty</th>
+			<td style="text-align:right">3,939</td>
+			<td style="text-align:right">&gt;95%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">2,916</td>
+			<td style="text-align:right">79%</td>
+			<td style="text-align:right">395</td>
+			<td style="text-align:right">3,679</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Tairawhiti</th>
+			<td style="text-align:right">848</td>
+			<td style="text-align:right">88%</td>
+			<td style="text-align:right">20</td>
+			<td style="text-align:right">643</td>
+			<td style="text-align:right">67%</td>
+			<td style="text-align:right">226</td>
+			<td style="text-align:right">965</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Taranaki</th>
+			<td style="text-align:right">1,020</td>
+			<td style="text-align:right">80%</td>
+			<td style="text-align:right">123</td>
+			<td style="text-align:right">742</td>
+			<td style="text-align:right">58%</td>
+			<td style="text-align:right">401</td>
+			<td style="text-align:right">1,270</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hawkes Bay</th>
+			<td style="text-align:right">4,983</td>
+			<td style="text-align:right">&gt;95%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">3,971</td>
+			<td style="text-align:right">79%</td>
+			<td style="text-align:right">547</td>
+			<td style="text-align:right">5,020</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">MidCentral</th>
+			<td style="text-align:right">3,685</td>
+			<td style="text-align:right">82%</td>
+			<td style="text-align:right">336</td>
+			<td style="text-align:right">2,780</td>
+			<td style="text-align:right">62%</td>
+			<td style="text-align:right">1,241</td>
+			<td style="text-align:right">4,468</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Whanganui</th>
+			<td style="text-align:right">1,020</td>
+			<td style="text-align:right">74%</td>
+			<td style="text-align:right">223</td>
+			<td style="text-align:right">790</td>
+			<td style="text-align:right">57%</td>
+			<td style="text-align:right">453</td>
+			<td style="text-align:right">1,381</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Capital and Coast</th>
+			<td style="text-align:right">15,352</td>
+			<td style="text-align:right">80%</td>
+			<td style="text-align:right">1,907</td>
+			<td style="text-align:right">12,053</td>
+			<td style="text-align:right">63%</td>
+			<td style="text-align:right">5,206</td>
+			<td style="text-align:right">19,177</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hutt Valley</th>
+			<td style="text-align:right">7,810</td>
+			<td style="text-align:right">79%</td>
+			<td style="text-align:right">1,095</td>
+			<td style="text-align:right">6,004</td>
+			<td style="text-align:right">61%</td>
+			<td style="text-align:right">2,901</td>
+			<td style="text-align:right">9,894</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Wairarapa</th>
+			<td style="text-align:right">672</td>
+			<td style="text-align:right">80%</td>
+			<td style="text-align:right">81</td>
+			<td style="text-align:right">529</td>
+			<td style="text-align:right">63%</td>
+			<td style="text-align:right">224</td>
+			<td style="text-align:right">837</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Nelson Marlborough</th>
+			<td style="text-align:right">3,568</td>
+			<td style="text-align:right">&gt;95%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">3,088</td>
+			<td style="text-align:right">&gt;95%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">2,115</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">West Coast</th>
+			<td style="text-align:right">224</td>
+			<td style="text-align:right">79%</td>
+			<td style="text-align:right">30</td>
+			<td style="text-align:right">167</td>
+			<td style="text-align:right">59%</td>
+			<td style="text-align:right">87</td>
+			<td style="text-align:right">282</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Canterbury</th>
+			<td style="text-align:right">10,217</td>
+			<td style="text-align:right">80%</td>
+			<td style="text-align:right">1,246</td>
+			<td style="text-align:right">7,476</td>
+			<td style="text-align:right">59%</td>
+			<td style="text-align:right">3,987</td>
+			<td style="text-align:right">12,737</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">South Canterbury</th>
+			<td style="text-align:right">759</td>
+			<td style="text-align:right">91%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">534</td>
+			<td style="text-align:right">64%</td>
+			<td style="text-align:right">219</td>
+			<td style="text-align:right">837</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Southern</th>
+			<td style="text-align:right">5,444</td>
+			<td style="text-align:right">90%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">4,253</td>
+			<td style="text-align:right">71%</td>
+			<td style="text-align:right">1,175</td>
+			<td style="text-align:right">6,031</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Overseas / Unknown</th>
+			<td style="text-align:right">338</td>
+			<td style="text-align:right">29%</td>
+			<td style="text-align:right">696</td>
+			<td style="text-align:right">287</td>
+			<td style="text-align:right">25%</td>
+			<td style="text-align:right">747</td>
+			<td style="text-align:right">1,149</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total</strong></th>
+			<td style="text-align:right"><strong>238,227</strong></td>
+			<td style="text-align:right"><strong>83%</strong></td>
+			<td style="text-align:right"><strong>19,786</strong></td>
+			<td style="text-align:right"><strong>185,272</strong></td>
+			<td style="text-align:right"><strong>65%</strong></td>
+			<td style="text-align:right"><strong>72,741</strong></td>
+			<td style="text-align:right"><strong>286,681</strong></td>
+		</tr>
+	</tbody>
+</table>
+<!--daily_end-->
+
+<hr/>
+<h2><a id="weekly-updates" name="weekly-updates"></a>COVID-19 vaccinations: weekly updates</h2>
+
+<div class="well well-sm">
+<p style="margin-top: 0"><strong>Data in this section is as at 11:59pm 19 October 2021 and is updated weekly on Wednesdays.</strong></p>
+</div>
+
+<h3><a id="model" model="" name="id="></a>Cumulative vaccinations</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccination doses administered compared to plan doses" class="img-responsive" height="830" src="/web/20211026003402im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/vaccineplanmodel_12.png" width="1780"/></figure>
+
+<p>Production plan figures are the volumes agreed with DHBs and national providers for expected vaccinations. These figures have been matched with expected supply. Detailed plans are available in the Excel file at the bottom of this page.</p>
+
+<p>The Stock received figures are the cumulative supply of doses to date.</p>
+
+<p>DHB capacity plans for the remainder of the year are undergoing review.</p>
+
+<hr/><!--
+<h3><a id="model" model="" name="id="></a>Cumulative vaccinations for last 6 weeks</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccination doses administered compared to plan doses - 6wks" class="img-responsive" height="830" src="/vaccineplanmodel_wks.png" width="1780" /></figure>
+
+<hr />
+-->
+<h3><a id="uptake" name="uptake"></a>Vaccine uptake</h3>
+
+<p>Maps and data related to uptake rates of the COVID-19 vaccine across the country are available on the pages linked below. These show&nbsp;vaccination records aggregated by area of residence for all New Zealand residents, Māori communities, and Pacific communities.</p>
+
+<ul>
+	<li><a href="/web/20211026003402/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-across-nz">COVID-19 Vaccination uptake rates across NZ</a></li>
+	<li><a href="/web/20211026003402/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-maori-communities-across-nz">COVID-19 Vaccination uptake rates within Māori communities across NZ</a></li>
+	<li><a href="/web/20211026003402/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-pacific-communities-across-nz">COVID-19 Vaccination uptake rates within Pacific communities across NZ</a></li>
+</ul>
+
+<h4><a id="uptake" name="uptake"></a>Vaccine uptake per rate ratio (unadjusted) Māori and Pacific compared with Non-Māori non-Pacific</h4>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine Uptake per 1,000 (HSU) Rate Ratio, Showing Prioritised Ethnicity, vs Non-Māori Non-Pacific, By Age Band" class="img-responsive" height="830" src="/web/20211026003402im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_mix_7.png" width="1780"/></figure>
+
+<p>In the Chart above, rate ratios tell us the rate Māori or Pacific People per population are being vaccinated compared with non-Māori non-Pacific. This comparison can be split by age group.</p>
+
+<ul>
+	<li>A rate of one means the groups being compared are being vaccinated at the same rate.</li>
+	<li>A rate over one means Māori (or Pacific) are being vaccinated at a higher rate than non-Māori non-Pacific.</li>
+	<li>A rate under one means Māori (or Pacific) are being vaccinated at a lower rate than non-Māori non-Pacific.</li>
+</ul>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<td colspan="2" style="border-top: 0 !important; border-bottom-color: #FDD6AF !important; border-right: 0 !important;">&nbsp;</td>
+			<th colspan="6" id="ac1">Māori</th>
+			<th colspan="6" id="ac8">Pacific Peoples</th>
+		</tr>
+		<tr>
+			<th id="ar1">DHB</th>
+			<th>Dose number</th>
+			<th headers="ac1" id="ac2">65+</th>
+			<th headers="ac1" id="ac3">50-64</th>
+			<th headers="ac1" id="ac4">35-49</th>
+			<th headers="ac1" id="ac5">20-34</th>
+			<th headers="ac1" id="ac6">12-19</th>
+			<th headers="ac1" id="ac7">All ages</th>
+			<th headers="ac8" id="ac9">65+</th>
+			<th headers="ac8" id="ac10">50-64</th>
+			<th headers="ac8" id="ac11">35-49</th>
+			<th headers="ac8" id="ac12">20-34</th>
+			<th headers="ac8" id="ac13">12-19</th>
+			<th headers="ac8" id="ac14">All ages</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th headers="ar1" id="ar2" rowspan="2">National</th>
+			<th headers="ar1 ar2" id="ar3">Dose 1</th>
+			<td headers="ar1 ar2 ar3 ac1 ac2" style="background-color:green; color: #FFF;"><strong>0.99</strong></td>
+			<td headers="ar1 ar2 ar3 ac1 ac3" style="background-color:mediumseagreen"><strong>0.92</strong></td>
+			<td headers="ar1 ar2 ar3 ac1 ac4" style="background-color:yellow"><strong>0.77</strong></td>
+			<td headers="ar1 ar2 ar3 ac1 ac5" style="background-color:tomato"><strong>0.64</strong></td>
+			<td headers="ar1 ar2 ar3 ac1 ac6" style="background-color:coral"><strong>0.69</strong></td>
+			<td headers="ar1 ar2 ar3 ac1 ac7" style="background-color:yellow"><strong>0.75</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac9" style="background-color:mediumseagreen"><strong>0.94</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac10" style="background-color:green; color: #FFF;"><strong>0.99</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac11" style="background-color:green; color: #FFF;"><strong>0.97</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac12" style="background-color:lightgreen"><strong>0.87</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac13" style="background-color:lightgreen"><strong>0.89</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac14" style="background-color:mediumseagreen"><strong>0.91</strong></td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar2" id="ar4">Dose 2</th>
+			<td headers="ar1 ar2 ar4 ac1 ac2" style="background-color:green; color: #FFF;"><strong>0.96</strong></td>
+			<td headers="ar1 ar2 ar4 ac1 ac3" style="background-color:lightgreen"><strong>0.87</strong></td>
+			<td headers="ar1 ar2 ar4 ac1 ac4" style="background-color:coral"><strong>0.68</strong></td>
+			<td headers="ar1 ar2 ar4 ac1 ac5" style="background-color:crimson; color: #FFF;"><strong>0.51</strong></td>
+			<td headers="ar1 ar2 ar4 ac1 ac6" style="background-color:crimson; color: #FFF;"><strong>0.57</strong></td>
+			<td headers="ar1 ar2 ar4 ac1 ac7" style="background-color:tomato"><strong>0.64</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac9" style="background-color:mediumseagreen"><strong>0.91</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac10" style="background-color:green; color: #FFF;"><strong>0.99</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac11" style="background-color:green; color: #FFF;"><strong>0.98</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac12" style="background-color:palegreen"><strong>0.82</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac13" style="background-color:lightgreen"><strong>0.85</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac14" style="background-color:palegreen"><strong>0.84</strong></td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar5" rowspan="2">Northland</th>
+			<th headers="ar1 ar5" id="ar6">Dose 1</th>
+			<td headers="ar1 ar5 ar6 ac1 ac2" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar5 ar6 ac1 ac3" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar5 ar6 ac1 ac4" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar5 ar6 ac1 ac5" style="background-color:tomato">0.64</td>
+			<td headers="ar1 ar5 ar6 ac1 ac6" style="background-color:orange">0.72</td>
+			<td headers="ar1 ar5 ar6 ac1 ac7" style="background-color:yellow">0.76</td>
+			<td headers="ar1 ar5 ar6 ac8 ac9" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar5 ar6 ac8 ac10" style="background-color:green; color: #FFF;">1.05</td>
+			<td headers="ar1 ar5 ar6 ac8 ac11" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar5 ar6 ac8 ac12" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar5 ar6 ac8 ac13" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar5 ar6 ac8 ac14" style="background-color:mediumseagreen">0.93</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar5" id="ar7">Dose 2</th>
+			<td headers="ar1 ar5 ar7 ac1 ac2" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar5 ar7 ac1 ac3" style="background-color:lightgreen">0.86</td>
+			<td headers="ar1 ar5 ar7 ac1 ac4" style="background-color:coral">0.68</td>
+			<td headers="ar1 ar5 ar7 ac1 ac5" style="background-color:crimson; color: #FFF;">0.48</td>
+			<td headers="ar1 ar5 ar7 ac1 ac6" style="background-color:crimson; color: #FFF;">0.58</td>
+			<td headers="ar1 ar5 ar7 ac1 ac7" style="background-color:tomato">0.62</td>
+			<td headers="ar1 ar5 ar7 ac8 ac9" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar5 ar7 ac8 ac10" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar5 ar7 ac8 ac11" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar5 ar7 ac8 ac12" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar5 ar7 ac8 ac13" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar5 ar7 ac8 ac14" style="background-color:yellow">0.78</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar8" rowspan="2">Auckland Metro</th>
+			<th headers="ar1 ar8" id="ar9">Dose 1</th>
+			<td headers="ar1 ar8 ar9 ac1 ac2" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar8 ar9 ac1 ac3" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar8 ar9 ac1 ac4" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar8 ar9 ac1 ac5" style="background-color:coral">0.68</td>
+			<td headers="ar1 ar8 ar9 ac1 ac6" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar8 ar9 ac1 ac7" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar8 ar9 ac8 ac9" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar8 ar9 ac8 ac10" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar8 ar9 ac8 ac11" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar8 ar9 ac8 ac12" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar8 ar9 ac8 ac13" style="background-color:palegreen">0.81</td>
+			<td headers="ar1 ar8 ar9 ac8 ac14" style="background-color:lightgreen">0.86</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar8" id="ar10">Dose 2</th>
+			<td headers="ar1 ar8 ar10 ac1 ac2" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar8 ar10 ac1 ac3" style="background-color:lightgreen">0.88</td>
+			<td headers="ar1 ar8 ar10 ac1 ac4" style="background-color:coral">0.68</td>
+			<td headers="ar1 ar8 ar10 ac1 ac5" style="background-color:crimson; color: #FFF;">0.52</td>
+			<td headers="ar1 ar8 ar10 ac1 ac6" style="background-color:crimson; color: #FFF;">0.57</td>
+			<td headers="ar1 ar8 ar10 ac1 ac7" style="background-color:coral">0.65</td>
+			<td headers="ar1 ar8 ar10 ac8 ac9" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar8 ar10 ac8 ac10" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar8 ar10 ac8 ac11" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar8 ar10 ac8 ac12" style="background-color:coral">0.65</td>
+			<td headers="ar1 ar8 ar10 ac8 ac13" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar8 ar10 ac8 ac14" style="background-color:yellow">0.77</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar11" rowspan="2">Waikato</th>
+			<th headers="ar1 ar11" id="ar12">Dose 1</th>
+			<td headers="ar1 ar11 ar12 ac1 ac2" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar11 ar12 ac1 ac3" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar11 ar12 ac1 ac4" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar11 ar12 ac1 ac5" style="background-color:coral">0.66</td>
+			<td headers="ar1 ar11 ar12 ac1 ac6" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar11 ar12 ac1 ac7" style="background-color:yellow">0.76</td>
+			<td headers="ar1 ar11 ar12 ac8 ac9" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar11 ar12 ac8 ac10" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar11 ar12 ac8 ac11" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar11 ar12 ac8 ac12" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar11 ar12 ac8 ac13" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar11 ar12 ac8 ac14" style="background-color:mediumseagreen">0.93</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar11" id="ar13">Dose 2</th>
+			<td headers="ar1 ar11 ar13 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar11 ar13 ac1 ac3" style="background-color:lightgreen">0.87</td>
+			<td headers="ar1 ar11 ar13 ac1 ac4" style="background-color:coral">0.68</td>
+			<td headers="ar1 ar11 ar13 ac1 ac5" style="background-color:crimson; color: #FFF;">0.50</td>
+			<td headers="ar1 ar11 ar13 ac1 ac6" style="background-color:crimson; color: #FFF;">0.56</td>
+			<td headers="ar1 ar11 ar13 ac1 ac7" style="background-color:tomato">0.63</td>
+			<td headers="ar1 ar11 ar13 ac8 ac9" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar11 ar13 ac8 ac10" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar11 ar13 ac8 ac11" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar11 ar13 ac8 ac12" style="background-color:lightgreen">0.86</td>
+			<td headers="ar1 ar11 ar13 ac8 ac13" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar11 ar13 ac8 ac14" style="background-color:lightgreen">0.87</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar14" rowspan="2">Bay of Plenty</th>
+			<th headers="ar1 ar14" id="ar15">Dose 1</th>
+			<td headers="ar1 ar14 ar15 ac1 ac2" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar14 ar15 ac1 ac3" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar14 ar15 ac1 ac4" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar14 ar15 ac1 ac5" style="background-color:crimson; color: #FFF;">0.55</td>
+			<td headers="ar1 ar14 ar15 ac1 ac6" style="background-color:tomato">0.62</td>
+			<td headers="ar1 ar14 ar15 ac1 ac7" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar14 ar15 ac8 ac9" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar14 ar15 ac8 ac10" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar14 ar15 ac8 ac11" style="background-color:green; color: #FFF;">1.44</td>
+			<td headers="ar1 ar14 ar15 ac8 ac12" style="background-color:green; color: #FFF;">1.50</td>
+			<td headers="ar1 ar14 ar15 ac8 ac13" style="background-color:lightgreen">0.87</td>
+			<td headers="ar1 ar14 ar15 ac8 ac14" style="background-color:green; color: #FFF;">1.20</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar14" id="ar16">Dose 2</th>
+			<td headers="ar1 ar14 ar16 ac1 ac2" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar14 ar16 ac1 ac3" style="background-color:palegreen">0.84</td>
+			<td headers="ar1 ar14 ar16 ac1 ac4" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar14 ar16 ac1 ac5" style="background-color:crimson; color: #FFF;">0.46</td>
+			<td headers="ar1 ar14 ar16 ac1 ac6" style="background-color:crimson; color: #FFF;">0.54</td>
+			<td headers="ar1 ar14 ar16 ac1 ac7" style="background-color:crimson; color: #FFF;">0.59</td>
+			<td headers="ar1 ar14 ar16 ac8 ac9" style="background-color:lightgreen">0.88</td>
+			<td headers="ar1 ar14 ar16 ac8 ac10" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar14 ar16 ac8 ac11" style="background-color:green; color: #FFF;">1.64</td>
+			<td headers="ar1 ar14 ar16 ac8 ac12" style="background-color:green; color: #FFF;">1.91</td>
+			<td headers="ar1 ar14 ar16 ac8 ac13" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar14 ar16 ac8 ac14" style="background-color:green; color: #FFF;">1.13</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar17" rowspan="2">Tairawhiti</th>
+			<th headers="ar1 ar17" id="ar18">Dose 1</th>
+			<td headers="ar1 ar17 ar18 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar17 ar18 ac1 ac3" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar17 ar18 ac1 ac4" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar17 ar18 ac1 ac5" style="background-color:tomato">0.60</td>
+			<td headers="ar1 ar17 ar18 ac1 ac6" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar17 ar18 ac1 ac7" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar17 ar18 ac8 ac9" style="background-color:green; color: #FFF;">1.05</td>
+			<td headers="ar1 ar17 ar18 ac8 ac10" style="background-color:green; color: #FFF;">1.07</td>
+			<td headers="ar1 ar17 ar18 ac8 ac11" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar17 ar18 ac8 ac12" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar17 ar18 ac8 ac13" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar17 ar18 ac8 ac14" style="background-color:green; color: #FFF;">0.99</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar17" id="ar19">Dose 2</th>
+			<td headers="ar1 ar17 ar19 ac1 ac2" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar17 ar19 ac1 ac3" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar17 ar19 ac1 ac4" style="background-color:coral">0.69</td>
+			<td headers="ar1 ar17 ar19 ac1 ac5" style="background-color:crimson; color: #FFF;">0.49</td>
+			<td headers="ar1 ar17 ar19 ac1 ac6" style="background-color:crimson; color: #FFF;">0.55</td>
+			<td headers="ar1 ar17 ar19 ac1 ac7" style="background-color:tomato">0.64</td>
+			<td headers="ar1 ar17 ar19 ac8 ac9" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar17 ar19 ac8 ac10" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar17 ar19 ac8 ac11" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar17 ar19 ac8 ac12" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar17 ar19 ac8 ac13" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar17 ar19 ac8 ac14" style="background-color:lightgreen">0.88</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar20" rowspan="2">Lakes</th>
+			<th headers="ar1 ar20" id="ar21">Dose 1</th>
+			<td headers="ar1 ar20 ar21 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar20 ar21 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar20 ar21 ac1 ac4" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar20 ar21 ac1 ac5" style="background-color:crimson; color: #FFF;">0.56</td>
+			<td headers="ar1 ar20 ar21 ac1 ac6" style="background-color:tomato">0.64</td>
+			<td headers="ar1 ar20 ar21 ac1 ac7" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar20 ar21 ac8 ac9" style="background-color:green; color: #FFF;">1.06</td>
+			<td headers="ar1 ar20 ar21 ac8 ac10" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar20 ar21 ac8 ac11" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar20 ar21 ac8 ac12" style="background-color:palegreen">0.81</td>
+			<td headers="ar1 ar20 ar21 ac8 ac13" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar20 ar21 ac8 ac14" style="background-color:lightgreen">0.89</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar20" id="ar22">Dose 2</th>
+			<td headers="ar1 ar20 ar22 ac1 ac2" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar20 ar22 ac1 ac3" style="background-color:palegreen">0.84</td>
+			<td headers="ar1 ar20 ar22 ac1 ac4" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar20 ar22 ac1 ac5" style="background-color:crimson; color: #FFF;">0.45</td>
+			<td headers="ar1 ar20 ar22 ac1 ac6" style="background-color:crimson; color: #FFF;">0.54</td>
+			<td headers="ar1 ar20 ar22 ac1 ac7" style="background-color:tomato">0.60</td>
+			<td headers="ar1 ar20 ar22 ac8 ac9" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar20 ar22 ac8 ac10" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar20 ar22 ac8 ac11" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar20 ar22 ac8 ac12" style="background-color:lightgreen">0.87</td>
+			<td headers="ar1 ar20 ar22 ac8 ac13" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar20 ar22 ac8 ac14" style="background-color:palegreen">0.84</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar23" rowspan="2">Taranaki</th>
+			<th headers="ar1 ar23" id="ar24">Dose 1</th>
+			<td headers="ar1 ar23 ar24 ac1 ac2" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar23 ar24 ac1 ac3" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar23 ar24 ac1 ac4" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar23 ar24 ac1 ac5" style="background-color:coral">0.65</td>
+			<td headers="ar1 ar23 ar24 ac1 ac6" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar23 ar24 ac1 ac7" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar23 ar24 ac8 ac9" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar23 ar24 ac8 ac10" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar23 ar24 ac8 ac11" style="background-color:green; color: #FFF;">1.05</td>
+			<td headers="ar1 ar23 ar24 ac8 ac12" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar23 ar24 ac8 ac13" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar23 ar24 ac8 ac14" style="background-color:mediumseagreen">0.93</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar23" id="ar25">Dose 2</th>
+			<td headers="ar1 ar23 ar25 ac1 ac2" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar23 ar25 ac1 ac3" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar23 ar25 ac1 ac4" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar23 ar25 ac1 ac5" style="background-color:crimson; color: #FFF;">0.52</td>
+			<td headers="ar1 ar23 ar25 ac1 ac6" style="background-color:crimson; color: #FFF;">0.54</td>
+			<td headers="ar1 ar23 ar25 ac1 ac7" style="background-color:tomato">0.62</td>
+			<td headers="ar1 ar23 ar25 ac8 ac9" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar23 ar25 ac8 ac10" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar23 ar25 ac8 ac11" style="background-color:green; color: #FFF;">1.23</td>
+			<td headers="ar1 ar23 ar25 ac8 ac12" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar23 ar25 ac8 ac13" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar23 ar25 ac8 ac14" style="background-color:lightgreen">0.88</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar26" rowspan="2">Whanganui</th>
+			<th headers="ar1 ar26" id="ar27">Dose 1</th>
+			<td headers="ar1 ar26 ar27 ac1 ac2" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar26 ar27 ac1 ac3" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar26 ar27 ac1 ac4" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar26 ar27 ac1 ac5" style="background-color:tomato">0.63</td>
+			<td headers="ar1 ar26 ar27 ac1 ac6" style="background-color:coral">0.68</td>
+			<td headers="ar1 ar26 ar27 ac1 ac7" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar26 ar27 ac8 ac9" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar26 ar27 ac8 ac10" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar26 ar27 ac8 ac11" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar26 ar27 ac8 ac12" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar26 ar27 ac8 ac13" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar26 ar27 ac8 ac14" style="background-color:lightgreen">0.86</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar26" id="ar28">Dose 2</th>
+			<td headers="ar1 ar26 ar28 ac1 ac2" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar26 ar28 ac1 ac3" style="background-color:lightgreen">0.88</td>
+			<td headers="ar1 ar26 ar28 ac1 ac4" style="background-color:coral">0.69</td>
+			<td headers="ar1 ar26 ar28 ac1 ac5" style="background-color:crimson; color: #FFF;">0.49</td>
+			<td headers="ar1 ar26 ar28 ac1 ac6" style="background-color:crimson; color: #FFF;">0.59</td>
+			<td headers="ar1 ar26 ar28 ac1 ac7" style="background-color:tomato">0.63</td>
+			<td headers="ar1 ar26 ar28 ac8 ac9" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar26 ar28 ac8 ac10" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar26 ar28 ac8 ac11" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar26 ar28 ac8 ac12" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar26 ar28 ac8 ac13" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar26 ar28 ac8 ac14" style="background-color:yellow">0.77</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar29" rowspan="2">Hawke&#39;s Bay</th>
+			<th headers="ar1 ar29" id="ar30">Dose 1</th>
+			<td headers="ar1 ar29 ar30 ac1 ac2" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar29 ar30 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar29 ar30 ac1 ac4" style="background-color:yellow">0.77</td>
+			<td headers="ar1 ar29 ar30 ac1 ac5" style="background-color:crimson; color: #FFF;">0.58</td>
+			<td headers="ar1 ar29 ar30 ac1 ac6" style="background-color:coral">0.69</td>
+			<td headers="ar1 ar29 ar30 ac1 ac7" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar29 ar30 ac8 ac9" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar29 ar30 ac8 ac10" style="background-color:green; color: #FFF;">1.05</td>
+			<td headers="ar1 ar29 ar30 ac8 ac11" style="background-color:green; color: #FFF;">1.41</td>
+			<td headers="ar1 ar29 ar30 ac8 ac12" style="background-color:green; color: #FFF;">1.33</td>
+			<td headers="ar1 ar29 ar30 ac8 ac13" style="background-color:lightgreen">0.88</td>
+			<td headers="ar1 ar29 ar30 ac8 ac14" style="background-color:green; color: #FFF;">1.15</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar29" id="ar31">Dose 2</th>
+			<td headers="ar1 ar29 ar31 ac1 ac2" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar29 ar31 ac1 ac3" style="background-color:palegreen">0.84</td>
+			<td headers="ar1 ar29 ar31 ac1 ac4" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar29 ar31 ac1 ac5" style="background-color:crimson; color: #FFF;">0.48</td>
+			<td headers="ar1 ar29 ar31 ac1 ac6" style="background-color:crimson; color: #FFF;">0.57</td>
+			<td headers="ar1 ar29 ar31 ac1 ac7" style="background-color:tomato">0.61</td>
+			<td headers="ar1 ar29 ar31 ac8 ac9" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar29 ar31 ac8 ac10" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar29 ar31 ac8 ac11" style="background-color:green; color: #FFF;">1.52</td>
+			<td headers="ar1 ar29 ar31 ac8 ac12" style="background-color:green; color: #FFF;">1.56</td>
+			<td headers="ar1 ar29 ar31 ac8 ac13" style="background-color:lightgreen">0.86</td>
+			<td headers="ar1 ar29 ar31 ac8 ac14" style="background-color:green; color: #FFF;">1.10</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar32" rowspan="2">MidCentral</th>
+			<th headers="ar1 ar32" id="ar33">Dose 1</th>
+			<td headers="ar1 ar32 ar33 ac1 ac2" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar32 ar33 ac1 ac3" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar32 ar33 ac1 ac4" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar32 ar33 ac1 ac5" style="background-color:coral">0.69</td>
+			<td headers="ar1 ar32 ar33 ac1 ac6" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar32 ar33 ac1 ac7" style="background-color:yellow">0.76</td>
+			<td headers="ar1 ar32 ar33 ac8 ac9" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar32 ar33 ac8 ac10" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar32 ar33 ac8 ac11" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar32 ar33 ac8 ac12" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar32 ar33 ac8 ac13" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar32 ar33 ac8 ac14" style="background-color:mediumseagreen">0.93</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar32" id="ar34">Dose 2</th>
+			<td headers="ar1 ar32 ar34 ac1 ac2" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar32 ar34 ac1 ac3" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar32 ar34 ac1 ac4" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar32 ar34 ac1 ac5" style="background-color:crimson; color: #FFF;">0.58</td>
+			<td headers="ar1 ar32 ar34 ac1 ac6" style="background-color:tomato">0.60</td>
+			<td headers="ar1 ar32 ar34 ac1 ac7" style="background-color:coral">0.66</td>
+			<td headers="ar1 ar32 ar34 ac8 ac9" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar32 ar34 ac8 ac10" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar32 ar34 ac8 ac11" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar32 ar34 ac8 ac12" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar32 ar34 ac8 ac13" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar32 ar34 ac8 ac14" style="background-color:palegreen">0.84</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar35" rowspan="2">Wairarapa</th>
+			<th headers="ar1 ar35" id="ar36">Dose 1</th>
+			<td headers="ar1 ar35 ar36 ac1 ac2" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar35 ar36 ac1 ac3" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar35 ar36 ac1 ac4" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar35 ar36 ac1 ac5" style="background-color:coral">0.68</td>
+			<td headers="ar1 ar35 ar36 ac1 ac6" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar35 ar36 ac1 ac7" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar35 ar36 ac8 ac9" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar35 ar36 ac8 ac10" style="background-color:green; color: #FFF;">1.07</td>
+			<td headers="ar1 ar35 ar36 ac8 ac11" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar35 ar36 ac8 ac12" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar35 ar36 ac8 ac13" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar35 ar36 ac8 ac14" style="background-color:mediumseagreen">0.92</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar35" id="ar37">Dose 2</th>
+			<td headers="ar1 ar35 ar37 ac1 ac2" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar35 ar37 ac1 ac3" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar35 ar37 ac1 ac4" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar35 ar37 ac1 ac5" style="background-color:crimson; color: #FFF;">0.54</td>
+			<td headers="ar1 ar35 ar37 ac1 ac6" style="background-color:crimson; color: #FFF;">0.59</td>
+			<td headers="ar1 ar35 ar37 ac1 ac7" style="background-color:tomato">0.62</td>
+			<td headers="ar1 ar35 ar37 ac8 ac9" style="background-color:green; color: #FFF;">1.06</td>
+			<td headers="ar1 ar35 ar37 ac8 ac10" style="background-color:green; color: #FFF;">1.06</td>
+			<td headers="ar1 ar35 ar37 ac8 ac11" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar35 ar37 ac8 ac12" style="background-color:green; color: #FFF;">1.06</td>
+			<td headers="ar1 ar35 ar37 ac8 ac13" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar35 ar37 ac8 ac14" style="background-color:lightgreen">0.85</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar38" rowspan="2">Capital &amp; Coast and Hutt Valley</th>
+			<th headers="ar1 ar38" id="ar39">Dose 1</th>
+			<td headers="ar1 ar38 ar39 ac1 ac2" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar38 ar39 ac1 ac3" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar38 ar39 ac1 ac4" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar38 ar39 ac1 ac5" style="background-color:orange">0.72</td>
+			<td headers="ar1 ar38 ar39 ac1 ac6" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar38 ar39 ac1 ac7" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar38 ar39 ac8 ac9" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar38 ar39 ac8 ac10" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar38 ar39 ac8 ac11" style="background-color:lightgreen">0.88</td>
+			<td headers="ar1 ar38 ar39 ac8 ac12" style="background-color:yellow">0.76</td>
+			<td headers="ar1 ar38 ar39 ac8 ac13" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar38 ar39 ac8 ac14" style="background-color:lightgreen">0.85</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar38" id="ar40">Dose 2</th>
+			<td headers="ar1 ar38 ar40 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar38 ar40 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar38 ar40 ac1 ac4" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar38 ar40 ac1 ac5" style="background-color:tomato">0.63</td>
+			<td headers="ar1 ar38 ar40 ac1 ac6" style="background-color:tomato">0.62</td>
+			<td headers="ar1 ar38 ar40 ac1 ac7" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar38 ar40 ac8 ac9" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar38 ar40 ac8 ac10" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar38 ar40 ac8 ac11" style="background-color:lightgreen">0.87</td>
+			<td headers="ar1 ar38 ar40 ac8 ac12" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar38 ar40 ac8 ac13" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar38 ar40 ac8 ac14" style="background-color:palegreen">0.80</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar41" rowspan="2">Nelson Marlborough</th>
+			<th headers="ar1 ar41" id="ar42">Dose 1</th>
+			<td headers="ar1 ar41 ar42 ac1 ac2" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar41 ar42 ac1 ac3" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar41 ar42 ac1 ac4" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar41 ar42 ac1 ac5" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar41 ar42 ac1 ac6" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar41 ar42 ac1 ac7" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar41 ar42 ac8 ac9" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar41 ar42 ac8 ac10" style="background-color:green; color: #FFF;">1.27</td>
+			<td headers="ar1 ar41 ar42 ac8 ac11" style="background-color:green; color: #FFF;">2.48</td>
+			<td headers="ar1 ar41 ar42 ac8 ac12" style="background-color:green; color: #FFF;">2.97</td>
+			<td headers="ar1 ar41 ar42 ac8 ac13" style="background-color:green; color: #FFF;">1.07</td>
+			<td headers="ar1 ar41 ar42 ac8 ac14" style="background-color:green; color: #FFF;">1.97</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar41" id="ar43">Dose 2</th>
+			<td headers="ar1 ar41 ar43 ac1 ac2" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar41 ar43 ac1 ac3" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar41 ar43 ac1 ac4" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar41 ar43 ac1 ac5" style="background-color:crimson; color: #FFF;">0.54</td>
+			<td headers="ar1 ar41 ar43 ac1 ac6" style="background-color:coral">0.66</td>
+			<td headers="ar1 ar41 ar43 ac1 ac7" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar41 ar43 ac8 ac9" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar41 ar43 ac8 ac10" style="background-color:green; color: #FFF;">1.25</td>
+			<td headers="ar1 ar41 ar43 ac8 ac11" style="background-color:green; color: #FFF;">2.65</td>
+			<td headers="ar1 ar41 ar43 ac8 ac12" style="background-color:green; color: #FFF;">3.65</td>
+			<td headers="ar1 ar41 ar43 ac8 ac13" style="background-color:green; color: #FFF;">1.05</td>
+			<td headers="ar1 ar41 ar43 ac8 ac14" style="background-color:green; color: #FFF;">1.96</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar44" rowspan="2">West Coast</th>
+			<th headers="ar1 ar44" id="ar45">Dose 1</th>
+			<td headers="ar1 ar44 ar45 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar44 ar45 ac1 ac3" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar44 ar45 ac1 ac4" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar44 ar45 ac1 ac5" style="background-color:yellow">0.77</td>
+			<td headers="ar1 ar44 ar45 ac1 ac6" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar44 ar45 ac1 ac7" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar44 ar45 ac8 ac9" style="background-color:green; color: #FFF;">1.34</td>
+			<td headers="ar1 ar44 ar45 ac8 ac10" style="background-color:green; color: #FFF;">1.05</td>
+			<td headers="ar1 ar44 ar45 ac8 ac11" style="background-color:green; color: #FFF;">1.07</td>
+			<td headers="ar1 ar44 ar45 ac8 ac12" style="background-color:green; color: #FFF;">1.27</td>
+			<td headers="ar1 ar44 ar45 ac8 ac13" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar44 ar45 ac8 ac14" style="background-color:green; color: #FFF;">0.99</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar44" id="ar46">Dose 2</th>
+			<td headers="ar1 ar44 ar46 ac1 ac2" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar44 ar46 ac1 ac3" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar44 ar46 ac1 ac4" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar44 ar46 ac1 ac5" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar44 ar46 ac1 ac6" style="background-color:lightgreen">0.88</td>
+			<td headers="ar1 ar44 ar46 ac1 ac7" style="background-color:yellow">0.76</td>
+			<td headers="ar1 ar44 ar46 ac8 ac9" style="background-color:green; color: #FFF;">1.35</td>
+			<td headers="ar1 ar44 ar46 ac8 ac10" style="background-color:green; color: #FFF;">1.07</td>
+			<td headers="ar1 ar44 ar46 ac8 ac11" style="background-color:green; color: #FFF;">1.07</td>
+			<td headers="ar1 ar44 ar46 ac8 ac12" style="background-color:green; color: #FFF;">1.58</td>
+			<td headers="ar1 ar44 ar46 ac8 ac13" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar44 ar46 ac8 ac14" style="background-color:mediumseagreen">0.92</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar47" rowspan="2">Canterbury</th>
+			<th headers="ar1 ar47" id="ar48">Dose 1</th>
+			<td headers="ar1 ar47 ar48 ac1 ac2" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar47 ar48 ac1 ac3" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar47 ar48 ac1 ac4" style="background-color:palegreen">0.81</td>
+			<td headers="ar1 ar47 ar48 ac1 ac5" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar47 ar48 ac1 ac6" style="background-color:yellow">0.76</td>
+			<td headers="ar1 ar47 ar48 ac1 ac7" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar47 ar48 ac8 ac9" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar47 ar48 ac8 ac10" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar47 ar48 ac8 ac11" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar47 ar48 ac8 ac12" style="background-color:palegreen">0.84</td>
+			<td headers="ar1 ar47 ar48 ac8 ac13" style="background-color:lightgreen">0.88</td>
+			<td headers="ar1 ar47 ar48 ac8 ac14" style="background-color:lightgreen">0.88</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar47" id="ar49">Dose 2</th>
+			<td headers="ar1 ar47 ar49 ac1 ac2" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar47 ar49 ac1 ac3" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar47 ar49 ac1 ac4" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar47 ar49 ac1 ac5" style="background-color:coral">0.68</td>
+			<td headers="ar1 ar47 ar49 ac1 ac6" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar47 ar49 ac1 ac7" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar47 ar49 ac8 ac9" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar47 ar49 ac8 ac10" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar47 ar49 ac8 ac11" style="background-color:green; color: #FFF;">1.10</td>
+			<td headers="ar1 ar47 ar49 ac8 ac12" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar47 ar49 ac8 ac13" style="background-color:green; color: #FFF;">1.10</td>
+			<td headers="ar1 ar47 ar49 ac8 ac14" style="background-color:lightgreen">0.87</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar50" rowspan="2">South Canterbury</th>
+			<th headers="ar1 ar50" id="ar51">Dose 1</th>
+			<td headers="ar1 ar50 ar51 ac1 ac2" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar50 ar51 ac1 ac3" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar50 ar51 ac1 ac4" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar50 ar51 ac1 ac5" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar50 ar51 ac1 ac6" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar50 ar51 ac1 ac7" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar50 ar51 ac8 ac9" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar50 ar51 ac8 ac10" style="background-color:green; color: #FFF;">1.10</td>
+			<td headers="ar1 ar50 ar51 ac8 ac11" style="background-color:green; color: #FFF;">1.19</td>
+			<td headers="ar1 ar50 ar51 ac8 ac12" style="background-color:green; color: #FFF;">1.21</td>
+			<td headers="ar1 ar50 ar51 ac8 ac13" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar50 ar51 ac8 ac14" style="background-color:green; color: #FFF;">1.05</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar50" id="ar52">Dose 2</th>
+			<td headers="ar1 ar50 ar52 ac1 ac2" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar50 ar52 ac1 ac3" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar50 ar52 ac1 ac4" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar50 ar52 ac1 ac5" style="background-color:tomato">0.64</td>
+			<td headers="ar1 ar50 ar52 ac1 ac6" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar50 ar52 ac1 ac7" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar50 ar52 ac8 ac9" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar50 ar52 ac8 ac10" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar50 ar52 ac8 ac11" style="background-color:green; color: #FFF;">1.15</td>
+			<td headers="ar1 ar50 ar52 ac8 ac12" style="background-color:green; color: #FFF;">1.17</td>
+			<td headers="ar1 ar50 ar52 ac8 ac13" style="background-color:green; color: #FFF;">1.07</td>
+			<td headers="ar1 ar50 ar52 ac8 ac14" style="background-color:lightgreen">0.87</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar53" rowspan="2">Southern</th>
+			<th headers="ar1 ar53" id="ar54">Dose 1</th>
+			<td headers="ar1 ar53 ar54 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar53 ar54 ac1 ac3" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar53 ar54 ac1 ac4" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar53 ar54 ac1 ac5" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar53 ar54 ac1 ac6" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar53 ar54 ac1 ac7" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar53 ar54 ac8 ac9" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar53 ar54 ac8 ac10" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar53 ar54 ac8 ac11" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar53 ar54 ac8 ac12" style="background-color:green; color: #FFF;">1.09</td>
+			<td headers="ar1 ar53 ar54 ac8 ac13" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar53 ar54 ac8 ac14" style="background-color:green; color: #FFF;">1.01</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar53" id="ar55">Dose 2</th>
+			<td headers="ar1 ar53 ar55 ac1 ac2" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar53 ar55 ac1 ac3" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar53 ar55 ac1 ac4" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar53 ar55 ac1 ac5" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar53 ar55 ac1 ac6" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar53 ar55 ac1 ac7" style="background-color:orange">0.72</td>
+			<td headers="ar1 ar53 ar55 ac8 ac9" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar53 ar55 ac8 ac10" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar53 ar55 ac8 ac11" style="background-color:green; color: #FFF;">1.11</td>
+			<td headers="ar1 ar53 ar55 ac8 ac12" style="background-color:green; color: #FFF;">1.07</td>
+			<td headers="ar1 ar53 ar55 ac8 ac13" style="background-color:lightgreen">0.86</td>
+			<td headers="ar1 ar53 ar55 ac8 ac14" style="background-color:mediumseagreen">0.92</td>
+		</tr>
+	</tbody>
+</table>
+
+<p>This table shows the rate of doses administered (per 1,000 population) to Māori or Pacific Peoples, relative to the rate of doses for Non-Māori and Non-Pacific groups. Less than one means the group is receiving a lower proportion of doses than would be expected if equity is being achieved. More than one means they are receiving a higher proportion of doses than would be expected if equity is being achieved. Exactly one means doses administered are in line with their proportion of population.</p>
+
+<ul>
+	<li><a download="" href="/web/20211026003402/https://www.health.govt.nz/system/files/documents/pages/rateratioexplainer_1.docx">Rate Ratio Explainer (Word, 434 KB)</a></li>
+</ul>
+
+<p>At all ages the size (weightings) of the age groups becomes a major contributing factor to comparative ratios, which is why the all ages (12+) figure may not appear to be in line with the age splits.</p>
+
+<h4><a id="uptake" name="uptake"></a>Vaccine uptake per 1,000 people by ethnicity</h4>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine uptake per 1,000 people by ethnicity" class="img-responsive" height="830" src="/web/20211026003402im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_eth_7.png" width="1780"/></figure>
+
+<h4><a id="uptake" name="uptake"></a>Vaccine uptake per 1,000 people by age band</h4>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine uptake per 1,000 people by age band" class="img-responsive" height="1030" src="/web/20211026003402im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_age_8.png" width="1780"/></figure>
+
+<h4><a id="uptake" name="location"></a>Vaccine uptake per 1,000 people by DHB of residence</h4>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine uptake per 1,000 people by DHB of residence" class="img-responsive" height="1030" src="/web/20211026003402im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_dhb_3.png" width="1780"/></figure>
+<!--
+<hr />
+<h3><a id="by_dhb_plan" name="dhb_plan"></a>Cumulative vaccination plan for DHBs</h3>
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">DHB of service</th>
+			<th scope="col" style="text-align:right">Actuals to Sunday 17 October</th>
+			<th scope="col" style="text-align:right">DHB Plan to Sunday 17 October</th>
+			<th scope="col" style="text-align:right">Variance</th>
+			<th scope="col" style="text-align:right">% of Plan</th>
+			<th scope="col" style="text-align:right">Week to date</th>
+		</tr>
+	</thead>
+	<tbody> --><!--plan--><!--
+<tr><td nowrap="nowrap">Auckland Metro</td><td>190621</td><td>205515</td><td>-14894</td><td>93%</td><td>9913</td></tr>
+<tr><td nowrap="nowrap">Bay of Plenty</td><td>22841</td><td>14255</td><td>8586</td><td>160%</td><td>1843</td></tr>
+<tr><td nowrap="nowrap">Canterbury</td><td>50558</td><td>39266</td><td>11292</td><td>129%</td><td>2769</td></tr>
+<tr><td nowrap="nowrap">Capital & Coast and Hutt Valley</td><td>48758</td><td>39742</td><td>9016</td><td>123%</td><td>1796</td></tr>
+<tr><td nowrap="nowrap">Hawke's Bay</td><td>15319</td><td>18205</td><td>-2886</td><td>84%</td><td>1351</td></tr>
+<tr><td nowrap="nowrap">Lakes</td><td>13437</td><td>12810</td><td>627</td><td>105%</td><td>731</td></tr>
+<tr><td nowrap="nowrap">MidCentral</td><td>10708</td><td>7237</td><td>3471</td><td>148%</td><td>1191</td></tr>
+<tr><td nowrap="nowrap">Nelson Marlborough</td><td>30198</td><td>18574</td><td>11624</td><td>163%</td><td>1285</td></tr>
+<tr><td nowrap="nowrap">Northland</td><td>21469</td><td>24762</td><td>-3293</td><td>87%</td><td>1257</td></tr>
+<tr><td nowrap="nowrap">South Canterbury</td><td>8106</td><td>8033</td><td>73</td><td>101%</td><td>389</td></tr>
+<tr><td nowrap="nowrap">Southern</td><td>35234</td><td>34594</td><td>640</td><td>102%</td><td>1794</td></tr>
+<tr><td nowrap="nowrap">Tairāwhiti</td><td>4579</td><td>4928</td><td>-349</td><td>93%</td><td>290</td></tr>
+<tr><td nowrap="nowrap">Taranaki</td><td>5619</td><td>5297</td><td>322</td><td>106%</td><td>168</td></tr>
+<tr><td nowrap="nowrap">Waikato</td><td>36070</td><td>32842</td><td>3228</td><td>110%</td><td>1905</td></tr>
+<tr><td nowrap="nowrap">Wairarapa</td><td>4516</td><td>4960</td><td>-444</td><td>91%</td><td>468</td></tr>
+<tr><td nowrap="nowrap">West Coast</td><td>3533</td><td>3300</td><td>233</td><td>107%</td><td>336</td></tr>
+<tr><td nowrap="nowrap">Whanganui</td><td>6982</td><td>4711</td><td>2271</td><td>148%</td><td>612</td></tr>
+<tr><td nowrap="nowrap">Other Sites</td><td>24890</td><td>14575</td><td>10315</td><td>171%</td><td>613</td></tr>
+<tr><td nowrap="nowrap">Total</td><td>533438</td><td>493606</td><td>39832</td><td>108%</td><td>28711</td></tr>
+!--plan_end--><!--	</tbody>
+</table>
+
+
+<p>The information provided in this table is based on cumulative DHB plans to the last week ending on Sunday. The final column shows vaccinations administered since Sunday by DHB of service to reconcile total actuals in this table to other total numbers shown.   On-going, and as we roll-out the vaccination programme, we anticipate that there could be a potential variance of up to ten percent (plus or minus) between DHB Plans and actual vaccination numbers. This is on the basis that, for example, an unplanned significant event could affect roll-out implementation or some DHBs might exceed their planned vaccination numbers.
+</p>
+-->
+
+<hr/>
+<h3><a id="by_dhb" name="location"></a>Cumulative vaccinations by DHB</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Cumulative vaccinations for DHBs" class="img-responsive" height="830" src="/web/20211026003402im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/dhbstacked_11.png" width="1780"/></figure>
+
+<hr/>
+<h3><a id="by-day" name="by-day"></a>Vaccinations by day</h3>
+
+<figure class="image-captioned img-responsive"><img alt="Vaccination doses administered per day" class="img-responsive" height="830" src="/web/20211026003402im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/vaccinebyday_11.png" width="1780"/></figure>
+
+<p>This chart shows the count of vaccinations administered on a given day from the COVID-19 Immunisation Register. Note some records are entered in the register at a later date than the immunisation was received. This means that the figures for a given date may move for some time after that date.</p>
+
+<hr/>
+<h3><a id="group" name="group"></a>Vaccinations by group by week</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccinations by group" class="img-responsive" height="830" src="/web/20211026003402im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/vaccinebygroupwk_11.png" width="1780"/></figure>
+
+<hr/>
+<h3><a id="group_d" name="group_d"></a>Cumulative vaccinations by group</h3>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">Priority Group</th>
+			<th scope="col" style="text-align:right">First dose administered</th>
+			<th scope="col" style="text-align:right">Second dose administered</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">Group 1</th>
+			<td style="text-align:right">66,654</td>
+			<td style="text-align:right">64,835</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Group 2</th>
+			<td style="text-align:right">634,957</td>
+			<td style="text-align:right">595,136</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Group 3</th>
+			<td style="text-align:right">790,330</td>
+			<td style="text-align:right">734,465</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Group 4</th>
+			<td style="text-align:right">2,101,547</td>
+			<td style="text-align:right">1,443,270</td>
+		</tr>
+	</tbody>
+</table>
+
+<p>For definitions of the groups and further detail see the downloadable spreadsheet at the bottom of the page.</p>
+
+<hr/>
+<h3><a id="by_soh" name="stockonhand"></a>Vaccine available for distribution at week end</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine available for distribution at week end" class="img-responsive" height="830" src="/web/20211026003402im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/stockonhand_12.png" width="1780"/></figure>
+
+<p>Vaccine available for distribution is stock (in doses) held at central warehouses. It does not include stock in transit or available at sites ready for use.</p>
+
+<hr/>
+<h3><a id="by_eth" name="ethnicity"></a>Total cumulative doses per 1,000 people by ethnicity</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Total cumulative doses per 1,000 people by ethnicity" class="img-responsive" height="830" src="/web/20211026003402im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/ethnicity_11.png" width="1780"/></figure>
+
+<p>This chart shows both first and second doses. As a result this chart may exceed 1,000 doses per 1,000 people.</p>
+
+<p><strong>*</strong> The prioritised ethnicity classification system allocates each person to a single ethnic group, based on the ethnic groups they identify with. Where people identify with more than one group, they are assigned in this order of priority: Māori, Pacific Peoples, Asian, and European/Other. So, if a person identifies as being Māori and New Zealand European, the person is counted as Māori. See <a href="/web/20211026003402/https://www.health.govt.nz/publication/hiso-100012017-ethnicity-data-protocols">Ethnicity Data Protocols</a> for further information.</p>
+
+<p>Ethnicity breakdown by DHB of residence is available in the downloadable spreadsheet at the bottom of the page.</p>
+
+<hr/>
+<h3><a id="by_age" name="age"></a>Cumulative vaccinations by age</h3>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">Age</th>
+			<th scope="col" style="text-align:right">First dose administered</th>
+			<th scope="col" style="text-align:right">First doses per 1,000 people</th>
+			<th scope="col" style="text-align:right">Fully vaccinated</th>
+			<th scope="col" style="text-align:right">Fully vaccinated per 1,000 people</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">12 - 19 years</th>
+			<td style="text-align:right">389,918</td>
+			<td style="text-align:right">776</td>
+			<td style="text-align:right">247,401</td>
+			<td style="text-align:right">492</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">20 - 34 years</th>
+			<td style="text-align:right">819,368</td>
+			<td style="text-align:right">792</td>
+			<td style="text-align:right">542,717</td>
+			<td style="text-align:right">525</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">35 - 49 years</th>
+			<td style="text-align:right">810,315</td>
+			<td style="text-align:right">847</td>
+			<td style="text-align:right">620,812</td>
+			<td style="text-align:right">649</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">50 - 64 years</th>
+			<td style="text-align:right">828,152</td>
+			<td style="text-align:right">893</td>
+			<td style="text-align:right">722,868</td>
+			<td style="text-align:right">779</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">65 and over</th>
+			<td style="text-align:right">745,735</td>
+			<td style="text-align:right">946</td>
+			<td style="text-align:right">703,908</td>
+			<td style="text-align:right">893</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total</strong></th>
+			<td style="text-align:right"><strong>3,593,488</strong></td>
+			<td style="text-align:right"><strong>854</strong></td>
+			<td style="text-align:right"><strong>2,837,706</strong></td>
+			<td style="text-align:right"><strong>674</strong></td>
+		</tr>
+	</tbody>
+</table>
+
+<p>Age breakdown by ethnicity and gender is available in the downloadable spreadsheet at the bottom of the page.</p>
+
+<hr/>
+<h3><a id="workforce" name="workforce"></a>Trained vaccinators and active vaccinators</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Trained vaccinators and active vaccinators" class="img-responsive" height="830" src="/web/20211026003402im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/workforce_11.png" width="1780"/></figure>
+
+<p><strong>Trained vaccinators</strong> are individuals who have completed the COVID-19 training. Many trained people are only able to offer a small number of hours to the COVID-19 vaccination programme.</p>
+
+<p><strong>Active vaccinators</strong> are trained individuals who are actively vaccinating. The number of active vaccinators does not reflect the hours worked vaccinating. For example, one vaccinator may work 40 hours in a week at one DHB and will show as 1 vaccinator in the headcount. In another DHB, 4 vaccinators may work 10 hours each (total 40 hours), but will show as 4 vaccinators in the headcount for that week.</p>
+
+<p>Both counts of trained and active vaccinators are cumulative. The difference between the two is due to a number of factors. This includes: individuals being trained in anticipation of future sites being opened (the largest factor); rostering; leave or non-availability; local health priorities; sites opening and closing.</p>
+
+<hr/>
+<h3><a id="usage" name="usage"></a>Wastage of vaccine stock</h3>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">&nbsp;</th>
+			<th scope="col">Wastage</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">New Zealand</th>
+			<td>0.27%</td>
+		</tr>
+	</tbody>
+</table>
+
+<p>Wastage is vials that have been reported as wasted since 13 July in the Inventory portal by DHBs or central warehouses divided by vials used over the same time frame.</p>
+
+<h3><a id="download" name="download"></a>Details of vaccination data</h3>
+
+<p>Download a spreadsheet containing key vaccination data. This includes HSU based population estimates for calculating vaccine uptake rates.</p>
+
+<p><a download="" href="/web/20211026003402/https://www.health.govt.nz/system/files/documents/pages/covid_vaccinations_19_10_2021.xlsx">COVID-19 vaccination data through 19 Oct 2021 (Excel, 359 KB)</a></p>
+
+<p>This spreadsheet is based on the information made available at the time of publishing and may be subject to changes. Please take note of any notes and caveats on each sheet.</p>
+
+<p>The below attachments provide some analysis on our progress on equity. The two PDF files are high level summaries of overall progress. The Excel documents are interactive and provides the ability to delve further into those overall numbers. NB: These Excel workbooks use features that are non-compatible with versions of MS Office 2016 and earlier.</p>
+
+<ul>
+	<li><a download="" href="/web/20211026003402/https://www.health.govt.nz/system/files/documents/pages/211017_-_cvip_equity_-_rate_ratios_by_ethicity_ageband_and_dhb.pdf">Covid-19 Vaccine Rate Ratios by Ethnicity, Ageband and DHB (PDF, 642 KB)</a></li>
+	<li><a download="" href="/web/20211026003402/https://www.health.govt.nz/system/files/documents/pages/211017_-_cvip_equity_-_uptake_by_ethicity_ageband_and_dhb.pdf">Covid-19 Vaccine Uptake by Ethnicity, Ageband and DHB (PDF, 551 KB)</a></li>
+	<li><a download="" href="/web/20211026003402/https://www.health.govt.nz/system/files/documents/pages/211017_-_cvip_equity_-_level_1_ethnicity_uptake_and_rate_ratios.xlsx">Covid-19 Vaccine Equity - Level 1 Ethnicity Uptake and Rate Ratios (Excel, 152 KB)</a></li>
+	<li><a download="" href="/web/20211026003402/https://www.health.govt.nz/system/files/documents/pages/211017_-_cvip_equity_-_level_2_ethnicity_uptake_and_rate_ratios.xlsx">Covid-19 Vaccine Equity - Level 2 Ethnicity Uptake and Rate Ratios (Excel, 378 KB)</a></li>
+	<li><a download="" href="/web/20211026003402/https://www.health.govt.nz/system/files/documents/pages/211017_-_cvip_equity_-_rate_ratios_and_uptake_over_time.xlsx">Rate Ratios and Uptake Over Time (Excel, 972 KB)</a></li>
+</ul>
+
+<hr/>
+<h3><a id="adverse-events" name="adverse-events"></a>Adverse events following&nbsp;immunisations (AEFI)</h3>
+
+<p>Like all medicines, the COVID-19 vaccine may cause side effects in some people. These are common, are usually mild, don&rsquo;t last long and won&rsquo;t stop people from having the second dose or going about daily life. Serious allergic reactions do occur but are extremely rare.</p>
+
+<p>Suspected AEFI to COVID-19 vaccines are reported to the <a href="https://web.archive.org/web/20211026003402/https://nzphvc.otago.ac.nz/">Centre for Adverse Reactions Monitoring</a> (CARM).&nbsp;<a href="https://web.archive.org/web/20211026003402/https://www.medsafe.govt.nz/">Medsafe</a> is closely monitoring the AEFI reported from the use of the COVID-19 vaccine and will report regularly on their findings.&nbsp;</p>
+
+<p><a href="https://web.archive.org/web/20211026003402/https://www.medsafe.govt.nz/COVID-19/vaccine-report-overview.asp">View Medsafe data on COVID-19 vaccine adverse effects following immunisation</a></p>
+</div></div></div>    </article>
+  </div>
+
+
+  </div>
+<div class="panel-pane pane-node-links even">
+
+
+
+  <div class="pane-content">
+          </div>
+
+
+  </div>
+
+<div class="panel-pane pane-views pane-sub-pages even">
+
+        <h2 class="pane-title h3">In this section</h2>
+
+
+  <div class="pane-content">
+        <div class="view view-sub-pages view-id-sub_pages view-display-id-block view-dom-id-9c86984bce1b9023a4688a56d474a841">
+
+
+
+      <div class="view-content">
+      <div class="item-list">    <ul>          <li class="views-row views-row-1 views-row-odd views-row-first">
+  <div class="views-field views-field-title">        <div class="field-content">
+<div class="views-field views-field-title">
+  <h3 class="field-content">
+    <a href="/web/20211026003402/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-across-nz">COVID-19 Vaccination uptake rates across NZ</a>  </h3>
+</div></div>  </div>
+  <span class="views-field views-field-body">        <span class="field-content">This page provides information related to uptake rates of the COVID-19 vaccine across the country.
+</span>  </span>
+  <span class="views-field views-field-view-node">        <span class="field-content"><a href="/web/20211026003402/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-across-nz">Read more</a></span>  </span></li>
+          <li class="views-row views-row-2 views-row-even">
+  <div class="views-field views-field-title">        <div class="field-content">
+<div class="views-field views-field-title">
+  <h3 class="field-content">
+    <a href="/web/20211026003402/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-maori-communities-across-nz">COVID-19 Vaccination uptake rates within Māori communities across NZ</a>  </h3>
+</div></div>  </div>
+  <span class="views-field views-field-body">        <span class="field-content">This page provides information related to uptake rates of the COVID-19 vaccine within Māori communities across New Zealand.
+</span>  </span>
+  <span class="views-field views-field-view-node">        <span class="field-content"><a href="/web/20211026003402/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-maori-communities-across-nz">Read more</a></span>  </span></li>
+          <li class="views-row views-row-3 views-row-odd views-row-last">
+  <div class="views-field views-field-title">        <div class="field-content">
+<div class="views-field views-field-title">
+  <h3 class="field-content">
+    <a href="/web/20211026003402/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-pacific-communities-across-nz">COVID-19 Vaccination uptake rates within Pacific communities across NZ</a>  </h3>
+</div></div>  </div>
+  <span class="views-field views-field-body">        <span class="field-content">This page provides information related to uptake rates of the COVID-19 vaccine within Pacific communities across New Zealand.
+</span>  </span>
+  <span class="views-field views-field-view-node">        <span class="field-content"><a href="/web/20211026003402/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-pacific-communities-across-nz">Read more</a></span>  </span></li>
+      </ul></div>    </div>
+
+
+
+
+
+
+</div>  </div>
+
+
+  </div>
+</div>          </div>
+
+  </div>
+
+</section>
+  </div>
+      </section>
+
+
+    </div>
+    <div id="content-footer-wrapper" class="clearfix">
+      <div id="content-footer" class="clearfix">
+                  <p class="page_updated">Page last updated: <span class="date">26 October 2021</span></p>                  <div class="region region-content-footer">
+    <section id="block-moh-tools-page-tools" class="block block-moh-tools clearfix">
+  <a href="#" data-placement="top" data-title="Share this content." data-html="true" data-content="<p>Share this page on some of the most popular social networking and content sites on the internet.</p><div class='service-links'><ul><li><a href='https://twitter.com/share?url=https%3A//www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data&amp;text=COVID-19%3A%20Vaccine%20data' title='Share this on Twitter' class='service-links-twitter' rel='nofollow'><img typeof='foaf:Image' class='img-responsive' src='https://www.health.govt.nz/sites/all/modules/contrib/service_links/images/twitter.png' alt='Twitter' /> Twitter</a></li>
+<li><a href='https://www.facebook.com/sharer.php?u=https%3A//www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data&amp;t=COVID-19%3A%20Vaccine%20data' title='Share on Facebook' class='service-links-facebook' rel='nofollow'><img typeof='foaf:Image' class='img-responsive' src='https://www.health.govt.nz/sites/all/modules/contrib/service_links/images/facebook.png' alt='Facebook' /> Facebook</a></li>
+</ul></div>" class="share-this-content"><i class="fa fa-share"></i> Share</a><a href="#" title="print this page" class="print"><i class="fa fa-print"></i> Print</a><a href="https://web.archive.org/web/20211026003402/https://www.health.govt.nz/forward?path=node/12052" title="Email this page" class="email"><i class="fa fa-envelope"></i> Email</a><a href="/web/20211026003402/https://www.health.govt.nz/feedback?ref=https%3A//www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="Feedback" class="rss"><i class="fa fa-comment"></i> Feedback</a></section>
+
+  </div>
+      </div>
+    </div>
+
+  </div>
+  <footer class="footer container">
+    <h2 class="hidden">Site Footer</h2>
+    <div class="footer-default">
+      <div class="row">
+        <div class="col-sm-6 col-md-6">
+          <div class="field field-name-field-tax-first-column-links">
+            <ul class="field-items"><li class="field-item"><a href="https://web.archive.org/web/20211026003402/https://www.health.govt.nz/node/492" class="">About this site</a></li><li class="field-item"><a href="https://web.archive.org/web/20211026003402/https://www.health.govt.nz/node/524" class="">Contact us</a></li><li class="field-item"><a href="https://web.archive.org/web/20211026003402/https://www.health.govt.nz/node/488" class="">Other Ministry of Health websites</a></li><li class="field-item"><a href="https://web.archive.org/web/20211026003402/https://www.health.govt.nz/node/7497" class="">Official Information Act requests</a></li><li class="field-item"><a href="https://web.archive.org/web/20211026003402/https://www.health.govt.nz/about-ministry/information-releases" class="">Information releases</a></li><li class="field-item"><a href="https://web.archive.org/web/20211026003402/https://consult.health.govt.nz/" class="">Consultations</a></li></ul>
+          </div>
+        </div>
+        <div class="col-sm-6 col-md-6">
+          <div class="field field-name-field-tax-footer-body field-type-text-long field-label-hidden"><div class="field-items"><div class="field-item even"><h3>Where to go for help</h3>
+
+<table>
+	<tbody>
+		<tr>
+			<th scope="row">Emergencies</th>
+			<td><strong>Dial <a href="tel:111">111</a></strong> (for ambulance, fire or police)</td>
+		</tr>
+		<tr>
+			<th scope="row">Healthline</th>
+			<td><strong>Dial <a href="tel:0800611116">0800 611 116</a></strong></td>
+		</tr>
+		<tr>
+			<th scope="row">Poisons</th>
+			<td><strong>Dial <a href="tel:0800764766">0800 POISON</a> </strong>(<a href="tel:0800764766">0800 764 766</a>)</td>
+		</tr>
+		<tr>
+			<th scope="row">Mental health crisis</th>
+			<td><strong><a href="/web/20211026003402/https://www.health.govt.nz/your-health/services-and-support/health-care-services/mental-health-services/crisis-assessment-teams">Emergency contact numbers</a></strong></td>
+		</tr>
+	</tbody>
+</table>
+</div></div></div>        </div>
+      </div>
+      <div class="row">
+        <div class="sub-footer">
+          <div class="column col-sm-12 col-md-3">
+            <a href="https://web.archive.org/web/20211026003402/https://www.govt.nz/">
+              <img src="/web/20211026003402im_/https://www.health.govt.nz/sites/all/themes/mohpub_bootstrap/images/nzgovtlogo_white.png" width="152" height="16" alt="govt.nz - connecting you to New Zealand central &amp; local government services" title="govt.nz - connecting you to New Zealand central &amp; local government services"/>
+            </a>
+          </div>
+          <div class="column col-sm-12 col-md-9">
+          <span class="bottom-menu-moh with-v-divider">&copy; Ministry of Health – Manatū Hauora</span><ul class="bottom-menu-list"><li class="bottom-menu-list-item with-v-divider"><a href="https://web.archive.org/web/20211026003402/https://www.health.govt.nz/sitemap" class="">Site map</a></li><li class="bottom-menu-list-item with-v-divider"><a href="https://web.archive.org/web/20211026003402/https://www.health.govt.nz/about-site/privacy-and-security" class="">Privacy &amp; security</a></li><li class="bottom-menu-list-item with-v-divider"><a href="https://web.archive.org/web/20211026003402/https://www.health.govt.nz/about-site/copyright" class="">Copyright</a></li></ul>          </div>
+        </div>
+      </div>
+    </div>
+    <div class="footer-print">&copy; Ministry of Health – Manatū Hauora</div>
+  </footer>
+  <a class="scrollToTop">Back to top <i class="fas fa-arrow-up"></i></a>
+</div>
+  <script src="https://web.archive.org/web/20211026003402js_/https://www.health.govt.nz/sites/default/files/js/js_akZOsKtodu3PdnQzY3_ElOfujkLxJcowmaWgHTBBLOE.js"></script>
+</body>
+</html>
+<!--
+     FILE ARCHIVED ON 00:34:02 Oct 26, 2021 AND RETRIEVED FROM THE
+     INTERNET ARCHIVE ON 03:23:04 Nov 07, 2021.
+     JAVASCRIPT APPENDED BY WAYBACK MACHINE, COPYRIGHT INTERNET ARCHIVE.
+
+     ALL OTHER CONTENT MAY ALSO BE PROTECTED BY COPYRIGHT (17 U.S.C.
+     SECTION 108(a)(3)).
+-->
+<!--
+playback timings (ms):
+  captures_list: 94.571
+  exclusion.robots: 0.186
+  exclusion.robots.policy: 0.178
+  RedisCDXSource: 2.292
+  esindex: 0.008
+  LoadShardBlock: 43.374 (3)
+  PetaboxLoader3.datanode: 53.753 (4)
+  CDXLines.iter: 33.28 (3)
+  load_resource: 80.056
+  PetaboxLoader3.resolve: 26.575
+-->

--- a/data/rawSite/2021-10-26.html
+++ b/data/rawSite/2021-10-26.html
@@ -1,0 +1,2511 @@
+
+<!DOCTYPE html>
+<html lang="en" dir="ltr" prefix="" class="no-js">
+<head><script src="//archive.org/includes/analytics.js?v=cf34f82" type="text/javascript"></script>
+<script type="text/javascript">window.addEventListener('DOMContentLoaded',function(){var v=archive_analytics.values;v.service='wb';v.server_name='wwwb-app210.us.archive.org';v.server_ms=921;archive_analytics.send_pageview({});});</script>
+<script type="text/javascript" src="/_static/js/bundle-playback.js?v=UfTkgsKx" charset="utf-8"></script>
+<script type="text/javascript" src="/_static/js/wombat.js?v=UHAOicsW" charset="utf-8"></script>
+<script type="text/javascript">
+  __wm.init("https://web.archive.org/web");
+  __wm.wombat("https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data","20211027072637","https://web.archive.org/","web","/_static/",
+	      "1635319597");
+</script>
+<link rel="stylesheet" type="text/css" href="/_static/css/banner-styles.css?v=omkqRugM" />
+<link rel="stylesheet" type="text/css" href="/_static/css/iconochive.css?v=qtvMKcIJ" />
+<!-- End Wayback Rewrite JS Include -->
+
+  <!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta name="format-detection" content="telephone=no"/>
+  <link rel="profile" href="http://www.w3.org/1999/xhtml/vocab"/>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+<link rel="shortcut icon" href="https://web.archive.org/web/20211027072637im_/https://www.health.govt.nz/sites/all/themes/mohpub_bootstrap/favicon.ico" type="image/vnd.microsoft.icon"/>
+<meta name="description" content="Dashboard of data and statistics about the rollout of COVID-19 vaccines in New Zealand"/>
+<meta name="generator" content="Drupal 7 (https://www.drupal.org)"/>
+<link rel="canonical" href="https://web.archive.org/web/20211027072637/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data"/>
+<link rel="shortlink" href="https://web.archive.org/web/20211027072637/https://www.health.govt.nz/node/12052"/>
+<meta property="og:site_name" content="Ministry of Health NZ"/>
+<meta property="og:type" content="article"/>
+<meta property="og:url" content="https://web.archive.org/web/20211027072637/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data"/>
+<meta property="og:title" content="COVID-19: Vaccine data"/>
+<meta property="og:description" content="Dashboard of data and statistics about the rollout of COVID-19 vaccines in New Zealand"/>
+  <title>COVID-19: Vaccine data | Ministry of Health NZ</title>
+  <link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211027072637cs_/https://www.health.govt.nz/sites/default/files/css/css_lQaZfjVpwP_oGNqdtWCSpJT1EMqXdMiU84ekLLxQnc4.css" media="all"/>
+<link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211027072637cs_/https://www.health.govt.nz/sites/default/files/css/css_jqUBpWfMaxMiP7LismdZVlyVv8azUJSE2yaH58nj0cE.css" media="all"/>
+<link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211027072637cs_/https://www.health.govt.nz/sites/default/files/css/css_Rb1wqFBC8VXCJC-BuNY53cvjjlj6UADGvqzo_f-1yN0.css" media="all"/>
+<link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211027072637cs_/https://www.health.govt.nz/sites/default/files/css/css_38_K1lHKg-98m4KKRfv57JBK0gvlKscexGt9MKoi0DE.css" media="all"/>
+<link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211027072637cs_/https://www.health.govt.nz/sites/default/files/css/css_r7NPyvpdYfAyZmk9zkK8OaFKEFj6er5ZJnam2H644DM.css" media="print"/>
+  <link rel="alternate stylesheet" type="text/css" href="/web/20211027072637cs_/https://www.health.govt.nz/sites/all/themes/mohpub_bootstrap/css/high-contrast.css" media="screen" title="High Contrast"/>
+  <script src="https://web.archive.org/web/20211027072637js_/https://www.health.govt.nz/sites/default/files/js/js_zS-CmNFGyegtLYJmqFRpxQvvQrfPIFrOMq_3T3C8sZE.js"></script>
+<script src="https://web.archive.org/web/20211027072637js_/https://www.health.govt.nz/sites/default/files/js/js_fNgZ4Okisfr70Q0yvAYsATgB0o_jD3-srhQQ-VHmlXE.js"></script>
+<script src="https://web.archive.org/web/20211027072637js_/https://www.health.govt.nz/sites/default/files/js/js_YAdPZfg12M1m7ROp3_gVJPS5sArqL0kYQgNRPoicvHE.js"></script>
+<script>(function(i,s,o,g,r,a,m){i["GoogleAnalyticsObject"]=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,"script","https://web.archive.org/web/20211027072637/https://www.google-analytics.com/analytics.js","ga");ga("create", "UA-3573389-24", {"cookieDomain":".www.health.govt.nz","siteSpeedSampleRate":15});ga("send", "pageview");</script>
+<script src="https://web.archive.org/web/20211027072637js_/https://www.health.govt.nz/sites/default/files/js/js_QAXZNPwLISRLHqyNpT4Vvr_iqD9foD6GTbEjlhIIjeo.js"></script>
+<script src="https://web.archive.org/web/20211027072637js_/https://www.health.govt.nz/sites/default/files/js/js_4VW9edmu3V8VjGJxFfXGAwkXeW2cJIa5h-6y7SgwVrk.js"></script>
+<script>    (function(h,o,t,j,a,r){
+        h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
+        h._hjSettings={hjid:930919,hjsv:6};
+        a=o.getElementsByTagName('head')[0];
+        r=o.createElement('script');r.async=1;
+        r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+        a.appendChild(r);
+    })(window,document,'https://web.archive.org/web/20211027072637/https://static.hotjar.com/c/hotjar-','.js?sv=');
+</script>
+<script>jQuery.extend(Drupal.settings, {"basePath":"\/","pathPrefix":"","ajaxPageState":{"theme":"mohpub_bootstrap","theme_token":"oXgskqrfbfFwSEVes7HPmjaf4UFj8IzOdb4gChgYggs","js":{"sites\/all\/modules\/custom\/table_d3chart\/js\/table_d3chart.js":1,"sites\/all\/modules\/custom\/moh_d3\/moh_d3.js":1,"sites\/all\/modules\/contrib\/jquery_update\/replace\/jquery\/1.7\/jquery.min.js":1,"misc\/jquery-extend-3.4.0.js":1,"misc\/jquery-html-prefilter-3.5.0-backport.js":1,"misc\/jquery.once.js":1,"misc\/drupal.js":1,"sites\/all\/modules\/contrib\/ckeditor_accordion\/js\/ckeditor-accordion.js":1,"sites\/all\/modules\/contrib\/extlink\/extlink.js":1,"modules\/field\/modules\/text\/text.js":1,"sites\/all\/modules\/contrib\/field_group\/field_group.js":1,"sites\/all\/modules\/contrib\/google_analytics\/googleanalytics.js":1,"0":1,"sites\/all\/libraries\/c3\/c3.js":1,"sites\/all\/libraries\/d3\/d3.min.js":1,"sites\/all\/modules\/contrib\/d3\/js\/d3.js":1,"sites\/all\/libraries\/d3.helpers\/d3.helpers.js":1,"sites\/all\/libraries\/d3.c3\/d3-c3.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/assets\/ios-fix.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/affix.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/alert.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/button.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/carousel.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/collapse.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/dropdown.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/modal.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/tooltip.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/popover.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/scrollspy.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/tab.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/transition.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/jquery.cookie.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/jquery.moh.announcement.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/svgeezy.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/fitvids.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/bootstrap-tabcollapse.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/jquery.scrollTo.min.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/script.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/jquery.google_analytics.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/bootstrap-accessibility.min.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/style-switcher.js":1,"1":1},"css":{"modules\/system\/system.base.css":1,"sites\/all\/modules\/contrib\/calendar\/css\/calendar_multiday.css":1,"sites\/all\/modules\/contrib\/ckeditor_accordion\/css\/ckeditor-accordion.css":1,"modules\/field\/theme\/field.css":1,"modules\/node\/node.css":1,"sites\/all\/modules\/contrib\/extlink\/extlink.css":1,"sites\/all\/modules\/contrib\/views\/css\/views.css":1,"sites\/all\/modules\/contrib\/ckeditor\/css\/ckeditor.css":1,"sites\/all\/modules\/contrib\/ctools\/css\/ctools.css":1,"sites\/all\/modules\/contrib\/panels\/css\/panels.css":1,"sites\/all\/libraries\/c3\/c3.css":1,"sites\/all\/libraries\/d3.c3\/d3-c3.css":1,"sites\/all\/themes\/mohpub_bootstrap\/fontawesome\/css\/fontawesome.min.css":1,"sites\/all\/themes\/mohpub_bootstrap\/fontawesome\/css\/solid.min.css":1,"sites\/all\/themes\/mohpub_bootstrap\/fontawesome\/css\/brands.min.css":1,"sites\/all\/modules\/features\/site_profile\/css\/fix-rubik-multiselect-height.css":1,"sites\/all\/themes\/mohpub_bootstrap\/css\/style.css":1,"sites\/all\/themes\/mohpub_bootstrap\/css\/responsive-tables.css":1,"sites\/all\/themes\/mohpub_bootstrap\/css\/print.css":1}},"field_group":{"div":"full"},"ckeditor_accordion":{"collapseAll":1},"extlink":{"extTarget":0,"extClass":"ext","extLabel":"(link is external)","extImgClass":0,"extIconPlacement":"append","extSubdomains":0,"extExclude":"","extInclude":"","extCssExclude":"","extCssExplicit":"","extAlert":0,"extAlertText":"This link will take you to an external web site. We are not responsible for their content.","mailtoClass":"mailto","mailtoLabel":"(link sends e-mail)"},"googleanalytics":{"trackOutbound":1,"trackMailto":1,"trackDownload":1,"trackDownloadExtensions":"7z|aac|arc|arj|asf|asx|avi|bin|csv|doc|exe|flv|gif|gz|gzip|hqx|jar|jpe?g|js|mp(2|3|4|e?g)|mov(ie)?|msi|msp|pdf|phps|png|ppt|qtm?|ra(m|r)?|sea|sit|tar|tgz|torrent|txt|wav|wma|wmv|wpd|xls|xml|z|zip|docx|xlsx|pptx|pptm|ppsx|ppsm|epub"},"mohD3":{"C3Types":["line","spline","step","area","area-spline","area-step","bar","scatter","pie","donut","gauge"],"graphRender":"line","graphLegend":true,"graphDefaultColors":"#2b8cbe, #abdda4, #7f7f7f, #92cddc, #dc8b0c","graphDefaultGroupedTooltip":0,"graphDefaultGridX":0,"graphDefaultGridY":0,"graphDefaultLegendPosition":"top-right","graphDefaultTooltip":1,"graphDefaultDataLabel":0,"graphLegendStep":"5","graphInteraction":true,"graphTypes":"","graphXaxisShow":true,"graphXaxisLabel":"","graphYaxisLabel":"","graphXaxisType":"category","graphXaxisCentered":false,"graphXaxisRotation":"","graphXaxisHeight":"","graphYaxisShow":true,"graphYaxisMax":"","graphYaxisMin":"","graphYaxisInverted":false,"graphYaxisCenter":"","graphYaxisPrefix":"","graphYaxisSuffix":"","graphYaxisPosition":"","graphY2axisShow":false,"graphY2axisSource":"","graphY2axisMax":"","graphY2axisMin":"","graphGroups":"","graphRotated":false,"graphIgnoreEmpty":false,"graphLineDot":true,"graphBarRatio":"0.9","graphDot":true,"graphDotR":"2.5","graphFocus":false},"tableD3":{"show":"View table data source","hide":"Hide table data source"},"urlIsAjaxTrusted":{"\/our-work\/diseases-and-conditions\/covid-19-novel-coronavirus\/covid-19-data-and-statistics\/covid-19-vaccine-data":true},"bootstrap":{"anchorsFix":1,"anchorsSmoothScrolling":1,"formHasError":1,"popoverEnabled":1,"popoverOptions":{"animation":1,"html":0,"placement":"right","selector":"","trigger":"click","triggerAutoclose":1,"title":"","content":"","delay":0,"container":"body"},"tooltipEnabled":1,"tooltipOptions":{"animation":1,"html":0,"placement":"auto left","selector":"","trigger":"hover focus","delay":0,"container":"body"}}});</script>
+  <!-- HTML5 element support for IE6-8 -->
+  <!--[if lt IE 9]>
+    <script src="/sites/all/themes/mohpub_bootstrap/js/assets/html5shiv.js"></script>
+    <script src="/sites/all/themes/mohpub_bootstrap/js/assets/respond.min.js"></script>
+  <![endif]-->
+</head>
+<body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-12052 node-type-page node-has-intro"><!-- BEGIN WAYBACK TOOLBAR INSERT -->
+<style type="text/css">
+body {
+  margin-top:0 !important;
+  padding-top:0 !important;
+  /*min-width:800px !important;*/
+}
+</style>
+<script>__wm.rw(0);</script>
+<div id="wm-ipp-base" lang="en" style="display:none;direction:ltr;">
+<div id="wm-ipp" style="position:fixed;left:0;top:0;right:0;">
+<div id="wm-ipp-inside">
+  <div style="position:relative;">
+    <div id="wm-logo" style="float:left;width:110px;padding-top:12px;">
+      <a href="/web/" title="Wayback Machine home page"><img src="/_static/images/toolbar/wayback-toolbar-logo-200.png" srcset="/_static/images/toolbar/wayback-toolbar-logo-100.png, /_static/images/toolbar/wayback-toolbar-logo-150.png 1.5x, /_static/images/toolbar/wayback-toolbar-logo-200.png 2x" alt="Wayback Machine" style="width:100px" border="0" /></a>
+    </div>
+    <div class="r" style="float:right;">
+      <div id="wm-btns" style="text-align:right;height:25px;">
+                  <div id="wm-save-snapshot-success">success</div>
+          <div id="wm-save-snapshot-fail">fail</div>
+          <a id="wm-save-snapshot-open" href="#"
+	     title="Share via My Web Archive" >
+            <span class="iconochive-web"></span>
+          </a>
+          <a href="https://archive.org/account/login.php"
+             title="Sign In"
+             id="wm-sign-in"
+          >
+            <span class="iconochive-person"></span>
+          </a>
+          <span id="wm-save-snapshot-in-progress" class="iconochive-web"></span>
+        	<a href="http://faq.web.archive.org/" title="Get some help using the Wayback Machine" style="top:-6px;"><span class="iconochive-question" style="color:rgb(87,186,244);font-size:160%;"></span></a>
+	<a id="wm-tb-close" href="#close" onclick="__wm.h(event);return false;" style="top:-2px;" title="Close the toolbar"><span class="iconochive-remove-circle" style="color:#888888;font-size:240%;"></span></a>
+      </div>
+      <div id="wm-share">
+          <a href="/web/20211027072637/http://web.archive.org/screenshot/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data"
+             id="wm-screenshot"
+             title="screenshot">
+            <span class="wm-icon-screen-shot"></span>
+          </a>
+          <a href="#"
+            id="wm-video"
+            title="video">
+            <span class="iconochive-movies"></span>
+          </a>
+	<a id="wm-share-facebook" href="#" data-url="https://web.archive.org/web/20211027072637/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="Share on Facebook" style="margin-right:5px;" target="_blank"><span class="iconochive-facebook" style="color:#3b5998;font-size:160%;"></span></a>
+	<a id="wm-share-twitter" href="#" data-url="https://web.archive.org/web/20211027072637/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="Share on Twitter" style="margin-right:5px;" target="_blank"><span class="iconochive-twitter" style="color:#1dcaff;font-size:160%;"></span></a>
+      </div>
+    </div>
+    <table class="c" style="">
+      <tbody>
+	<tr>
+	  <td class="u" colspan="2">
+	    <form target="_top" method="get" action="/web/submit" name="wmtb" id="wmtb"><input type="text" name="url" id="wmtbURL" value="https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" onfocus="this.focus();this.select();" /><input type="hidden" name="type" value="replay" /><input type="hidden" name="date" value="20211027072637" /><input type="submit" value="Go" /></form>
+	  </td>
+	  <td class="n" rowspan="2" style="width:110px;">
+	    <table>
+	      <tbody>
+		<!-- NEXT/PREV MONTH NAV AND MONTH INDICATOR -->
+		<tr class="m">
+		  <td class="b" nowrap="nowrap"><a href="https://web.archive.org/web/20210927063305/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="27 Sep 2021"><strong>Sep</strong></a></td>
+		  <td class="c" id="displayMonthEl" title="You are here: 07:26:37 Oct 27, 2021">OCT</td>
+		  <td class="f" nowrap="nowrap">Nov</td>
+		</tr>
+		<!-- NEXT/PREV CAPTURE NAV AND DAY OF MONTH INDICATOR -->
+		<tr class="d">
+		  <td class="b" nowrap="nowrap"><a href="https://web.archive.org/web/20211026003402/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="00:34:02 Oct 26, 2021"><img src="/_static/images/toolbar/wm_tb_prv_on.png" alt="Previous capture" width="14" height="16" border="0" /></a></td>
+		  <td class="c" id="displayDayEl" style="width:34px;font-size:24px;white-space:nowrap;" title="You are here: 07:26:37 Oct 27, 2021">27</td>
+		  <td class="f" nowrap="nowrap"><a href="https://web.archive.org/web/20211028090127/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="09:01:27 Oct 28, 2021"><img src="/_static/images/toolbar/wm_tb_nxt_on.png" alt="Next capture" width="14" height="16" border="0" /></a></td>
+		</tr>
+		<!-- NEXT/PREV YEAR NAV AND YEAR INDICATOR -->
+		<tr class="y">
+		  <td class="b" nowrap="nowrap">2020</td>
+		  <td class="c" id="displayYearEl" title="You are here: 07:26:37 Oct 27, 2021">2021</td>
+		  <td class="f" nowrap="nowrap">2022</td>
+		</tr>
+	      </tbody>
+	    </table>
+	  </td>
+	</tr>
+	<tr>
+	  <td class="s">
+	    	    <div id="wm-nav-captures">
+	      	      <a class="t" href="/web/20211027072637*/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="See a list of every capture for this URL">682 captures</a>
+	      <div class="r" title="Timespan for captures of this URL">07 Apr 2021 - 06 Nov 2021</div>
+	      </div>
+	  </td>
+	  <td class="k">
+	    <a href="" id="wm-graph-anchor">
+	      <div id="wm-ipp-sparkline" title="Explore captures for this URL" style="position: relative">
+		<canvas id="wm-sparkline-canvas" width="650" height="27" border="0"></canvas>
+	      </div>
+	    </a>
+	  </td>
+	</tr>
+      </tbody>
+    </table>
+    <div style="position:absolute;bottom:0;right:2px;text-align:right;">
+      <a id="wm-expand" class="wm-btn wm-closed" href="#expand" onclick="__wm.ex(event);return false;"><span id="wm-expand-icon" class="iconochive-down-solid"></span> <span style="font-size:80%">About this capture</span></a>
+    </div>
+  </div>
+    <div id="wm-capinfo" style="border-top:1px solid #777;display:none; overflow: hidden">
+                    <div id="wm-capinfo-collected-by">
+    <div style="background-color:#666;color:#fff;font-weight:bold;text-align:center">COLLECTED BY</div>
+    <div style="padding:3px;position:relative" id="wm-collected-by-content">
+      <div style="display:inline-block;vertical-align:top;width:49%;">
+			<span class="c-logo" style="background-image:url(https://archive.org/services/img/GDELT_Project)"></span>
+		<div>Collection: <a style="color:#33f;" href="https://archive.org/details/GDELT_Project" target="_new"><span class="wm-title">GDELT Project</span></a></div>
+	      </div>
+    </div>
+    </div>
+    <div id="wm-capinfo-timestamps">
+    <div style="background-color:#666;color:#fff;font-weight:bold;text-align:center" title="Timestamps for the elements of this page">TIMESTAMPS</div>
+    <div>
+      <div id="wm-capresources" style="margin:0 5px 5px 5px;max-height:250px;overflow-y:scroll !important"></div>
+      <div id="wm-capresources-loading" style="text-align:left;margin:0 20px 5px 5px;display:none"><img src="/_static/images/loading.gif" alt="loading" /></div>
+    </div>
+    </div>
+  </div></div></div></div><div id="wm-ipp-print">The Wayback Machine - https://web.archive.org/web/20211027072637/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data</div>
+<div id="donato" style="position:relative;width:100%;">
+  <div id="donato-base">
+    <iframe id="donato-if" src="https://archive.org/includes/donate.php?as_page=1&amp;platform=wb&amp;referer=https%3A//web.archive.org/web/20211027072637/https%3A//www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data"
+	    scrolling="no" frameborder="0" style="width:100%; height:100%">
+    </iframe>
+  </div>
+</div><script type="text/javascript">
+__wm.bt(650,27,25,2,"web","https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data","20211027072637",1996,"/_static/",["/_static/css/banner-styles.css?v=omkqRugM","/_static/css/iconochive.css?v=qtvMKcIJ"], "False");
+  __wm.rw(1);
+</script>
+<!-- END WAYBACK TOOLBAR INSERT -->
+<!--googleoff: all-->
+  <div id="skip-link">
+    <a href="#skip-content" id="skipper" class="element-invisible element-focusable">Skip to main content</a>
+  </div>
+    <div id="page">
+  <header id="navbar" role="banner" class="navbar container navbar-default">
+          <ul class="menu nav navbar-nav secondary"><li class="first leaf jobs depth-1"><a href="https://web.archive.org/web/20211027072637/https://careers.health.govt.nz/" title="">Jobs</a></li>
+<li class="leaf news depth-1"><a href="/web/20211027072637/https://www.health.govt.nz/news-media" data-is-top-level="0" title="">News</a></li>
+<li class="leaf contact-us depth-1"><a href="/web/20211027072637/https://www.health.govt.nz/about-ministry/contact-us" title="">Contact us</a></li>
+<li class="leaf facebook depth-1"><a href="https://web.archive.org/web/20211027072637/https://www.facebook.com/minhealthnz/">Facebook</a></li>
+<li class="leaf twitter depth-1"><a href="https://web.archive.org/web/20211027072637/https://twitter.com/minhealthnz" data-is-top-level="0" title="">Twitter</a></li>
+<li class="last leaf youtube depth-1"><a href="https://web.archive.org/web/20211027072637/https://www.youtube.com/user/minhealthnz" data-is-top-level="0" title="">Youtube</a></li>
+</ul>        <div class="container">
+      <div class="navbar-header">
+                <a class="logo navbar-btn pull-left" href="/web/20211027072637/https://www.health.govt.nz/" title="Home">
+          <img src="/web/20211027072637im_/https://www.health.govt.nz/sites/all/themes/mohpub_bootstrap/images/mohlogo.svg" alt="Ministry of Health"/>
+        </a>
+                  <div class="region region-header-top">
+    <section id="block-apachesolr-panels-search-form" class="block block-apachesolr-panels clearfix">
+
+
+  <form action="/web/20211027072637/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" method="post" id="apachesolr-panels-search-block" accept-charset="UTF-8"><div><div class="form-item form-item-apachesolr-panels-search-form form-type-textfield form-group"> <label class="control-label" for="edit-apachesolr-panels-search-form">Search</label>
+<input title="Enter the terms you wish to search for." class="form-control form-text" type="text" id="edit-apachesolr-panels-search-form" name="apachesolr_panels_search_form" value="" size="15" maxlength="128"/></div><input type="hidden" name="form_build_id" value="form-vp9NAHd8tJ7qri39A3fJjGQJknUSoDMzHj1nVMU7Qqo"/>
+<input type="hidden" name="form_id" value="apachesolr_panels_search_block"/>
+<div class="form-actions form-wrapper form-group" id="edit-actions"><button type="submit" id="edit-submit" name="op" value="Search" class="btn btn-primary form-submit">Search</button>
+</div></div></form>
+</section>
+  </div>
+        <!-- .btn-navbar is used as the toggle for collapsed navbar content -->
+        <button aria-expanded="false" aria-controls="megamenu" type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+                    <span class="menu-text">Menu</span><span class="sr-only">Toggle navigation</span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+
+        </button>
+      </div>
+
+              <div class="navbar-collapse collapse">
+          <nav id="megamenu" role="navigation">
+                          <h2 class="element-invisible">Main menu</h2><ul id="main-menu" class="menu nav navbar-nav yamm navbar"><li class="first dropdown"><a href="/web/20211027072637/https://www.health.govt.nz/your-health" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="megamenu-dropdown-780">Your health <b class="caret"></b></a>
+    <div id="megamenu-dropdown-780" class="dropdown-menu">
+    <div class="yamm-content">
+      <div class="row">
+                            <div class="col">
+            <h3><a href="/web/20211027072637/https://www.health.govt.nz/your-health/conditions-and-treatments?mega=Your%20health&amp;title=Conditions%20%26%20treatments" class="menu-header">Conditions &amp; treatments</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211027072637/https://www.health.govt.nz/your-health/conditions-and-treatments/mental-health/depression?mega=Your%20health&amp;title=Depression">Depression</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/diabetes?mega=Your%20health&amp;title=Diabetes">Diabetes</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/influenza?mega=Your%20health&amp;title=Influenza">Influenza</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/measles?mega=Your%20health&amp;title=Measles">Measles</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/meningococcal-disease-including-meningitis?mega=Your%20health&amp;title=Meningococcal%20disease">Meningococcal disease</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/mumps?mega=Your%20health&amp;title=Mumps">Mumps</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/respiratory-syncytial-virus-rsv?mega=Your%20health&amp;title=RSV">RSV</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/sore-throat?mega=Your%20health&amp;title=Sore%20throat">Sore throat</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/your-health/conditions-and-treatments?mega=Your%20health&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211027072637/https://www.health.govt.nz/your-health/healthy-living?mega=Your%20health&amp;title=Healthy%20living" class="menu-header">Healthy living</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211027072637/https://www.health.govt.nz/your-health/healthy-living/drinking-water?mega=Your%20health&amp;title=Drinking-water">Drinking-water</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/your-health/healthy-living/food-activity-and-sleep/green-prescriptions?mega=Your%20health&amp;title=Green%20Prescriptions">Green Prescriptions</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/your-health/healthy-living/food-activity-and-sleep/healthy-eating?mega=Your%20health&amp;title=Healthy%20eating">Healthy eating</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/your-health/healthy-living/immunisation?mega=Your%20health&amp;title=Immunisation">Immunisation</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/your-health/healthy-living/food-activity-and-sleep/physical-activity?mega=Your%20health&amp;title=Physical%20activity">Physical activity</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/your-health/healthy-living/addictions/quitting-smoking?mega=Your%20health&amp;title=Smoking">Smoking</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/your-health/healthy-living/teeth-and-gums?mega=Your%20health&amp;title=Teeth%20and%20gums">Teeth and gums</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/your-health/healthy-living?mega=Your%20health&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211027072637/https://www.health.govt.nz/your-health/pregnancy-and-kids?mega=Your%20health&amp;title=Pregnancy%20and%20kids" class="menu-header">Pregnancy and kids</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211027072637/https://www.health.govt.nz/your-health/pregnancy-and-kids/birth-and-afterwards?mega=Your%20health&amp;title=Birth%20and%20afterwards">Birth and afterwards</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/your-health/pregnancy-and-kids/first-year/helpful-advice-during-first-year/breastfeeding-perfect-you-and-your-baby?mega=Your%20health&amp;title=Breastfeeding">Breastfeeding</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/your-health/pregnancy-and-kids/pregnancy?mega=Your%20health&amp;title=Pregnancy">Pregnancy</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/your-health/pregnancy-and-kids/services-and-support-during-pregnancy?mega=Your%20health&amp;title=Services%20and%20support%20during%20pregnancy">Services and support during pregnancy</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/your-health/pregnancy-and-kids/services-and-support-you-and-your-child?mega=Your%20health&amp;title=Services%20and%20support%20for%20you%20and%20your%20child">Services and support for you and your child</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/your-health/pregnancy-and-kids/first-year?mega=Your%20health&amp;title=The%20first%20year">The first year</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/your-health/pregnancy-and-kids/under-fives?mega=Your%20health&amp;title=Under%20fives">Under fives</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/your-health/pregnancy-and-kids?mega=Your%20health&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211027072637/https://www.health.govt.nz/your-health/services-and-support?mega=Your%20health&amp;title=Services%20and%20support" class="menu-header">Services &amp; support</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211027072637/https://www.health.govt.nz/your-health/services-and-support/health-care-services/help-alcohol-and-drug-problems?mega=Your%20health&amp;title=Alcohol%20and%20drugs">Alcohol and drugs</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/your-health/services-and-support/disability-services?mega=Your%20health&amp;title=Disability%20services">Disability services</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/your-health/services-and-support/health-care-services/earthquake-support-line?mega=Your%20health&amp;title=Earthquake%20Support%20Line">Earthquake Support Line</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/your-health/services-and-support/health-care-services/healthline?mega=Your%20health&amp;title=Healthline">Healthline</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/your-health/services-and-support/health-care-services/mental-health-services?mega=Your%20health&amp;title=Mental%20health%20services">Mental health services</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/your-health/services-and-support/health-care-services/maori-health-provider-directory?mega=Your%20health&amp;title=M%C4%81ori%20health%20providers">Māori health providers</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/your-health/services-and-support/health-care-services/services-older-people/rest-home-certification-and-audits?mega=Your%20health&amp;title=Rest%20home%20certification">Rest home certification</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/your-health/services-and-support/health-care-services/hospitals-and-specialist-services/travel-assistance?mega=Your%20health&amp;title=Travel%20assistance">Travel assistance</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/your-health/services-and-support?mega=Your%20health&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                        </div>
+    </div>
+    <div class="feature-links">
+      <h3 class="sr-only">Other related resources</h3>
+      <a href="/web/20211027072637/https://www.health.govt.nz/your-health/full-a-z?mega=Your%20health&amp;title=A-Z">View the full A-Z</a>    </div>
+  </div>
+</li>
+<li class="dropdown"><a href="/web/20211027072637/https://www.health.govt.nz/new-zealand-health-system" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="megamenu-dropdown-6076">NZ health system <b class="caret"></b></a>
+    <div id="megamenu-dropdown-6076" class="dropdown-menu">
+    <div class="yamm-content">
+      <div class="row">
+                            <div class="col">
+            <h3><a href="/web/20211027072637/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people?mega=NZ%20health%20system&amp;title=Key%20organisations" class="menu-header">Key organisations</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211027072637/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/crown-entities-and-statutory-boards?mega=NZ%20health%20system&amp;title=Crown%20entities%20%26%20agencies">Crown entities &amp; agencies</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/district-health-boards?mega=NZ%20health%20system&amp;title=District%20health%20boards">District health boards</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/non-governmental-organisations?mega=NZ%20health%20system&amp;title=Non-governmental%20organisations">Non-governmental organisations</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/primary-health-organisations?mega=NZ%20health%20system&amp;title=Primary%20health%20organisations">Primary health organisations</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/public-health-units?mega=NZ%20health%20system&amp;title=Public%20health%20units">Public health units</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people?mega=NZ%20health%20system&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211027072637/https://www.health.govt.nz/new-zealand-health-system/health-system-indicators-framework?mega=NZ%20health%20system&amp;title=Health%20System%20Indicators%20framework" class="menu-header">Health System Indicators framework</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211027072637/https://www.health.govt.nz/new-zealand-health-system/health-system-indicators-framework?mega=NZ%20health%20system&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211027072637/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services?mega=NZ%20health%20system&amp;title=Eligibility%20for%20public%20health%20services" class="menu-header">Eligibility for public health services</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211027072637/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services/guide-eligibility-publicly-funded-health-services?mega=NZ%20health%20system&amp;title=Guide%20to%20eligibility">Guide to eligibility</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services/eligibility-questions-and-answers-consumers?mega=NZ%20health%20system&amp;title=Q%26A%20for%20consumers">Q&amp;A for consumers</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services/eligibility-questions-and-answers-service-providers?mega=NZ%20health%20system&amp;title=Q%26A%20for%20service%20providers">Q&amp;A for service providers</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services/reciprocal-health-agreements?mega=NZ%20health%20system&amp;title=Reciprocal%20health%20agreements">Reciprocal health agreements</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services?mega=NZ%20health%20system&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211027072637/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements?mega=NZ%20health%20system&amp;title=Claims%2C%20provider%20payments%20and%20entitlements" class="menu-header">Claims &amp; provider payments</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211027072637/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/carer-support-claims?mega=NZ%20health%20system&amp;title=Carer%20Support">Carer Support</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/high-use-health-card-payments?mega=NZ%20health%20system&amp;title=High%20Use%20Health%20Card%20payments">High Use Health Card payments</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/between-travel-settlement?mega=NZ%20health%20system&amp;title=In-Between%20Travel%20Settlement">In-Between Travel Settlement</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/maternity-claim-forms?mega=NZ%20health%20system&amp;title=Maternity%20claim%20forms">Maternity claim forms</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/national-travel-assistance?mega=NZ%20health%20system&amp;title=National%20travel%20assistance%20claims">National travel assistance claims</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements?mega=NZ%20health%20system&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                        </div>
+    </div>
+    <div class="feature-links">
+      <h3 class="sr-only">Other related resources</h3>
+      <a href="/web/20211027072637/https://www.health.govt.nz/new-zealand-health-system/overview-health-system?mega=NZ%20health%20system&amp;title=Overview">Overview of the health system</a>  <a href="/web/20211027072637/https://www.health.govt.nz/new-zealand-health-system/my-dhb?mega=NZ%20health%20system&amp;title=Mydhb">My DHB</a> <a href="/web/20211027072637/https://www.health.govt.nz/new-zealand-health-system/system-level-measures-framework?mega=NZ%20health%20system&amp;title=SLM">System level measures</a>  <a href="/web/20211027072637/https://www.health.govt.nz/publication/new-zealand-health-strategy-2016?mega=NZ%20health%20system&amp;title=HealthStrategy">NZ Health Strategy</a>    </div>
+  </div>
+</li>
+<li class="dropdown"><a href="/web/20211027072637/https://www.health.govt.nz/our-work" class="dropdown-toggle active-trail" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="megamenu-dropdown-776">Our work <b class="caret"></b></a>
+  <div id="megamenu-dropdown-776" class="dropdown-menu">
+    <div class="yamm-content">
+      <div class="row">
+                            <ul class="col list-unstyled no-menu-header">
+                                                                                <li>
+                <a href="/web/20211027072637/https://www.health.govt.nz/our-work/diseases-and-conditions/antimicrobial-resistance?mega=Our%20work&amp;title=Antimicrobial%20resistance" class="menu-header">Antimicrobial resistance</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211027072637/https://www.health.govt.nz/our-work/populations/asian-and-migrant-health?mega=Our%20work&amp;title=Asian%20and%20migrant%20health" class="menu-header">Asian and migrant health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211027072637/https://www.health.govt.nz/our-work/border-health?mega=Our%20work&amp;title=Border%20health" class="menu-header">Border health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211027072637/https://www.health.govt.nz/our-work/life-stages/breastfeeding?mega=Our%20work&amp;title=Breastfeeding" class="menu-header">Breastfeeding</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211027072637/https://www.health.govt.nz/our-work/diseases-and-conditions/cancer?mega=Our%20work&amp;title=Cancer" class="menu-header">Cancer</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211027072637/https://www.health.govt.nz/our-work/regulation-health-and-disability-system/certification-health-care-services?mega=Our%20work&amp;title=Certification%20of%20health%20care%20services" class="menu-header">Certification of health care services</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211027072637/https://www.health.govt.nz/our-work/life-stages/child-health?mega=Our%20work&amp;title=Child%20health" class="menu-header">Child health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211027072637/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus?mega=Our%20work&amp;title=COVID-19" class="menu-header">COVID-19 (novel coronavirus)</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211027072637/https://www.health.govt.nz/our-work/diseases-and-conditions/diabetes?mega=Our%20work&amp;title=Diabetes" class="menu-header">Diabetes</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211027072637/https://www.health.govt.nz/our-work/digital-health?mega=Our%20work&amp;title=Digital%20health" class="menu-header">Digital health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211027072637/https://www.health.govt.nz/our-work/disability-services?mega=Our%20work&amp;title=Disability%20services" class="menu-header">Disability services</a>                              </li>
+                                                                </ul>
+                            <ul class="col list-unstyled no-menu-header">
+                                                                                <li>
+                <a href="/web/20211027072637/https://www.health.govt.nz/our-work/diseases-and-conditions?mega=Our%20work&amp;title=Diseases%20and%20conditions" class="menu-header">Diseases and conditions</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211027072637/https://www.health.govt.nz/our-work/hospitals-and-specialist-care/emergency-departments?mega=Our%20work&amp;title=Emergency%20departments" class="menu-header">Emergency departments</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211027072637/https://www.health.govt.nz/our-work/emergency-management?mega=Our%20work&amp;title=Emergency%20management" class="menu-header">Emergency management</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211027072637/https://www.health.govt.nz/our-work/environmental-health?mega=Our%20work&amp;title=Environmental%20health" class="menu-header">Environmental health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211027072637/https://www.health.govt.nz/our-work/preventative-health-wellness/family-violence?mega=Our%20work&amp;title=Family%20violence" class="menu-header">Family violence</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211027072637/https://www.health.govt.nz/our-work/preventative-health-wellness/fluoride-and-oral-health?mega=Our%20work&amp;title=Fluoride%20and%20oral%20health" class="menu-header">Fluoride and oral health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211027072637/https://www.health.govt.nz/our-work/health-identity?mega=Our%20work&amp;title=Health%20identity" class="menu-header">Health identity</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211027072637/https://www.health.govt.nz/our-work/digital-health/digital-health-sector-architecture-standards-and-governance/health-information-standards-0?mega=Our%20work&amp;title=Health%20information%20standards" class="menu-header">Health information standards</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211027072637/https://www.health.govt.nz/our-work/life-stages/health-older-people?mega=Our%20work&amp;title=Health%20of%20older%20people" class="menu-header">Health of older people</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211027072637/https://www.health.govt.nz/our-work/health-workforce?mega=Our%20work&amp;title=Health%20workforce" class="menu-header">Health workforce</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211027072637/https://www.health.govt.nz/our-work/hospitals-and-specialist-care?mega=Our%20work&amp;title=Hospitals%20and%20specialist%20care" class="menu-header">Hospitals and specialist care</a>                              </li>
+                                                                </ul>
+                            <ul class="col list-unstyled no-menu-header">
+                                                                                <li>
+                <a href="/web/20211027072637/https://www.health.govt.nz/our-work/preventative-health-wellness/immunisation?mega=Our%20work&amp;title=Immunisation" class="menu-header">Immunisation</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211027072637/https://www.health.govt.nz/our-work/ionising-radiation-safety?mega=Our%20work&amp;title=Ionising%20radiation%20safety" class="menu-header">Ionising radiation safety</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211027072637/https://www.health.govt.nz/our-work/populations/maori-health?mega=Our%20work&amp;title=M%C4%81ori%20health" class="menu-header">Māori health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211027072637/https://www.health.govt.nz/our-work/life-stages/maternity-services?mega=Our%20work&amp;title=Maternity" class="menu-header">Maternity</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211027072637/https://www.health.govt.nz/our-work/regulation-health-and-disability-system/medicinal-cannabis-agency?mega=Our%20work&amp;title=Medicinal%20Cannabis%20Agency" class="menu-header">Medicinal cannabis</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211027072637/https://www.health.govt.nz/our-work/regulation-health-and-disability-system/medicines-control?mega=Our%20work&amp;title=Medicines%20control" class="menu-header">Medicines control</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211027072637/https://www.health.govt.nz/our-work/mental-health-and-addiction?mega=Our%20work&amp;title=Mental%20health%20and%20addiction" class="menu-header">Mental health and addiction</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211027072637/https://www.health.govt.nz/our-work/nursing?mega=Our%20work&amp;title=Nursing" class="menu-header">Nursing</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211027072637/https://www.health.govt.nz/our-work/preventative-health-wellness/nutrition?mega=Our%20work&amp;title=Nutrition" class="menu-header">Nutrition</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211027072637/https://www.health.govt.nz/our-work/preventative-health-wellness/oral-health?mega=Our%20work&amp;title=Oral%20health" class="menu-header">Oral health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211027072637/https://www.health.govt.nz/our-work/hospitals-and-specialist-care/organ-donation-and-transplantation?mega=Our%20work&amp;title=Organ%20donation%20and%20transplantation" class="menu-header">Organ donation and transplantation</a>                              </li>
+                                                                </ul>
+                            <ul class="col list-unstyled no-menu-header">
+                                                                                <li>
+                <a href="/web/20211027072637/https://www.health.govt.nz/our-work/populations/pacific-health?mega=Our%20work&amp;title=Pacific%20health" class="menu-header">Pacific health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211027072637/https://www.health.govt.nz/new-zealand-health-system/pay-equity-settlements?mega=Our%20work&amp;title=Pay%20equity%20settlements" class="menu-header">Pay equity</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211027072637/https://www.health.govt.nz/our-work/preventative-health-wellness/physical-activity?mega=Our%20work&amp;title=Physical%20activity" class="menu-header">Physical activity</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211027072637/https://www.health.govt.nz/our-work/hospitals-and-specialist-care/planned-care-services?mega=Our%20work&amp;title=Planned%20Care%20services" class="menu-header">Planned Care services</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211027072637/https://www.health.govt.nz/our-work/preventative-health-wellness?mega=Our%20work&amp;title=Preventative%20health/wellness" class="menu-header">Preventative health/wellness</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211027072637/https://www.health.govt.nz/our-work/primary-health-care?mega=Our%20work&amp;title=Primary%20health%20care" class="menu-header">Primary health care</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211027072637/https://www.health.govt.nz/our-work/public-health-workforce-development?mega=Our%20work&amp;title=Public%20health%20workforce%20development" class="menu-header">Public health workforce</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211027072637/https://www.health.govt.nz/our-work/regulation-health-and-disability-system?mega=Our%20work&amp;title=Regulation" class="menu-header">Regulation</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211027072637/https://www.health.govt.nz/our-work/preventative-health-wellness/tobacco-control?mega=Our%20work&amp;title=Tobacco%20control" class="menu-header">Tobacco control</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211027072637/https://www.health.govt.nz/our-work/regulation-health-and-disability-system/regulation-vaping-and-smokeless-tobacco-products?mega=Our%20work&amp;title=Vaping%20and%20smokeless%20tobacco%20products" class="menu-header">Vaping &amp; smokeless tobacco</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211027072637/https://www.health.govt.nz/our-work/who-code-nz?mega=Our%20work&amp;title=WHO%20Code%20in%20NZ" class="menu-header">WHO Code in NZ</a>                              </li>
+                      </ul>
+              </div>
+    </div>
+    <div class="feature-links">
+      <a href="/web/20211027072637/https://www.health.govt.nz/our-work?mega=Our%20work&amp;title=A-Z">View the full A-Z</a>    </div>
+  </div>
+</li>
+<li class="dropdown"><a href="/web/20211027072637/https://www.health.govt.nz/nz-health-statistics" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="megamenu-dropdown-778">Health statistics <b class="caret"></b></a>
+    <div id="megamenu-dropdown-778" class="dropdown-menu">
+    <div class="yamm-content">
+      <div class="row">
+                            <div class="col">
+            <h3><a href="/web/20211027072637/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets?mega=Health%20statistics&amp;title=Health%20statistics%20and%20data%20sets" class="menu-header">Statistics by topic</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211027072637/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/cancer-data-and-stats?mega=Health%20statistics&amp;title=Cancer">Cancer</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/diabetes-data-and-stats?mega=Health%20statistics&amp;title=Diabetes">Diabetes</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/mental-health-data-and-stats?mega=Health%20statistics&amp;title=Mental%20health">Mental health</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/maori-health-data-and-stats?mega=Health%20statistics&amp;title=M%C4%81ori%20health">Māori health</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/obesity-statistics?mega=Health%20statistics&amp;title=Obesity">Obesity</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/suicide-data-and-stats?mega=Health%20statistics&amp;title=Suicide">Suicide</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/tobacco-data-and-stats?mega=Health%20statistics&amp;title=Tobacco">Tobacco</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets?mega=Health%20statistics&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211027072637/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys?mega=Health%20statistics&amp;title=National%20collections%20and%20surveys" class="menu-header">About our surveys &amp; data collections</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211027072637/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/surveys/past-surveys/alcohol-and-drug-use-survey?mega=Health%20statistics&amp;title=Alcohol%20%26%20Drug%20Use%20Survey">Alcohol &amp; Drug Use Survey</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/national-collections-annual-maintenance-project?mega=Health%20statistics&amp;title=NCAMP">NCAMP</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/collections/new-zealand-cancer-registry-nzcr?mega=Health%20statistics&amp;title=NZ%20Cancer%20Registry">NZ Cancer Registry</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/surveys/new-zealand-health-survey?mega=Health%20statistics&amp;title=NZ%20Health%20Survey">NZ Health Survey</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/surveys/past-surveys/nutrition-survey?mega=Health%20statistics&amp;title=Nutrition%20Survey">Nutrition Survey</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/collections/primhd-mental-health-data?mega=Health%20statistics&amp;title=PRIMHD">PRIMHD</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys?mega=Health%20statistics&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211027072637/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology?mega=Health%20statistics&amp;title=Classification%20and%20Terminology" class="menu-header">Classification &amp; terminology</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211027072637/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology/using-icd-10-am-achi-acs/coding-queries/coding-query-database?mega=Health%20statistics&amp;title=Coding%20query%20database">Coding query database</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology/using-icd-10-am-achi-acs/courses-clinical-coding?mega=Health%20statistics&amp;title=Courses%20on%20clinical%20coding">Courses on clinical coding</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology/new-zealand-snomed-ct-national-release-centre?mega=Health%20statistics&amp;title=SNOMED%20CT">SNOMED CT</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology/using-icd-10-am-achi-acs?mega=Health%20statistics&amp;title=Using%20ICD-10-AM/ACHI/ACS">Using ICD-10-AM/ACHI/ACS</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology?mega=Health%20statistics&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211027072637/https://www.health.govt.nz/nz-health-statistics/data-references?mega=Health%20statistics&amp;title=Data%20references" class="menu-header">Data references</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211027072637/https://www.health.govt.nz/nz-health-statistics/data-references/code-tables?mega=Health%20statistics&amp;title=Code%20tables">Code tables</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/nz-health-statistics/data-references/data-dictionaries?mega=Health%20statistics&amp;title=Data%20dictionaries">Data dictionaries</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/nz-health-statistics/data-references/diagnosis-related-groups?mega=Health%20statistics&amp;title=Diagnosis-related%20groups">Diagnosis-related groups</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/nz-health-statistics/data-references/code-tables/common-code-tables/domicile-code-table?mega=Health%20statistics&amp;title=Domicile%20code%20table">Domicile code table</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/nz-health-statistics/data-references/mapping-tools?mega=Health%20statistics&amp;title=ICD%20mapping%20tools">ICD mapping tools</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/nz-health-statistics/data-references/weighted-inlier-equivalent-separations?mega=Health%20statistics&amp;title=Weighted%20Inlier%20Equivalent%20Separations">Weighted Inlier Equivalent Separations</a></li>
+                                  <li><a href="/web/20211027072637/https://www.health.govt.nz/nz-health-statistics/data-references?mega=Health%20statistics&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                        </div>
+    </div>
+    <div class="feature-links">
+      <h3 class="sr-only">Other related resources</h3>
+      <a href="/web/20211027072637/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/tier-1-health-statistics-release-calendar?mega=Health%20statistics&amp;title=Tier%201%20calendar">Release calendar for our Tier 1 statistics</a> <a href="/web/20211027072637/https://www.health.govt.nz/nz-health-statistics/about-data-collection?mega=Health%20statistics&amp;title=Enquiries">Data and survey enquiries</a>    </div>
+  </div>
+</li>
+<li class=""><a href="/web/20211027072637/https://www.health.govt.nz/publications" aria-haspopup="false">Publications</a></li>
+<li class=""><a href="/web/20211027072637/https://www.health.govt.nz/about-ministry" aria-haspopup="false">About us</a></li>
+<li class="visible-xs"><a href="/web/20211027072637/https://www.health.govt.nz/contactus" aria-haspopup="false">Contact us</a></li>
+</ul>
+                                  </nav>
+        </div>
+          </div>
+  </header>
+
+  <div class="main-container container">
+    <!-- announcement -->
+        <!-- /announcement -->
+
+    <header role="banner" id="page-header">
+
+          </header> <!-- /#page-header -->
+
+    <div class="row">
+
+      <section class="col-sm-12">
+                        <a id="main-content"></a>
+                                                                            <div class="breadcrumbs">
+            <ul><li><a href="/web/20211027072637/https://www.health.govt.nz/">Home</a></li><li><a href="/web/20211027072637/https://www.health.govt.nz/our-work">Our work</a></li><li><a href="/web/20211027072637/https://www.health.govt.nz/our-work/diseases-and-conditions">Diseases and conditions</a></li><li><a href="/web/20211027072637/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished" data-is-top-level="1" title="">COVID-19</a></li><li><a href="/web/20211027072637/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics" class="menu-node-unpublished menu-node-unpublished">Data and statistics</a></li><li><span class="current-breadcrumb">Vaccine data</span></li></ul>          </div>
+
+
+
+          <div class="region region-content">
+    <section id="block-system-main" class="block block-system clearfix">
+
+
+  <div class="bootstrap-threecol-stacked">
+
+      <div class="row"> <!-- @TODO: Add extra classes -->
+      <div class="panel-panel left col-xs-12 col-md-3 col-lg-3"><div class="panel-pane pane-block pane-menu-block-1 odd pane-top-link">
+
+        <span class="top-link"><a href="/web/20211027072637/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished active-trail" data-is-top-level="1">COVID-19</a></span>
+
+
+  <div class="pane-content">
+        <div class="menu-block-wrapper menu-block-1 menu-name-main-menu parent-mlid-1445 menu-level-2">
+  <ul class="menu nav"><li class="first collapsed menu-mlid-10163 health-advice depth-4"><a href="/web/20211027072637/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-health-advice-public" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished">Health advice</a></li>
+<li class="collapsed menu-mlid-10630 covid-19-vaccines- depth-4 section-overview hide-children"><a href="/web/20211027072637/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-vaccines" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished" data-is-top-level="1" title="">COVID-19 vaccines </a></li>
+<li class="collapsed menu-mlid-9997 health-professionals depth-4"><a href="/web/20211027072637/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-information-health-professionals" class="menu-node-unpublished menu-node-unpublished">Health professionals</a></li>
+<li class="collapsed menu-mlid-10019 specific-audiences depth-4"><a href="/web/20211027072637/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-information-specific-audiences" class="menu-node-unpublished">Specific audiences</a></li>
+<li class="expanded active-trail menu-mlid-10096 data-and-statistics depth-4"><a href="/web/20211027072637/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics" class="menu-node-unpublished menu-node-unpublished active-trail">Data and statistics</a><ul class="menu nav"><li class="first leaf menu-mlid-10062 current-cases depth-5 same-level-as-node"><a href="/web/20211027072637/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-current-cases" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Current cases</a></li>
+<li class="leaf menu-mlid-10146 case-demographics depth-5 same-level-as-node"><a href="/web/20211027072637/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-case-demographics">Case demographics</a></li>
+<li class="leaf menu-mlid-10097 source-of-cases depth-5 same-level-as-node"><a href="/web/20211027072637/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-source-cases" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Source of cases</a></li>
+<li class="leaf menu-mlid-10119 testing-for-covid-19 depth-5 same-level-as-node"><a href="/web/20211027072637/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/testing-covid-19" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Testing for COVID-19</a></li>
+<li class="leaf menu-mlid-10371 nz-covid-tracer-app-data depth-5 same-level-as-node"><a href="/web/20211027072637/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-nz-covid-tracer-app-data" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">NZ COVID Tracer app data</a></li>
+<li class="expanded active-trail active menu-mlid-10584 active vaccine-data depth-5 same-level-as-node"><a href="/web/20211027072637/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished active-trail active">Vaccine data</a><ul class="menu nav"><li class="first leaf menu-mlid-10867 covid-19-vaccination-uptake-rates-across-nz depth-6"><a href="/web/20211027072637/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-across-nz" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">COVID-19 Vaccination uptake rates across NZ</a></li>
+<li class="leaf menu-mlid-10868 covid-19-vaccination-uptake-rates---māori depth-6"><a href="/web/20211027072637/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-maori-communities-across-nz" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">COVID-19 Vaccination uptake rates - Māori</a></li>
+<li class="last leaf menu-mlid-10869 covid-19-vaccination-uptake-rates---pacific depth-6"><a href="/web/20211027072637/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-pacific-communities-across-nz" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">COVID-19 Vaccination uptake rates - Pacific</a></li>
+</ul></li>
+<li class="last leaf menu-mlid-10404 data-resources depth-5 same-level-as-node"><a href="/web/20211027072637/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-data-resources" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Data resources</a></li>
+</ul></li>
+<li class="collapsed menu-mlid-10369 response-planning depth-4"><a href="/web/20211027072637/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-response-planning" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Response planning</a></li>
+<li class="collapsed menu-mlid-10015 resources-and-tools depth-4"><a href="/web/20211027072637/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-resources-and-tools" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Resources and tools</a></li>
+<li class="last leaf menu-mlid-10004 news-and-media depth-4 section-overview hide-children"><a href="/web/20211027072637/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-news-and-media-updates" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">News and media</a></li>
+</ul></div>
+  </div>
+
+
+  </div>
+</div>      <div class="panel-panel middle col-xs-12 col-md-9 col-lg-9"><div class="panel-pane pane-page-title even">
+
+
+
+  <div class="pane-content">
+    <span id="skip-content" tabindex="-1"></span>    <h1>COVID-19: Vaccine data</h1>
+  </div>
+
+
+  </div>
+<div class="panel-pane pane-node-content odd">
+
+
+
+  <div class="pane-content">
+        <article id="node-12052" class="node node-page node-sticky view-mode-full clearfix" about="/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" typeof="sioc:Item foaf:Document">
+    <header>
+            <span property="dc:title" content="COVID-19: Vaccine data" class="rdf-meta element-hidden"></span>      </header>
+    <div class="field field-name-field-intro-text field-type-text-long field-label-hidden"><div class="field-items"><div class="field-item even"><p class="intro-text">Data and statistics about the rollout of COVID-19 vaccines in New Zealand.</p></div></div></div><div class="field field-name-body field-type-text-with-summary field-label-hidden"><div class="field-items"><div class="field-item even" property="content:encoded"><p>On this page:</p>
+
+<ul>
+	<li><a href="#daily">Daily updates</a>
+
+	<ul>
+		<li><a href="#total-vaccinations">Total vaccinations</a></li>
+		<li><a href="#ethnicity">Vaccinations by ethnicity</a></li>
+		<li><a href="#90pct">Vaccinations to 90% by DHB</a></li>
+	</ul>
+	</li>
+	<li><a href="#weekly-updates">Weekly updates</a>
+	<ul>
+		<li><a href="#model">Vaccinations against plan</a></li>
+		<li><a href="#uptake">Vaccinations uptake</a></li>
+		<li><a href="#by-day">Vaccinations by day</a></li>
+		<li><a href="#location">Vaccinations by DHB</a></li>
+		<li><a href="#group">Vaccinations by group</a></li>
+		<li><a href="#by_soh">Stock on hand</a></li>
+		<li><a href="#age">Vaccinations by age</a></li>
+		<li><a href="#workforce">Trained vaccinator and active vaccinator</a></li>
+		<li><a href="#group">Vaccinations by group</a></li>
+		<li><a href="#download">Details of vaccination&nbsp;data</a></li>
+	</ul>
+	</li>
+	<li><a href="#adverse-events">Adverse events from immunisations</a></li>
+</ul>
+
+<hr/><!--daily-->
+<h2><a id="daily" name="daily"></a>COVID-19 vaccinations: daily updates</h2>
+
+<div class="well well-sm">
+<p style="margin-top: 0"><strong>Data in this section is as at 11:59pm 26 October 2021 and is updated daily.</strong></p>
+</div>
+
+<h3><a id="total-vaccinations" name="total-vaccinations"></a>Total Vaccinations</h3>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">&nbsp;</th>
+			<th scope="col" style="text-align:right">Vaccinations yesterday</th>
+			<th scope="col" style="text-align:right">Cumulative total</th>
+			<th scope="col" style="text-align:right">Eligible population vaccinated %</th>
+			<th scope="col" style="text-align:right">Total population vaccinated %</th>
+			<th scope="col" style="text-align:right">Vaccinated or booked</th>
+			<th scope="col" style="text-align:right">Eligible vaccinated or booked %</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">First dose</th>
+			<td style="text-align:right">10,872</td>
+			<td style="text-align:right">3,657,970</td>
+			<td style="text-align:right">87%</td>
+			<td style="text-align:right">73%</td>
+			<td style="text-align:right">3,676,773</td>
+			<td style="text-align:right">87%</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Second dose</th>
+			<td style="text-align:right">31,264</td>
+			<td style="text-align:right">3,018,830</td>
+			<td style="text-align:right">72%</td>
+			<td style="text-align:right">60%</td>
+			<td style="text-align:right">3,332,135</td>
+			<td style="text-align:right">79%</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total doses</strong></th>
+			<td style="text-align:right"><strong>42,136</strong></td>
+			<td style="text-align:right"><strong>6,676,800</strong></td>
+		</tr>
+	</tbody>
+</table>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Total vaccinations" class="img-responsive" height="900" src="/web/20211027072637im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_summary_17.png" width="5340"/></figure>
+
+<h5>Definitions</h5>
+
+<ul>
+	<li><strong>Cumulative total:</strong>&nbsp;All vaccinations that have been administered and entered into the COVID-19 Immunisation Register up until midnight of the night before the data is published.</li>
+	<li><strong>Eligible population vaccinated %:</strong>&nbsp;Vaccinations administered divided by HSU population estimates for the eligible population (12+).</li>
+	<li><strong>Total population vaccinated %:</strong>&nbsp;Vaccinations administered divided by HSU population estimates for the total population (0+).</li>
+	<li><strong>Vaccinated or booked:</strong>&nbsp;Count of individuals who have either received their vaccination or have booked via Book My Vaccine to receive a vaccination.</li>
+	<li><strong>Eligible vaccinated or booked %:</strong>&nbsp;Count of individuals who have either received their vaccination or have booked via Book My Vaccine to receive a vaccination divided by HSU population estimates for the eligible population (12+).</li>
+</ul>
+
+<p>HSU population estimates are available in the downloadable spreadsheet at the bottom of the page. Throughout the rest of this sheet doses per 1,000 are based on eligible (12+) population.</p>
+
+<p>Bookings are only counted if the site is using Book My Vaccine. Bookings made through other Patient Management Systems are not counted.</p>
+
+<hr/>
+<h3><a id="by_eth" name="ethnicity"></a>Cumulative vaccinations by ethnicity</h3>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">Ethnicity *</th>
+			<th scope="col" style="text-align:right">First dose administered</th>
+			<th scope="col" style="text-align:right">First doses per 1,000 people</th>
+			<th scope="col" style="text-align:right">Second dose administered</th>
+			<th scope="col" style="text-align:right">Second doses per 1,000 people</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">Māori</th>
+			<td style="text-align:right">397,304</td>
+			<td style="text-align:right">696</td>
+			<td style="text-align:right">281,609</td>
+			<td style="text-align:right">493</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Pacific Peoples</th>
+			<td style="text-align:right">239,171</td>
+			<td style="text-align:right">834</td>
+			<td style="text-align:right">186,999</td>
+			<td style="text-align:right">652</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Asian</th>
+			<td style="text-align:right">603,341</td>
+			<td style="text-align:right">&gt;950</td>
+			<td style="text-align:right">521,251</td>
+			<td style="text-align:right">871</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">European / Other</th>
+			<td style="text-align:right">2,384,548</td>
+			<td style="text-align:right">873</td>
+			<td style="text-align:right">2,001,847</td>
+			<td style="text-align:right">733</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Unknown</th>
+			<td style="text-align:right">33,606</td>
+			<td style="text-align:right">-</td>
+			<td style="text-align:right">27,124</td>
+			<td style="text-align:right">-</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total</strong></th>
+			<td style="text-align:right"><strong>3,657,970</strong></td>
+			<td style="text-align:right"><strong>869</strong></td>
+			<td style="text-align:right"><strong>3,018,830</strong></td>
+			<td style="text-align:right"><strong>717</strong></td>
+		</tr>
+	</tbody>
+</table>
+
+<p><strong>*</strong> The prioritised ethnicity classification system allocates each person to a single ethnic group, based on the ethnic groups they identify with. Where people identify with more than one group, they are assigned in this order of priority: Māori, Pacific Peoples, Asian, and European/Other. So, if a person identifies as being Māori and New Zealand European, the person is counted as Māori. See <a href="/web/20211027072637/https://www.health.govt.nz/publication/hiso-100012017-ethnicity-data-protocols">Ethnicity Data Protocols</a> for further information.</p>
+
+<p>Ethnicity breakdown by DHB of residence is available in the downloadable spreadsheet at the bottom of the page.</p>
+
+<hr/>
+<h3><a id="90pct" name="90pct"></a>Vaccinations to 90% by DHB</h3>
+
+<h4><a id="90pct all ethnicities" name="90pct all ethnicities"></a>All Ethnicities</h4>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">&nbsp;</th>
+			<th scope="col" style="text-align:right">First doses</th>
+			<th scope="col" style="text-align:right">First doses %</th>
+			<th scope="col" style="text-align:right">First doses to 90%</th>
+			<th scope="col" style="text-align:right">Second doses</th>
+			<th scope="col" style="text-align:right">Second doses %</th>
+			<th scope="col" style="text-align:right">Second doses to 90%</th>
+			<th scope="col" style="text-align:right">Population</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">Northland</th>
+			<td style="text-align:right">126,113</td>
+			<td style="text-align:right">78%</td>
+			<td style="text-align:right">19,075</td>
+			<td style="text-align:right">100,405</td>
+			<td style="text-align:right">62%</td>
+			<td style="text-align:right">44,783</td>
+			<td style="text-align:right">161,320</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waitemata</th>
+			<td style="text-align:right">476,318</td>
+			<td style="text-align:right">91%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">407,232</td>
+			<td style="text-align:right">77%</td>
+			<td style="text-align:right">66,246</td>
+			<td style="text-align:right">526,087</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Auckland</th>
+			<td style="text-align:right">395,771</td>
+			<td style="text-align:right">93%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">346,533</td>
+			<td style="text-align:right">82%</td>
+			<td style="text-align:right">35,029</td>
+			<td style="text-align:right">423,958</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Counties Manukau</th>
+			<td style="text-align:right">424,592</td>
+			<td style="text-align:right">88%</td>
+			<td style="text-align:right">9,904</td>
+			<td style="text-align:right">358,286</td>
+			<td style="text-align:right">74%</td>
+			<td style="text-align:right">76,210</td>
+			<td style="text-align:right">482,773</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waikato</th>
+			<td style="text-align:right">305,128</td>
+			<td style="text-align:right">85%</td>
+			<td style="text-align:right">16,330</td>
+			<td style="text-align:right">246,417</td>
+			<td style="text-align:right">69%</td>
+			<td style="text-align:right">75,041</td>
+			<td style="text-align:right">357,176</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Lakes</th>
+			<td style="text-align:right">74,708</td>
+			<td style="text-align:right">79%</td>
+			<td style="text-align:right">10,269</td>
+			<td style="text-align:right">58,905</td>
+			<td style="text-align:right">62%</td>
+			<td style="text-align:right">26,072</td>
+			<td style="text-align:right">94,419</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Bay of Plenty</th>
+			<td style="text-align:right">177,852</td>
+			<td style="text-align:right">82%</td>
+			<td style="text-align:right">17,395</td>
+			<td style="text-align:right">138,563</td>
+			<td style="text-align:right">64%</td>
+			<td style="text-align:right">56,684</td>
+			<td style="text-align:right">216,941</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Tairawhiti</th>
+			<td style="text-align:right">32,115</td>
+			<td style="text-align:right">77%</td>
+			<td style="text-align:right">5,654</td>
+			<td style="text-align:right">25,714</td>
+			<td style="text-align:right">61%</td>
+			<td style="text-align:right">12,054</td>
+			<td style="text-align:right">41,965</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Taranaki</th>
+			<td style="text-align:right">84,620</td>
+			<td style="text-align:right">83%</td>
+			<td style="text-align:right">7,312</td>
+			<td style="text-align:right">63,991</td>
+			<td style="text-align:right">63%</td>
+			<td style="text-align:right">27,941</td>
+			<td style="text-align:right">102,147</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hawkes Bay</th>
+			<td style="text-align:right">120,998</td>
+			<td style="text-align:right">83%</td>
+			<td style="text-align:right">10,016</td>
+			<td style="text-align:right">99,150</td>
+			<td style="text-align:right">68%</td>
+			<td style="text-align:right">31,864</td>
+			<td style="text-align:right">145,571</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">MidCentral</th>
+			<td style="text-align:right">129,489</td>
+			<td style="text-align:right">85%</td>
+			<td style="text-align:right">7,583</td>
+			<td style="text-align:right">105,954</td>
+			<td style="text-align:right">70%</td>
+			<td style="text-align:right">31,118</td>
+			<td style="text-align:right">152,302</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Whanganui</th>
+			<td style="text-align:right">45,437</td>
+			<td style="text-align:right">79%</td>
+			<td style="text-align:right">6,085</td>
+			<td style="text-align:right">37,709</td>
+			<td style="text-align:right">66%</td>
+			<td style="text-align:right">13,813</td>
+			<td style="text-align:right">57,247</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Capital and Coast</th>
+			<td style="text-align:right">247,969</td>
+			<td style="text-align:right">91%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">208,626</td>
+			<td style="text-align:right">77%</td>
+			<td style="text-align:right">35,431</td>
+			<td style="text-align:right">271,174</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hutt Valley</th>
+			<td style="text-align:right">113,246</td>
+			<td style="text-align:right">87%</td>
+			<td style="text-align:right">3,969</td>
+			<td style="text-align:right">92,134</td>
+			<td style="text-align:right">71%</td>
+			<td style="text-align:right">25,081</td>
+			<td style="text-align:right">130,239</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Wairarapa</th>
+			<td style="text-align:right">34,941</td>
+			<td style="text-align:right">84%</td>
+			<td style="text-align:right">2,343</td>
+			<td style="text-align:right">28,946</td>
+			<td style="text-align:right">70%</td>
+			<td style="text-align:right">8,338</td>
+			<td style="text-align:right">41,427</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Nelson Marlborough</th>
+			<td style="text-align:right">116,158</td>
+			<td style="text-align:right">86%</td>
+			<td style="text-align:right">6,011</td>
+			<td style="text-align:right">100,452</td>
+			<td style="text-align:right">74%</td>
+			<td style="text-align:right">21,717</td>
+			<td style="text-align:right">135,743</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">West Coast</th>
+			<td style="text-align:right">22,120</td>
+			<td style="text-align:right">79%</td>
+			<td style="text-align:right">2,995</td>
+			<td style="text-align:right">17,733</td>
+			<td style="text-align:right">64%</td>
+			<td style="text-align:right">7,382</td>
+			<td style="text-align:right">27,906</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Canterbury</th>
+			<td style="text-align:right">429,514</td>
+			<td style="text-align:right">89%</td>
+			<td style="text-align:right">5,087</td>
+			<td style="text-align:right">328,695</td>
+			<td style="text-align:right">68%</td>
+			<td style="text-align:right">105,906</td>
+			<td style="text-align:right">482,890</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">South Canterbury</th>
+			<td style="text-align:right">44,441</td>
+			<td style="text-align:right">85%</td>
+			<td style="text-align:right">2,885</td>
+			<td style="text-align:right">37,256</td>
+			<td style="text-align:right">71%</td>
+			<td style="text-align:right">10,070</td>
+			<td style="text-align:right">52,584</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Southern</th>
+			<td style="text-align:right">254,414</td>
+			<td style="text-align:right">88%</td>
+			<td style="text-align:right">4,800</td>
+			<td style="text-align:right">214,523</td>
+			<td style="text-align:right">74%</td>
+			<td style="text-align:right">44,690</td>
+			<td style="text-align:right">288,015</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Overseas / Unknown</th>
+			<td style="text-align:right">2,026</td>
+			<td style="text-align:right">12%</td>
+			<td style="text-align:right">13,430</td>
+			<td style="text-align:right">1,606</td>
+			<td style="text-align:right">9%</td>
+			<td style="text-align:right">13,850</td>
+			<td style="text-align:right">17,173</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total</strong></th>
+			<td style="text-align:right"><strong>3,657,970</strong></td>
+			<td style="text-align:right"><strong>87%</strong></td>
+			<td style="text-align:right"><strong>130,181</strong></td>
+			<td style="text-align:right"><strong>3,018,830</strong></td>
+			<td style="text-align:right"><strong>72%</strong></td>
+			<td style="text-align:right"><strong>769,321</strong></td>
+			<td style="text-align:right"><strong>4,209,057</strong></td>
+		</tr>
+	</tbody>
+</table>
+
+<p>First/second doses % are the number of first/second doses administered divided by the eligible population. First/second doses to 90% are the number of doses required to reach 90% of the eligible population. For these two measures, the national total may not be the sum of DHB measures.</p>
+
+<h4><a id="90pct Māori" name="90pct Māori">Māori</a></h4>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">&nbsp;</th>
+			<th scope="col" style="text-align:right">First doses</th>
+			<th scope="col" style="text-align:right">First doses %</th>
+			<th scope="col" style="text-align:right">First doses to 90%</th>
+			<th scope="col" style="text-align:right">Second doses</th>
+			<th scope="col" style="text-align:right">Second doses %</th>
+			<th scope="col" style="text-align:right">Second doses to 90%</th>
+			<th scope="col" style="text-align:right">Population</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">Northland</th>
+			<td style="text-align:right">33,073</td>
+			<td style="text-align:right">66%</td>
+			<td style="text-align:right">12,366</td>
+			<td style="text-align:right">22,606</td>
+			<td style="text-align:right">45%</td>
+			<td style="text-align:right">22,833</td>
+			<td style="text-align:right">50,488</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waitemata</th>
+			<td style="text-align:right">32,218</td>
+			<td style="text-align:right">78%</td>
+			<td style="text-align:right">4,784</td>
+			<td style="text-align:right">24,031</td>
+			<td style="text-align:right">58%</td>
+			<td style="text-align:right">12,971</td>
+			<td style="text-align:right">41,113</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Auckland</th>
+			<td style="text-align:right">22,520</td>
+			<td style="text-align:right">81%</td>
+			<td style="text-align:right">2,493</td>
+			<td style="text-align:right">17,261</td>
+			<td style="text-align:right">62%</td>
+			<td style="text-align:right">7,752</td>
+			<td style="text-align:right">27,792</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Counties Manukau</th>
+			<td style="text-align:right">45,164</td>
+			<td style="text-align:right">71%</td>
+			<td style="text-align:right">11,980</td>
+			<td style="text-align:right">31,760</td>
+			<td style="text-align:right">50%</td>
+			<td style="text-align:right">25,384</td>
+			<td style="text-align:right">63,493</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waikato</th>
+			<td style="text-align:right">49,008</td>
+			<td style="text-align:right">70%</td>
+			<td style="text-align:right">13,728</td>
+			<td style="text-align:right">33,221</td>
+			<td style="text-align:right">48%</td>
+			<td style="text-align:right">29,515</td>
+			<td style="text-align:right">69,707</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Lakes</th>
+			<td style="text-align:right">19,008</td>
+			<td style="text-align:right">63%</td>
+			<td style="text-align:right">8,068</td>
+			<td style="text-align:right">13,126</td>
+			<td style="text-align:right">44%</td>
+			<td style="text-align:right">13,950</td>
+			<td style="text-align:right">30,085</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Bay of Plenty</th>
+			<td style="text-align:right">29,811</td>
+			<td style="text-align:right">62%</td>
+			<td style="text-align:right">13,150</td>
+			<td style="text-align:right">20,108</td>
+			<td style="text-align:right">42%</td>
+			<td style="text-align:right">22,853</td>
+			<td style="text-align:right">47,734</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Tairawhiti</th>
+			<td style="text-align:right">12,991</td>
+			<td style="text-align:right">65%</td>
+			<td style="text-align:right">4,864</td>
+			<td style="text-align:right">9,440</td>
+			<td style="text-align:right">48%</td>
+			<td style="text-align:right">8,415</td>
+			<td style="text-align:right">19,839</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Taranaki</th>
+			<td style="text-align:right">10,510</td>
+			<td style="text-align:right">66%</td>
+			<td style="text-align:right">3,804</td>
+			<td style="text-align:right">6,761</td>
+			<td style="text-align:right">43%</td>
+			<td style="text-align:right">7,553</td>
+			<td style="text-align:right">15,904</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hawkes Bay</th>
+			<td style="text-align:right">22,109</td>
+			<td style="text-align:right">65%</td>
+			<td style="text-align:right">8,544</td>
+			<td style="text-align:right">15,627</td>
+			<td style="text-align:right">46%</td>
+			<td style="text-align:right">15,026</td>
+			<td style="text-align:right">34,059</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">MidCentral</th>
+			<td style="text-align:right">16,774</td>
+			<td style="text-align:right">69%</td>
+			<td style="text-align:right">5,028</td>
+			<td style="text-align:right">11,960</td>
+			<td style="text-align:right">49%</td>
+			<td style="text-align:right">9,842</td>
+			<td style="text-align:right">24,225</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Whanganui</th>
+			<td style="text-align:right">8,577</td>
+			<td style="text-align:right">63%</td>
+			<td style="text-align:right">3,584</td>
+			<td style="text-align:right">6,316</td>
+			<td style="text-align:right">47%</td>
+			<td style="text-align:right">5,845</td>
+			<td style="text-align:right">13,512</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Capital and Coast</th>
+			<td style="text-align:right">21,195</td>
+			<td style="text-align:right">79%</td>
+			<td style="text-align:right">3,075</td>
+			<td style="text-align:right">16,020</td>
+			<td style="text-align:right">59%</td>
+			<td style="text-align:right">8,250</td>
+			<td style="text-align:right">26,967</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hutt Valley</th>
+			<td style="text-align:right">13,617</td>
+			<td style="text-align:right">71%</td>
+			<td style="text-align:right">3,594</td>
+			<td style="text-align:right">9,771</td>
+			<td style="text-align:right">51%</td>
+			<td style="text-align:right">7,440</td>
+			<td style="text-align:right">19,123</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Wairarapa</th>
+			<td style="text-align:right">4,294</td>
+			<td style="text-align:right">68%</td>
+			<td style="text-align:right">1,378</td>
+			<td style="text-align:right">3,000</td>
+			<td style="text-align:right">48%</td>
+			<td style="text-align:right">2,672</td>
+			<td style="text-align:right">6,302</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Nelson Marlborough</th>
+			<td style="text-align:right">7,691</td>
+			<td style="text-align:right">68%</td>
+			<td style="text-align:right">2,432</td>
+			<td style="text-align:right">5,799</td>
+			<td style="text-align:right">52%</td>
+			<td style="text-align:right">4,324</td>
+			<td style="text-align:right">11,248</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">West Coast</th>
+			<td style="text-align:right">1,921</td>
+			<td style="text-align:right">69%</td>
+			<td style="text-align:right">568</td>
+			<td style="text-align:right">1,370</td>
+			<td style="text-align:right">50%</td>
+			<td style="text-align:right">1,118</td>
+			<td style="text-align:right">2,765</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Canterbury</th>
+			<td style="text-align:right">27,021</td>
+			<td style="text-align:right">73%</td>
+			<td style="text-align:right">6,251</td>
+			<td style="text-align:right">18,415</td>
+			<td style="text-align:right">50%</td>
+			<td style="text-align:right">14,857</td>
+			<td style="text-align:right">36,969</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">South Canterbury</th>
+			<td style="text-align:right">2,332</td>
+			<td style="text-align:right">68%</td>
+			<td style="text-align:right">753</td>
+			<td style="text-align:right">1,718</td>
+			<td style="text-align:right">50%</td>
+			<td style="text-align:right">1,367</td>
+			<td style="text-align:right">3,428</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Southern</th>
+			<td style="text-align:right">17,288</td>
+			<td style="text-align:right">73%</td>
+			<td style="text-align:right">3,993</td>
+			<td style="text-align:right">13,168</td>
+			<td style="text-align:right">56%</td>
+			<td style="text-align:right">8,113</td>
+			<td style="text-align:right">23,646</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Overseas / Unknown</th>
+			<td style="text-align:right">182</td>
+			<td style="text-align:right">7%</td>
+			<td style="text-align:right">2,206</td>
+			<td style="text-align:right">131</td>
+			<td style="text-align:right">5%</td>
+			<td style="text-align:right">2,257</td>
+			<td style="text-align:right">2,653</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total</strong></th>
+			<td style="text-align:right"><strong>397,304</strong></td>
+			<td style="text-align:right"><strong>70%</strong></td>
+			<td style="text-align:right"><strong>116,643</strong></td>
+			<td style="text-align:right"><strong>281,609</strong></td>
+			<td style="text-align:right"><strong>49%</strong></td>
+			<td style="text-align:right"><strong>232,338</strong></td>
+			<td style="text-align:right"><strong>571,052</strong></td>
+		</tr>
+	</tbody>
+</table>
+
+<h4><a id="90pct Pacific Peoples" name="90pct Pacific Peoples"></a>Pacific Peoples</h4>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">&nbsp;</th>
+			<th scope="col" style="text-align:right">First doses</th>
+			<th scope="col" style="text-align:right">First doses %</th>
+			<th scope="col" style="text-align:right">First doses to 90%</th>
+			<th scope="col" style="text-align:right">Second doses</th>
+			<th scope="col" style="text-align:right">Second doses %</th>
+			<th scope="col" style="text-align:right">Second doses to 90%</th>
+			<th scope="col" style="text-align:right">Population</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">Northland</th>
+			<td style="text-align:right">2,336</td>
+			<td style="text-align:right">80%</td>
+			<td style="text-align:right">305</td>
+			<td style="text-align:right">1,659</td>
+			<td style="text-align:right">57%</td>
+			<td style="text-align:right">982</td>
+			<td style="text-align:right">2,934</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waitemata</th>
+			<td style="text-align:right">31,649</td>
+			<td style="text-align:right">84%</td>
+			<td style="text-align:right">2,167</td>
+			<td style="text-align:right">24,718</td>
+			<td style="text-align:right">66%</td>
+			<td style="text-align:right">9,098</td>
+			<td style="text-align:right">37,573</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Auckland</th>
+			<td style="text-align:right">38,941</td>
+			<td style="text-align:right">83%</td>
+			<td style="text-align:right">3,238</td>
+			<td style="text-align:right">30,733</td>
+			<td style="text-align:right">66%</td>
+			<td style="text-align:right">11,446</td>
+			<td style="text-align:right">46,866</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Counties Manukau</th>
+			<td style="text-align:right">95,327</td>
+			<td style="text-align:right">82%</td>
+			<td style="text-align:right">9,521</td>
+			<td style="text-align:right">74,853</td>
+			<td style="text-align:right">64%</td>
+			<td style="text-align:right">29,995</td>
+			<td style="text-align:right">116,498</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waikato</th>
+			<td style="text-align:right">9,001</td>
+			<td style="text-align:right">84%</td>
+			<td style="text-align:right">613</td>
+			<td style="text-align:right">6,941</td>
+			<td style="text-align:right">65%</td>
+			<td style="text-align:right">2,673</td>
+			<td style="text-align:right">10,682</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Lakes</th>
+			<td style="text-align:right">1,788</td>
+			<td style="text-align:right">78%</td>
+			<td style="text-align:right">269</td>
+			<td style="text-align:right">1,364</td>
+			<td style="text-align:right">60%</td>
+			<td style="text-align:right">693</td>
+			<td style="text-align:right">2,286</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Bay of Plenty</th>
+			<td style="text-align:right">3,965</td>
+			<td style="text-align:right">&gt;95%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">2,991</td>
+			<td style="text-align:right">81%</td>
+			<td style="text-align:right">320</td>
+			<td style="text-align:right">3,679</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Tairawhiti</th>
+			<td style="text-align:right">850</td>
+			<td style="text-align:right">88%</td>
+			<td style="text-align:right">18</td>
+			<td style="text-align:right">647</td>
+			<td style="text-align:right">67%</td>
+			<td style="text-align:right">222</td>
+			<td style="text-align:right">965</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Taranaki</th>
+			<td style="text-align:right">1,029</td>
+			<td style="text-align:right">81%</td>
+			<td style="text-align:right">114</td>
+			<td style="text-align:right">750</td>
+			<td style="text-align:right">59%</td>
+			<td style="text-align:right">393</td>
+			<td style="text-align:right">1,270</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hawkes Bay</th>
+			<td style="text-align:right">5,011</td>
+			<td style="text-align:right">&gt;95%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">4,029</td>
+			<td style="text-align:right">80%</td>
+			<td style="text-align:right">489</td>
+			<td style="text-align:right">5,020</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">MidCentral</th>
+			<td style="text-align:right">3,697</td>
+			<td style="text-align:right">83%</td>
+			<td style="text-align:right">324</td>
+			<td style="text-align:right">2,812</td>
+			<td style="text-align:right">63%</td>
+			<td style="text-align:right">1,209</td>
+			<td style="text-align:right">4,468</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Whanganui</th>
+			<td style="text-align:right">1,023</td>
+			<td style="text-align:right">74%</td>
+			<td style="text-align:right">220</td>
+			<td style="text-align:right">796</td>
+			<td style="text-align:right">58%</td>
+			<td style="text-align:right">447</td>
+			<td style="text-align:right">1,381</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Capital and Coast</th>
+			<td style="text-align:right">15,409</td>
+			<td style="text-align:right">80%</td>
+			<td style="text-align:right">1,850</td>
+			<td style="text-align:right">12,164</td>
+			<td style="text-align:right">63%</td>
+			<td style="text-align:right">5,095</td>
+			<td style="text-align:right">19,177</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hutt Valley</th>
+			<td style="text-align:right">7,831</td>
+			<td style="text-align:right">79%</td>
+			<td style="text-align:right">1,074</td>
+			<td style="text-align:right">6,068</td>
+			<td style="text-align:right">61%</td>
+			<td style="text-align:right">2,837</td>
+			<td style="text-align:right">9,894</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Wairarapa</th>
+			<td style="text-align:right">676</td>
+			<td style="text-align:right">81%</td>
+			<td style="text-align:right">77</td>
+			<td style="text-align:right">534</td>
+			<td style="text-align:right">64%</td>
+			<td style="text-align:right">219</td>
+			<td style="text-align:right">837</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Nelson Marlborough</th>
+			<td style="text-align:right">3,580</td>
+			<td style="text-align:right">&gt;95%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">3,104</td>
+			<td style="text-align:right">&gt;95%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">2,115</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">West Coast</th>
+			<td style="text-align:right">225</td>
+			<td style="text-align:right">80%</td>
+			<td style="text-align:right">29</td>
+			<td style="text-align:right">168</td>
+			<td style="text-align:right">60%</td>
+			<td style="text-align:right">86</td>
+			<td style="text-align:right">282</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Canterbury</th>
+			<td style="text-align:right">10,266</td>
+			<td style="text-align:right">81%</td>
+			<td style="text-align:right">1,197</td>
+			<td style="text-align:right">7,565</td>
+			<td style="text-align:right">59%</td>
+			<td style="text-align:right">3,898</td>
+			<td style="text-align:right">12,737</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">South Canterbury</th>
+			<td style="text-align:right">762</td>
+			<td style="text-align:right">91%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">539</td>
+			<td style="text-align:right">64%</td>
+			<td style="text-align:right">214</td>
+			<td style="text-align:right">837</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Southern</th>
+			<td style="text-align:right">5,468</td>
+			<td style="text-align:right">91%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">4,276</td>
+			<td style="text-align:right">71%</td>
+			<td style="text-align:right">1,152</td>
+			<td style="text-align:right">6,031</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Overseas / Unknown</th>
+			<td style="text-align:right">337</td>
+			<td style="text-align:right">29%</td>
+			<td style="text-align:right">697</td>
+			<td style="text-align:right">288</td>
+			<td style="text-align:right">25%</td>
+			<td style="text-align:right">746</td>
+			<td style="text-align:right">1,149</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total</strong></th>
+			<td style="text-align:right"><strong>239,171</strong></td>
+			<td style="text-align:right"><strong>83%</strong></td>
+			<td style="text-align:right"><strong>18,842</strong></td>
+			<td style="text-align:right"><strong>186,999</strong></td>
+			<td style="text-align:right"><strong>65%</strong></td>
+			<td style="text-align:right"><strong>71,014</strong></td>
+			<td style="text-align:right"><strong>286,681</strong></td>
+		</tr>
+	</tbody>
+</table>
+<!--daily_end-->
+
+<hr/>
+<h2><a id="weekly-updates" name="weekly-updates"></a>COVID-19 vaccinations: weekly updates</h2>
+
+<div class="well well-sm">
+<p style="margin-top: 0"><strong>Data in this section is as at 11:59pm 26 October 2021 and is updated weekly on Wednesdays.</strong></p>
+</div>
+
+<h3><a id="model" model="" name="id="></a>Cumulative vaccinations</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccination doses administered compared to plan doses" class="img-responsive" height="830" src="/web/20211027072637im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/vaccineplanmodel_13.png" width="1780"/></figure>
+
+<p>Production plan figures are the volumes agreed with DHBs and national providers for expected vaccinations. These figures have been matched with expected supply. Detailed plans are available in the Excel file at the bottom of this page.</p>
+
+<p>The Stock received figures are the cumulative supply of doses to date.</p>
+
+<p>DHB capacity plans for the remainder of the year are undergoing review.</p>
+
+<hr/><!--
+<h3><a id="model" model="" name="id="></a>Cumulative vaccinations for last 6 weeks</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccination doses administered compared to plan doses - 6wks" class="img-responsive" height="830" src="/vaccineplanmodel_wks.png" width="1780" /></figure>
+
+<hr />
+-->
+<h3><a id="uptake" name="uptake"></a>Vaccine uptake</h3>
+
+<p>Maps and data related to uptake rates of the COVID-19 vaccine across the country are available on the pages linked below. These show&nbsp;vaccination records aggregated by area of residence for all New Zealand residents, Māori communities, and Pacific communities.</p>
+
+<ul>
+	<li><a href="/web/20211027072637/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-across-nz">COVID-19 Vaccination uptake rates across NZ</a></li>
+	<li><a href="/web/20211027072637/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-maori-communities-across-nz">COVID-19 Vaccination uptake rates within Māori communities across NZ</a></li>
+	<li><a href="/web/20211027072637/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-pacific-communities-across-nz">COVID-19 Vaccination uptake rates within Pacific communities across NZ</a></li>
+</ul>
+
+<h4><a id="uptake" name="uptake"></a>Vaccine uptake per rate ratio (unadjusted) Māori and Pacific compared with Non-Māori non-Pacific</h4>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine Uptake per 1,000 (HSU) Rate Ratio, Showing Prioritised Ethnicity, vs Non-Māori Non-Pacific, By Age Band" class="img-responsive" height="830" src="/web/20211027072637im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_mix_8.png" width="1780"/></figure>
+
+<p>In the Chart above, rate ratios tell us the rate Māori or Pacific People per population are being vaccinated compared with non-Māori non-Pacific. This comparison can be split by age group.</p>
+
+<ul>
+	<li>A rate of one means the groups being compared are being vaccinated at the same rate.</li>
+	<li>A rate over one means Māori (or Pacific) are being vaccinated at a higher rate than non-Māori non-Pacific.</li>
+	<li>A rate under one means Māori (or Pacific) are being vaccinated at a lower rate than non-Māori non-Pacific.</li>
+</ul>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<td colspan="2" style="border-top: 0 !important; border-bottom-color: #FDD6AF !important; border-right: 0 !important;">&nbsp;</td>
+			<th colspan="6" id="ac1">Māori</th>
+			<th colspan="6" id="ac8">Pacific Peoples</th>
+		</tr>
+		<tr>
+			<th id="ar1">DHB</th>
+			<th>Dose number</th>
+			<th headers="ac1" id="ac2">65+</th>
+			<th headers="ac1" id="ac3">50-64</th>
+			<th headers="ac1" id="ac4">35-49</th>
+			<th headers="ac1" id="ac5">20-34</th>
+			<th headers="ac1" id="ac6">12-19</th>
+			<th headers="ac1" id="ac7">All ages</th>
+			<th headers="ac8" id="ac9">65+</th>
+			<th headers="ac8" id="ac10">50-64</th>
+			<th headers="ac8" id="ac11">35-49</th>
+			<th headers="ac8" id="ac12">20-34</th>
+			<th headers="ac8" id="ac13">12-19</th>
+			<th headers="ac8" id="ac14">All ages</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th headers="ar1" id="ar2" rowspan="2">National</th>
+			<th headers="ar1 ar2" id="ar3">Dose 1</th>
+			<td headers="ar1 ar2 ar3 ac1 ac2" style="background-color:green; color: #FFF;"><strong>0.99</strong></td>
+			<td headers="ar1 ar2 ar3 ac1 ac3" style="background-color:mediumseagreen"><strong>0.93</strong></td>
+			<td headers="ar1 ar2 ar3 ac1 ac4" style="background-color:yellow"><strong>0.79</strong></td>
+			<td headers="ar1 ar2 ar3 ac1 ac5" style="background-color:coral"><strong>0.67</strong></td>
+			<td headers="ar1 ar2 ar3 ac1 ac6" style="background-color:orange"><strong>0.71</strong></td>
+			<td headers="ar1 ar2 ar3 ac1 ac7" style="background-color:yellow"><strong>0.77</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac9" style="background-color:mediumseagreen"><strong>0.94</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac10" style="background-color:green; color: #FFF;"><strong>0.99</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac11" style="background-color:green; color: #FFF;"><strong>0.98</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac12" style="background-color:lightgreen"><strong>0.89</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac13" style="background-color:mediumseagreen"><strong>0.90</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac14" style="background-color:mediumseagreen"><strong>0.93</strong></td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar2" id="ar4">Dose 2</th>
+			<td headers="ar1 ar2 ar4 ac1 ac2" style="background-color:green; color: #FFF;"><strong>0.96</strong></td>
+			<td headers="ar1 ar2 ar4 ac1 ac3" style="background-color:lightgreen"><strong>0.87</strong></td>
+			<td headers="ar1 ar2 ar4 ac1 ac4" style="background-color:coral"><strong>0.68</strong></td>
+			<td headers="ar1 ar2 ar4 ac1 ac5" style="background-color:crimson; color: #FFF;"><strong>0.51</strong></td>
+			<td headers="ar1 ar2 ar4 ac1 ac6" style="background-color:crimson; color: #FFF;"><strong>0.57</strong></td>
+			<td headers="ar1 ar2 ar4 ac1 ac7" style="background-color:coral"><strong>0.65</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac9" style="background-color:mediumseagreen"><strong>0.92</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac10" style="background-color:green; color: #FFF;"><strong>0.99</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac11" style="background-color:green; color: #FFF;"><strong>0.97</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac12" style="background-color:palegreen"><strong>0.82</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac13" style="background-color:lightgreen"><strong>0.86</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac14" style="background-color:lightgreen"><strong>0.86</strong></td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar5" rowspan="2">Northland</th>
+			<th headers="ar1 ar5" id="ar6">Dose 1</th>
+			<td headers="ar1 ar5 ar6 ac1 ac2" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar5 ar6 ac1 ac3" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar5 ar6 ac1 ac4" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar5 ar6 ac1 ac5" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar5 ar6 ac1 ac6" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar5 ar6 ac1 ac7" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar5 ar6 ac8 ac9" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar5 ar6 ac8 ac10" style="background-color:green; color: #FFF;">1.06</td>
+			<td headers="ar1 ar5 ar6 ac8 ac11" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar5 ar6 ac8 ac12" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar5 ar6 ac8 ac13" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar5 ar6 ac8 ac14" style="background-color:mediumseagreen">0.94</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar5" id="ar7">Dose 2</th>
+			<td headers="ar1 ar5 ar7 ac1 ac2" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar5 ar7 ac1 ac3" style="background-color:lightgreen">0.87</td>
+			<td headers="ar1 ar5 ar7 ac1 ac4" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar5 ar7 ac1 ac5" style="background-color:crimson; color: #FFF;">0.49</td>
+			<td headers="ar1 ar5 ar7 ac1 ac6" style="background-color:crimson; color: #FFF;">0.59</td>
+			<td headers="ar1 ar5 ar7 ac1 ac7" style="background-color:tomato">0.63</td>
+			<td headers="ar1 ar5 ar7 ac8 ac9" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar5 ar7 ac8 ac10" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar5 ar7 ac8 ac11" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar5 ar7 ac8 ac12" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar5 ar7 ac8 ac13" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar5 ar7 ac8 ac14" style="background-color:palegreen">0.80</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar8" rowspan="2">Auckland Metro</th>
+			<th headers="ar1 ar8" id="ar9">Dose 1</th>
+			<td headers="ar1 ar8 ar9 ac1 ac2" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar8 ar9 ac1 ac3" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar8 ar9 ac1 ac4" style="background-color:palegreen">0.81</td>
+			<td headers="ar1 ar8 ar9 ac1 ac5" style="background-color:orange">0.72</td>
+			<td headers="ar1 ar8 ar9 ac1 ac6" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar8 ar9 ac1 ac7" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar8 ar9 ac8 ac9" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar8 ar9 ac8 ac10" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar8 ar9 ac8 ac11" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar8 ar9 ac8 ac12" style="background-color:palegreen">0.81</td>
+			<td headers="ar1 ar8 ar9 ac8 ac13" style="background-color:palegreen">0.84</td>
+			<td headers="ar1 ar8 ar9 ac8 ac14" style="background-color:lightgreen">0.88</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar8" id="ar10">Dose 2</th>
+			<td headers="ar1 ar8 ar10 ac1 ac2" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar8 ar10 ac1 ac3" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar8 ar10 ac1 ac4" style="background-color:coral">0.69</td>
+			<td headers="ar1 ar8 ar10 ac1 ac5" style="background-color:crimson; color: #FFF;">0.54</td>
+			<td headers="ar1 ar8 ar10 ac1 ac6" style="background-color:crimson; color: #FFF;">0.59</td>
+			<td headers="ar1 ar8 ar10 ac1 ac7" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar8 ar10 ac8 ac9" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar8 ar10 ac8 ac10" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar8 ar10 ac8 ac11" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar8 ar10 ac8 ac12" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar8 ar10 ac8 ac13" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar8 ar10 ac8 ac14" style="background-color:yellow">0.78</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar11" rowspan="2">Waikato</th>
+			<th headers="ar1 ar11" id="ar12">Dose 1</th>
+			<td headers="ar1 ar11 ar12 ac1 ac2" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar11 ar12 ac1 ac3" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar11 ar12 ac1 ac4" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar11 ar12 ac1 ac5" style="background-color:coral">0.69</td>
+			<td headers="ar1 ar11 ar12 ac1 ac6" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar11 ar12 ac1 ac7" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar11 ar12 ac8 ac9" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar11 ar12 ac8 ac10" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar11 ar12 ac8 ac11" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar11 ar12 ac8 ac12" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar11 ar12 ac8 ac13" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar11 ar12 ac8 ac14" style="background-color:mediumseagreen">0.94</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar11" id="ar13">Dose 2</th>
+			<td headers="ar1 ar11 ar13 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar11 ar13 ac1 ac3" style="background-color:lightgreen">0.87</td>
+			<td headers="ar1 ar11 ar13 ac1 ac4" style="background-color:coral">0.68</td>
+			<td headers="ar1 ar11 ar13 ac1 ac5" style="background-color:crimson; color: #FFF;">0.50</td>
+			<td headers="ar1 ar11 ar13 ac1 ac6" style="background-color:crimson; color: #FFF;">0.57</td>
+			<td headers="ar1 ar11 ar13 ac1 ac7" style="background-color:tomato">0.64</td>
+			<td headers="ar1 ar11 ar13 ac8 ac9" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar11 ar13 ac8 ac10" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar11 ar13 ac8 ac11" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar11 ar13 ac8 ac12" style="background-color:palegreen">0.84</td>
+			<td headers="ar1 ar11 ar13 ac8 ac13" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar11 ar13 ac8 ac14" style="background-color:lightgreen">0.87</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar14" rowspan="2">Bay of Plenty</th>
+			<th headers="ar1 ar14" id="ar15">Dose 1</th>
+			<td headers="ar1 ar14 ar15 ac1 ac2" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar14 ar15 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar14 ar15 ac1 ac4" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar14 ar15 ac1 ac5" style="background-color:crimson; color: #FFF;">0.57</td>
+			<td headers="ar1 ar14 ar15 ac1 ac6" style="background-color:tomato">0.64</td>
+			<td headers="ar1 ar14 ar15 ac1 ac7" style="background-color:orange">0.72</td>
+			<td headers="ar1 ar14 ar15 ac8 ac9" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar14 ar15 ac8 ac10" style="background-color:green; color: #FFF;">1.09</td>
+			<td headers="ar1 ar14 ar15 ac8 ac11" style="background-color:green; color: #FFF;">1.47</td>
+			<td headers="ar1 ar14 ar15 ac8 ac12" style="background-color:green; color: #FFF;">1.52</td>
+			<td headers="ar1 ar14 ar15 ac8 ac13" style="background-color:lightgreen">0.87</td>
+			<td headers="ar1 ar14 ar15 ac8 ac14" style="background-color:green; color: #FFF;">1.23</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar14" id="ar16">Dose 2</th>
+			<td headers="ar1 ar14 ar16 ac1 ac2" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar14 ar16 ac1 ac3" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar14 ar16 ac1 ac4" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar14 ar16 ac1 ac5" style="background-color:crimson; color: #FFF;">0.46</td>
+			<td headers="ar1 ar14 ar16 ac1 ac6" style="background-color:crimson; color: #FFF;">0.54</td>
+			<td headers="ar1 ar14 ar16 ac1 ac7" style="background-color:tomato">0.60</td>
+			<td headers="ar1 ar14 ar16 ac8 ac9" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar14 ar16 ac8 ac10" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar14 ar16 ac8 ac11" style="background-color:green; color: #FFF;">1.60</td>
+			<td headers="ar1 ar14 ar16 ac8 ac12" style="background-color:green; color: #FFF;">1.78</td>
+			<td headers="ar1 ar14 ar16 ac8 ac13" style="background-color:yellow">0.77</td>
+			<td headers="ar1 ar14 ar16 ac8 ac14" style="background-color:green; color: #FFF;">1.15</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar17" rowspan="2">Tairawhiti</th>
+			<th headers="ar1 ar17" id="ar18">Dose 1</th>
+			<td headers="ar1 ar17 ar18 ac1 ac2" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar17 ar18 ac1 ac3" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar17 ar18 ac1 ac4" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar17 ar18 ac1 ac5" style="background-color:tomato">0.62</td>
+			<td headers="ar1 ar17 ar18 ac1 ac6" style="background-color:coral">0.69</td>
+			<td headers="ar1 ar17 ar18 ac1 ac7" style="background-color:yellow">0.76</td>
+			<td headers="ar1 ar17 ar18 ac8 ac9" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar17 ar18 ac8 ac10" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar17 ar18 ac8 ac11" style="background-color:green; color: #FFF;">1.10</td>
+			<td headers="ar1 ar17 ar18 ac8 ac12" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar17 ar18 ac8 ac13" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar17 ar18 ac8 ac14" style="background-color:green; color: #FFF;">1.01</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar17" id="ar19">Dose 2</th>
+			<td headers="ar1 ar17 ar19 ac1 ac2" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar17 ar19 ac1 ac3" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar17 ar19 ac1 ac4" style="background-color:coral">0.68</td>
+			<td headers="ar1 ar17 ar19 ac1 ac5" style="background-color:crimson; color: #FFF;">0.49</td>
+			<td headers="ar1 ar17 ar19 ac1 ac6" style="background-color:crimson; color: #FFF;">0.55</td>
+			<td headers="ar1 ar17 ar19 ac1 ac7" style="background-color:tomato">0.64</td>
+			<td headers="ar1 ar17 ar19 ac8 ac9" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar17 ar19 ac8 ac10" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar17 ar19 ac8 ac11" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar17 ar19 ac8 ac12" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar17 ar19 ac8 ac13" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar17 ar19 ac8 ac14" style="background-color:mediumseagreen">0.90</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar20" rowspan="2">Lakes</th>
+			<th headers="ar1 ar20" id="ar21">Dose 1</th>
+			<td headers="ar1 ar20 ar21 ac1 ac2" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar20 ar21 ac1 ac3" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar20 ar21 ac1 ac4" style="background-color:yellow">0.76</td>
+			<td headers="ar1 ar20 ar21 ac1 ac5" style="background-color:crimson; color: #FFF;">0.58</td>
+			<td headers="ar1 ar20 ar21 ac1 ac6" style="background-color:coral">0.65</td>
+			<td headers="ar1 ar20 ar21 ac1 ac7" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar20 ar21 ac8 ac9" style="background-color:green; color: #FFF;">1.06</td>
+			<td headers="ar1 ar20 ar21 ac8 ac10" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar20 ar21 ac8 ac11" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar20 ar21 ac8 ac12" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar20 ar21 ac8 ac13" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar20 ar21 ac8 ac14" style="background-color:mediumseagreen">0.90</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar20" id="ar22">Dose 2</th>
+			<td headers="ar1 ar20 ar22 ac1 ac2" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar20 ar22 ac1 ac3" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar20 ar22 ac1 ac4" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar20 ar22 ac1 ac5" style="background-color:crimson; color: #FFF;">0.44</td>
+			<td headers="ar1 ar20 ar22 ac1 ac6" style="background-color:crimson; color: #FFF;">0.53</td>
+			<td headers="ar1 ar20 ar22 ac1 ac7" style="background-color:tomato">0.61</td>
+			<td headers="ar1 ar20 ar22 ac8 ac9" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar20 ar22 ac8 ac10" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar20 ar22 ac8 ac11" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar20 ar22 ac8 ac12" style="background-color:palegreen">0.83</td>
+			<td headers="ar1 ar20 ar22 ac8 ac13" style="background-color:lightgreen">0.86</td>
+			<td headers="ar1 ar20 ar22 ac8 ac14" style="background-color:palegreen">0.83</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar23" rowspan="2">Taranaki</th>
+			<th headers="ar1 ar23" id="ar24">Dose 1</th>
+			<td headers="ar1 ar23 ar24 ac1 ac2" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar23 ar24 ac1 ac3" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar23 ar24 ac1 ac4" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar23 ar24 ac1 ac5" style="background-color:coral">0.68</td>
+			<td headers="ar1 ar23 ar24 ac1 ac6" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar23 ar24 ac1 ac7" style="background-color:yellow">0.77</td>
+			<td headers="ar1 ar23 ar24 ac8 ac9" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar23 ar24 ac8 ac10" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar23 ar24 ac8 ac11" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar23 ar24 ac8 ac12" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar23 ar24 ac8 ac13" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar23 ar24 ac8 ac14" style="background-color:mediumseagreen">0.94</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar23" id="ar25">Dose 2</th>
+			<td headers="ar1 ar23 ar25 ac1 ac2" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar23 ar25 ac1 ac3" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar23 ar25 ac1 ac4" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar23 ar25 ac1 ac5" style="background-color:crimson; color: #FFF;">0.52</td>
+			<td headers="ar1 ar23 ar25 ac1 ac6" style="background-color:crimson; color: #FFF;">0.56</td>
+			<td headers="ar1 ar23 ar25 ac1 ac7" style="background-color:tomato">0.64</td>
+			<td headers="ar1 ar23 ar25 ac8 ac9" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar23 ar25 ac8 ac10" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar23 ar25 ac8 ac11" style="background-color:green; color: #FFF;">1.21</td>
+			<td headers="ar1 ar23 ar25 ac8 ac12" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar23 ar25 ac8 ac13" style="background-color:lightgreen">0.87</td>
+			<td headers="ar1 ar23 ar25 ac8 ac14" style="background-color:lightgreen">0.89</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar26" rowspan="2">Whanganui</th>
+			<th headers="ar1 ar26" id="ar27">Dose 1</th>
+			<td headers="ar1 ar26 ar27 ac1 ac2" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar26 ar27 ac1 ac3" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar26 ar27 ac1 ac4" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar26 ar27 ac1 ac5" style="background-color:coral">0.65</td>
+			<td headers="ar1 ar26 ar27 ac1 ac6" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar26 ar27 ac1 ac7" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar26 ar27 ac8 ac9" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar26 ar27 ac8 ac10" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar26 ar27 ac8 ac11" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar26 ar27 ac8 ac12" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar26 ar27 ac8 ac13" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar26 ar27 ac8 ac14" style="background-color:lightgreen">0.87</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar26" id="ar28">Dose 2</th>
+			<td headers="ar1 ar26 ar28 ac1 ac2" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar26 ar28 ac1 ac3" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar26 ar28 ac1 ac4" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar26 ar28 ac1 ac5" style="background-color:crimson; color: #FFF;">0.51</td>
+			<td headers="ar1 ar26 ar28 ac1 ac6" style="background-color:tomato">0.60</td>
+			<td headers="ar1 ar26 ar28 ac1 ac7" style="background-color:coral">0.65</td>
+			<td headers="ar1 ar26 ar28 ac8 ac9" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar26 ar28 ac8 ac10" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar26 ar28 ac8 ac11" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar26 ar28 ac8 ac12" style="background-color:palegreen">0.83</td>
+			<td headers="ar1 ar26 ar28 ac8 ac13" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar26 ar28 ac8 ac14" style="background-color:palegreen">0.80</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar29" rowspan="2">Hawke&#39;s Bay</th>
+			<th headers="ar1 ar29" id="ar30">Dose 1</th>
+			<td headers="ar1 ar29 ar30 ac1 ac2" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar29 ar30 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar29 ar30 ac1 ac4" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar29 ar30 ac1 ac5" style="background-color:crimson; color: #FFF;">0.59</td>
+			<td headers="ar1 ar29 ar30 ac1 ac6" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar29 ar30 ac1 ac7" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar29 ar30 ac8 ac9" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar29 ar30 ac8 ac10" style="background-color:green; color: #FFF;">1.05</td>
+			<td headers="ar1 ar29 ar30 ac8 ac11" style="background-color:green; color: #FFF;">1.42</td>
+			<td headers="ar1 ar29 ar30 ac8 ac12" style="background-color:green; color: #FFF;">1.32</td>
+			<td headers="ar1 ar29 ar30 ac8 ac13" style="background-color:lightgreen">0.88</td>
+			<td headers="ar1 ar29 ar30 ac8 ac14" style="background-color:green; color: #FFF;">1.16</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar29" id="ar31">Dose 2</th>
+			<td headers="ar1 ar29 ar31 ac1 ac2" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar29 ar31 ac1 ac3" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar29 ar31 ac1 ac4" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar29 ar31 ac1 ac5" style="background-color:crimson; color: #FFF;">0.47</td>
+			<td headers="ar1 ar29 ar31 ac1 ac6" style="background-color:crimson; color: #FFF;">0.57</td>
+			<td headers="ar1 ar29 ar31 ac1 ac7" style="background-color:tomato">0.61</td>
+			<td headers="ar1 ar29 ar31 ac8 ac9" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar29 ar31 ac8 ac10" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar29 ar31 ac8 ac11" style="background-color:green; color: #FFF;">1.48</td>
+			<td headers="ar1 ar29 ar31 ac8 ac12" style="background-color:green; color: #FFF;">1.48</td>
+			<td headers="ar1 ar29 ar31 ac8 ac13" style="background-color:lightgreen">0.86</td>
+			<td headers="ar1 ar29 ar31 ac8 ac14" style="background-color:green; color: #FFF;">1.10</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar32" rowspan="2">MidCentral</th>
+			<th headers="ar1 ar32" id="ar33">Dose 1</th>
+			<td headers="ar1 ar32 ar33 ac1 ac2" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar32 ar33 ac1 ac3" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar32 ar33 ac1 ac4" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar32 ar33 ac1 ac5" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar32 ar33 ac1 ac6" style="background-color:orange">0.72</td>
+			<td headers="ar1 ar32 ar33 ac1 ac7" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar32 ar33 ac8 ac9" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar32 ar33 ac8 ac10" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar32 ar33 ac8 ac11" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar32 ar33 ac8 ac12" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar32 ar33 ac8 ac13" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar32 ar33 ac8 ac14" style="background-color:mediumseagreen">0.94</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar32" id="ar34">Dose 2</th>
+			<td headers="ar1 ar32 ar34 ac1 ac2" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar32 ar34 ac1 ac3" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar32 ar34 ac1 ac4" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar32 ar34 ac1 ac5" style="background-color:crimson; color: #FFF;">0.58</td>
+			<td headers="ar1 ar32 ar34 ac1 ac6" style="background-color:tomato">0.60</td>
+			<td headers="ar1 ar32 ar34 ac1 ac7" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar32 ar34 ac8 ac9" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar32 ar34 ac8 ac10" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar32 ar34 ac8 ac11" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar32 ar34 ac8 ac12" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar32 ar34 ac8 ac13" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar32 ar34 ac8 ac14" style="background-color:lightgreen">0.85</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar35" rowspan="2">Wairarapa</th>
+			<th headers="ar1 ar35" id="ar36">Dose 1</th>
+			<td headers="ar1 ar35 ar36 ac1 ac2" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar35 ar36 ac1 ac3" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar35 ar36 ac1 ac4" style="background-color:palegreen">0.84</td>
+			<td headers="ar1 ar35 ar36 ac1 ac5" style="background-color:orange">0.72</td>
+			<td headers="ar1 ar35 ar36 ac1 ac6" style="background-color:yellow">0.77</td>
+			<td headers="ar1 ar35 ar36 ac1 ac7" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar35 ar36 ac8 ac9" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar35 ar36 ac8 ac10" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar35 ar36 ac8 ac11" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar35 ar36 ac8 ac12" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar35 ar36 ac8 ac13" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar35 ar36 ac8 ac14" style="background-color:mediumseagreen">0.92</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar35" id="ar37">Dose 2</th>
+			<td headers="ar1 ar35 ar37 ac1 ac2" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar35 ar37 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar35 ar37 ac1 ac4" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar35 ar37 ac1 ac5" style="background-color:crimson; color: #FFF;">0.55</td>
+			<td headers="ar1 ar35 ar37 ac1 ac6" style="background-color:tomato">0.63</td>
+			<td headers="ar1 ar35 ar37 ac1 ac7" style="background-color:tomato">0.64</td>
+			<td headers="ar1 ar35 ar37 ac8 ac9" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar35 ar37 ac8 ac10" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar35 ar37 ac8 ac11" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar35 ar37 ac8 ac12" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar35 ar37 ac8 ac13" style="background-color:palegreen">0.84</td>
+			<td headers="ar1 ar35 ar37 ac8 ac14" style="background-color:lightgreen">0.86</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar38" rowspan="2">Capital &amp; Coast and Hutt Valley</th>
+			<th headers="ar1 ar38" id="ar39">Dose 1</th>
+			<td headers="ar1 ar38 ar39 ac1 ac2" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar38 ar39 ac1 ac3" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar38 ar39 ac1 ac4" style="background-color:palegreen">0.83</td>
+			<td headers="ar1 ar38 ar39 ac1 ac5" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar38 ar39 ac1 ac6" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar38 ar39 ac1 ac7" style="background-color:palegreen">0.81</td>
+			<td headers="ar1 ar38 ar39 ac8 ac9" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar38 ar39 ac8 ac10" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar38 ar39 ac8 ac11" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar38 ar39 ac8 ac12" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar38 ar39 ac8 ac13" style="background-color:palegreen">0.84</td>
+			<td headers="ar1 ar38 ar39 ac8 ac14" style="background-color:lightgreen">0.86</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar38" id="ar40">Dose 2</th>
+			<td headers="ar1 ar38 ar40 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar38 ar40 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar38 ar40 ac1 ac4" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar38 ar40 ac1 ac5" style="background-color:tomato">0.63</td>
+			<td headers="ar1 ar38 ar40 ac1 ac6" style="background-color:tomato">0.62</td>
+			<td headers="ar1 ar38 ar40 ac1 ac7" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar38 ar40 ac8 ac9" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar38 ar40 ac8 ac10" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar38 ar40 ac8 ac11" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar38 ar40 ac8 ac12" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar38 ar40 ac8 ac13" style="background-color:yellow">0.76</td>
+			<td headers="ar1 ar38 ar40 ac8 ac14" style="background-color:palegreen">0.80</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar41" rowspan="2">Nelson Marlborough</th>
+			<th headers="ar1 ar41" id="ar42">Dose 1</th>
+			<td headers="ar1 ar41 ar42 ac1 ac2" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar41 ar42 ac1 ac3" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar41 ar42 ac1 ac4" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar41 ar42 ac1 ac5" style="background-color:coral">0.69</td>
+			<td headers="ar1 ar41 ar42 ac1 ac6" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar41 ar42 ac1 ac7" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar41 ar42 ac8 ac9" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar41 ar42 ac8 ac10" style="background-color:green; color: #FFF;">1.28</td>
+			<td headers="ar1 ar41 ar42 ac8 ac11" style="background-color:green; color: #FFF;">2.45</td>
+			<td headers="ar1 ar41 ar42 ac8 ac12" style="background-color:green; color: #FFF;">2.89</td>
+			<td headers="ar1 ar41 ar42 ac8 ac13" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar41 ar42 ac8 ac14" style="background-color:green; color: #FFF;">1.97</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar41" id="ar43">Dose 2</th>
+			<td headers="ar1 ar41 ar43 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar41 ar43 ac1 ac3" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar41 ar43 ac1 ac4" style="background-color:orange">0.72</td>
+			<td headers="ar1 ar41 ar43 ac1 ac5" style="background-color:crimson; color: #FFF;">0.57</td>
+			<td headers="ar1 ar41 ar43 ac1 ac6" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar41 ar43 ac1 ac7" style="background-color:coral">0.69</td>
+			<td headers="ar1 ar41 ar43 ac8 ac9" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar41 ar43 ac8 ac10" style="background-color:green; color: #FFF;">1.26</td>
+			<td headers="ar1 ar41 ar43 ac8 ac11" style="background-color:green; color: #FFF;">2.57</td>
+			<td headers="ar1 ar41 ar43 ac8 ac12" style="background-color:green; color: #FFF;">3.47</td>
+			<td headers="ar1 ar41 ar43 ac8 ac13" style="background-color:green; color: #FFF;">1.05</td>
+			<td headers="ar1 ar41 ar43 ac8 ac14" style="background-color:green; color: #FFF;">1.95</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar44" rowspan="2">West Coast</th>
+			<th headers="ar1 ar44" id="ar45">Dose 1</th>
+			<td headers="ar1 ar44 ar45 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar44 ar45 ac1 ac3" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar44 ar45 ac1 ac4" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar44 ar45 ac1 ac5" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar44 ar45 ac1 ac6" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar44 ar45 ac1 ac7" style="background-color:lightgreen">0.86</td>
+			<td headers="ar1 ar44 ar45 ac8 ac9" style="background-color:green; color: #FFF;">1.33</td>
+			<td headers="ar1 ar44 ar45 ac8 ac10" style="background-color:green; color: #FFF;">1.06</td>
+			<td headers="ar1 ar44 ar45 ac8 ac11" style="background-color:green; color: #FFF;">1.07</td>
+			<td headers="ar1 ar44 ar45 ac8 ac12" style="background-color:green; color: #FFF;">1.24</td>
+			<td headers="ar1 ar44 ar45 ac8 ac13" style="background-color:palegreen">0.83</td>
+			<td headers="ar1 ar44 ar45 ac8 ac14" style="background-color:green; color: #FFF;">0.99</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar44" id="ar46">Dose 2</th>
+			<td headers="ar1 ar44 ar46 ac1 ac2" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar44 ar46 ac1 ac3" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar44 ar46 ac1 ac4" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar44 ar46 ac1 ac5" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar44 ar46 ac1 ac6" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar44 ar46 ac1 ac7" style="background-color:yellow">0.76</td>
+			<td headers="ar1 ar44 ar46 ac8 ac9" style="background-color:green; color: #FFF;">1.33</td>
+			<td headers="ar1 ar44 ar46 ac8 ac10" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar44 ar46 ac8 ac11" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar44 ar46 ac8 ac12" style="background-color:green; color: #FFF;">1.57</td>
+			<td headers="ar1 ar44 ar46 ac8 ac13" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar44 ar46 ac8 ac14" style="background-color:mediumseagreen">0.91</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar47" rowspan="2">Canterbury</th>
+			<th headers="ar1 ar47" id="ar48">Dose 1</th>
+			<td headers="ar1 ar47 ar48 ac1 ac2" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar47 ar48 ac1 ac3" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar47 ar48 ac1 ac4" style="background-color:palegreen">0.83</td>
+			<td headers="ar1 ar47 ar48 ac1 ac5" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar47 ar48 ac1 ac6" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar47 ar48 ac1 ac7" style="background-color:palegreen">0.81</td>
+			<td headers="ar1 ar47 ar48 ac8 ac9" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar47 ar48 ac8 ac10" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar47 ar48 ac8 ac11" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar47 ar48 ac8 ac12" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar47 ar48 ac8 ac13" style="background-color:lightgreen">0.88</td>
+			<td headers="ar1 ar47 ar48 ac8 ac14" style="background-color:lightgreen">0.89</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar47" id="ar49">Dose 2</th>
+			<td headers="ar1 ar47 ar49 ac1 ac2" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar47 ar49 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar47 ar49 ac1 ac4" style="background-color:yellow">0.77</td>
+			<td headers="ar1 ar47 ar49 ac1 ac5" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar47 ar49 ac1 ac6" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar47 ar49 ac1 ac7" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar47 ar49 ac8 ac9" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar47 ar49 ac8 ac10" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar47 ar49 ac8 ac11" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar47 ar49 ac8 ac12" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar47 ar49 ac8 ac13" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar47 ar49 ac8 ac14" style="background-color:lightgreen">0.85</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar50" rowspan="2">South Canterbury</th>
+			<th headers="ar1 ar50" id="ar51">Dose 1</th>
+			<td headers="ar1 ar50 ar51 ac1 ac2" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar50 ar51 ac1 ac3" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar50 ar51 ac1 ac4" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar50 ar51 ac1 ac5" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar50 ar51 ac1 ac6" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar50 ar51 ac1 ac7" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar50 ar51 ac8 ac9" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar50 ar51 ac8 ac10" style="background-color:green; color: #FFF;">1.09</td>
+			<td headers="ar1 ar50 ar51 ac8 ac11" style="background-color:green; color: #FFF;">1.18</td>
+			<td headers="ar1 ar50 ar51 ac8 ac12" style="background-color:green; color: #FFF;">1.23</td>
+			<td headers="ar1 ar50 ar51 ac8 ac13" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar50 ar51 ac8 ac14" style="background-color:green; color: #FFF;">1.06</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar50" id="ar52">Dose 2</th>
+			<td headers="ar1 ar50 ar52 ac1 ac2" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar50 ar52 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar50 ar52 ac1 ac4" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar50 ar52 ac1 ac5" style="background-color:tomato">0.63</td>
+			<td headers="ar1 ar50 ar52 ac1 ac6" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar50 ar52 ac1 ac7" style="background-color:coral">0.69</td>
+			<td headers="ar1 ar50 ar52 ac8 ac9" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar50 ar52 ac8 ac10" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar50 ar52 ac8 ac11" style="background-color:green; color: #FFF;">1.09</td>
+			<td headers="ar1 ar50 ar52 ac8 ac12" style="background-color:green; color: #FFF;">1.15</td>
+			<td headers="ar1 ar50 ar52 ac8 ac13" style="background-color:green; color: #FFF;">1.05</td>
+			<td headers="ar1 ar50 ar52 ac8 ac14" style="background-color:lightgreen">0.89</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar53" rowspan="2">Southern</th>
+			<th headers="ar1 ar53" id="ar54">Dose 1</th>
+			<td headers="ar1 ar53 ar54 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar53 ar54 ac1 ac3" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar53 ar54 ac1 ac4" style="background-color:palegreen">0.83</td>
+			<td headers="ar1 ar53 ar54 ac1 ac5" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar53 ar54 ac1 ac6" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar53 ar54 ac1 ac7" style="background-color:palegreen">0.81</td>
+			<td headers="ar1 ar53 ar54 ac8 ac9" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar53 ar54 ac8 ac10" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar53 ar54 ac8 ac11" style="background-color:green; color: #FFF;">1.07</td>
+			<td headers="ar1 ar53 ar54 ac8 ac12" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar53 ar54 ac8 ac13" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar53 ar54 ac8 ac14" style="background-color:green; color: #FFF;">1.01</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar53" id="ar55">Dose 2</th>
+			<td headers="ar1 ar53 ar55 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar53 ar55 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar53 ar55 ac1 ac4" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar53 ar55 ac1 ac5" style="background-color:coral">0.66</td>
+			<td headers="ar1 ar53 ar55 ac1 ac6" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar53 ar55 ac1 ac7" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar53 ar55 ac8 ac9" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar53 ar55 ac8 ac10" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar53 ar55 ac8 ac11" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar53 ar55 ac8 ac12" style="background-color:green; color: #FFF;">1.05</td>
+			<td headers="ar1 ar53 ar55 ac8 ac13" style="background-color:lightgreen">0.87</td>
+			<td headers="ar1 ar53 ar55 ac8 ac14" style="background-color:mediumseagreen">0.93</td>
+		</tr>
+	</tbody>
+</table>
+
+<p>This table shows the rate of doses administered (per 1,000 population) to Māori or Pacific Peoples, relative to the rate of doses for Non-Māori and Non-Pacific groups. Less than one means the group is receiving a lower proportion of doses than would be expected if equity is being achieved. More than one means they are receiving a higher proportion of doses than would be expected if equity is being achieved. Exactly one means doses administered are in line with their proportion of population.</p>
+
+<ul>
+	<li><a download="" href="/web/20211027072637/https://www.health.govt.nz/system/files/documents/pages/rateratioexplainer_2.docx">Rate Ratio Explainer (Word, 434 KB)</a></li>
+</ul>
+
+<p>At all ages the size (weightings) of the age groups becomes a major contributing factor to comparative ratios, which is why the all ages (12+) figure may not appear to be in line with the age splits.</p>
+
+<h4><a id="uptake" name="uptake"></a>Vaccine uptake per 1,000 people by ethnicity</h4>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine uptake per 1,000 people by ethnicity" class="img-responsive" height="830" src="/web/20211027072637im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_eth_8.png" width="1780"/></figure>
+
+<h4><a id="uptake" name="uptake"></a>Vaccine uptake per 1,000 people by age band</h4>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine uptake per 1,000 people by age band" class="img-responsive" height="1030" src="/web/20211027072637im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_age_9.png" width="1780"/></figure>
+
+<h4><a id="uptake" name="location"></a>Vaccine uptake per 1,000 people by DHB of residence</h4>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine uptake per 1,000 people by DHB of residence" class="img-responsive" height="1030" src="/web/20211027072637im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_dhb_4.png" width="1780"/></figure>
+<!--
+<hr />
+<h3><a id="by_dhb_plan" name="dhb_plan"></a>Cumulative vaccination plan for DHBs</h3>
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">DHB of service</th>
+			<th scope="col" style="text-align:right">Actuals to Sunday 24 October</th>
+			<th scope="col" style="text-align:right">DHB Plan to Sunday 24 October</th>
+			<th scope="col" style="text-align:right">Variance</th>
+			<th scope="col" style="text-align:right">% of Plan</th>
+			<th scope="col" style="text-align:right">Week to date</th>
+		</tr>
+	</thead>
+	<tbody> --><!--plan--><!--
+<tr><td nowrap="nowrap">Auckland Metro</td><td>190621</td><td>205515</td><td>-14894</td><td>93%</td><td>9913</td></tr>
+<tr><td nowrap="nowrap">Bay of Plenty</td><td>22841</td><td>14255</td><td>8586</td><td>160%</td><td>1843</td></tr>
+<tr><td nowrap="nowrap">Canterbury</td><td>50558</td><td>39266</td><td>11292</td><td>129%</td><td>2769</td></tr>
+<tr><td nowrap="nowrap">Capital & Coast and Hutt Valley</td><td>48758</td><td>39742</td><td>9016</td><td>123%</td><td>1796</td></tr>
+<tr><td nowrap="nowrap">Hawke's Bay</td><td>15319</td><td>18205</td><td>-2886</td><td>84%</td><td>1351</td></tr>
+<tr><td nowrap="nowrap">Lakes</td><td>13437</td><td>12810</td><td>627</td><td>105%</td><td>731</td></tr>
+<tr><td nowrap="nowrap">MidCentral</td><td>10708</td><td>7237</td><td>3471</td><td>148%</td><td>1191</td></tr>
+<tr><td nowrap="nowrap">Nelson Marlborough</td><td>30198</td><td>18574</td><td>11624</td><td>163%</td><td>1285</td></tr>
+<tr><td nowrap="nowrap">Northland</td><td>21469</td><td>24762</td><td>-3293</td><td>87%</td><td>1257</td></tr>
+<tr><td nowrap="nowrap">South Canterbury</td><td>8106</td><td>8033</td><td>73</td><td>101%</td><td>389</td></tr>
+<tr><td nowrap="nowrap">Southern</td><td>35234</td><td>34594</td><td>640</td><td>102%</td><td>1794</td></tr>
+<tr><td nowrap="nowrap">Tairāwhiti</td><td>4579</td><td>4928</td><td>-349</td><td>93%</td><td>290</td></tr>
+<tr><td nowrap="nowrap">Taranaki</td><td>5619</td><td>5297</td><td>322</td><td>106%</td><td>168</td></tr>
+<tr><td nowrap="nowrap">Waikato</td><td>36070</td><td>32842</td><td>3228</td><td>110%</td><td>1905</td></tr>
+<tr><td nowrap="nowrap">Wairarapa</td><td>4516</td><td>4960</td><td>-444</td><td>91%</td><td>468</td></tr>
+<tr><td nowrap="nowrap">West Coast</td><td>3533</td><td>3300</td><td>233</td><td>107%</td><td>336</td></tr>
+<tr><td nowrap="nowrap">Whanganui</td><td>6982</td><td>4711</td><td>2271</td><td>148%</td><td>612</td></tr>
+<tr><td nowrap="nowrap">Other Sites</td><td>24890</td><td>14575</td><td>10315</td><td>171%</td><td>613</td></tr>
+<tr><td nowrap="nowrap">Total</td><td>533438</td><td>493606</td><td>39832</td><td>108%</td><td>28711</td></tr>
+!--plan_end--><!--	</tbody>
+</table>
+
+
+<p>The information provided in this table is based on cumulative DHB plans to the last week ending on Sunday. The final column shows vaccinations administered since Sunday by DHB of service to reconcile total actuals in this table to other total numbers shown.   On-going, and as we roll-out the vaccination programme, we anticipate that there could be a potential variance of up to ten percent (plus or minus) between DHB Plans and actual vaccination numbers. This is on the basis that, for example, an unplanned significant event could affect roll-out implementation or some DHBs might exceed their planned vaccination numbers.
+</p>
+-->
+
+<hr/>
+<h3><a id="by_dhb" name="location"></a>Cumulative vaccinations by DHB</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Cumulative vaccinations for DHBs" class="img-responsive" height="830" src="/web/20211027072637im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/dhbstacked_12.png" width="1780"/></figure>
+
+<hr/>
+<h3><a id="by-day" name="by-day"></a>Vaccinations by day</h3>
+
+<figure class="image-captioned img-responsive"><img alt="Vaccination doses administered per day" class="img-responsive" height="830" src="/web/20211027072637im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/vaccinebyday_12.png" width="1780"/></figure>
+
+<p>This chart shows the count of vaccinations administered on a given day from the COVID-19 Immunisation Register. Note some records are entered in the register at a later date than the immunisation was received. This means that the figures for a given date may move for some time after that date.</p>
+
+<hr/>
+<h3><a id="group" name="group"></a>Vaccinations by group by week</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccinations by group" class="img-responsive" height="830" src="/web/20211027072637im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/vaccinebygroupwk_12.png" width="1780"/></figure>
+
+<hr/>
+<h3><a id="group_d" name="group_d"></a>Cumulative vaccinations by group</h3>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">Priority Group</th>
+			<th scope="col" style="text-align:right">First dose administered</th>
+			<th scope="col" style="text-align:right">Second dose administered</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">Group 1</th>
+			<td style="text-align:right">66,767</td>
+			<td style="text-align:right">65,205</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Group 2</th>
+			<td style="text-align:right">661,231</td>
+			<td style="text-align:right">621,689</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Group 3</th>
+			<td style="text-align:right">793,481</td>
+			<td style="text-align:right">746,741</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Group 4</th>
+			<td style="text-align:right">2,136,491</td>
+			<td style="text-align:right">1,585,195</td>
+		</tr>
+	</tbody>
+</table>
+
+<p>For definitions of the groups and further detail see the downloadable spreadsheet at the bottom of the page.</p>
+
+<hr/>
+<h3><a id="by_soh" name="stockonhand"></a>Vaccine available for distribution at week end</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine available for distribution at week end" class="img-responsive" height="830" src="/web/20211027072637im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/stockonhand_13.png" width="1780"/></figure>
+
+<p>Vaccine available for distribution is stock (in doses) held at central warehouses. It does not include stock in transit or available at sites ready for use.</p>
+
+<hr/>
+<h3><a id="by_eth" name="ethnicity"></a>Total cumulative doses per 1,000 people by ethnicity</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Total cumulative doses per 1,000 people by ethnicity" class="img-responsive" height="830" src="/web/20211027072637im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/ethnicity_12.png" width="1780"/></figure>
+
+<p>This chart shows both first and second doses. As a result this chart may exceed 1,000 doses per 1,000 people.</p>
+
+<p><strong>*</strong> The prioritised ethnicity classification system allocates each person to a single ethnic group, based on the ethnic groups they identify with. Where people identify with more than one group, they are assigned in this order of priority: Māori, Pacific Peoples, Asian, and European/Other. So, if a person identifies as being Māori and New Zealand European, the person is counted as Māori. See <a href="/web/20211027072637/https://www.health.govt.nz/publication/hiso-100012017-ethnicity-data-protocols">Ethnicity Data Protocols</a> for further information.</p>
+
+<p>Ethnicity breakdown by DHB of residence is available in the downloadable spreadsheet at the bottom of the page.</p>
+
+<hr/>
+<h3><a id="by_age" name="age"></a>Cumulative vaccinations by age</h3>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">Age</th>
+			<th scope="col" style="text-align:right">First dose administered</th>
+			<th scope="col" style="text-align:right">First doses per 1,000 people</th>
+			<th scope="col" style="text-align:right">Fully vaccinated</th>
+			<th scope="col" style="text-align:right">Fully vaccinated per 1,000 people</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">12 - 19 years</th>
+			<td style="text-align:right">403,029</td>
+			<td style="text-align:right">802</td>
+			<td style="text-align:right">279,575</td>
+			<td style="text-align:right">557</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">20 - 34 years</th>
+			<td style="text-align:right">845,409</td>
+			<td style="text-align:right">817</td>
+			<td style="text-align:right">604,676</td>
+			<td style="text-align:right">585</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">35 - 49 years</th>
+			<td style="text-align:right">824,175</td>
+			<td style="text-align:right">862</td>
+			<td style="text-align:right">670,851</td>
+			<td style="text-align:right">701</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">50 - 64 years</th>
+			<td style="text-align:right">836,170</td>
+			<td style="text-align:right">901</td>
+			<td style="text-align:right">749,933</td>
+			<td style="text-align:right">809</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">65 and over</th>
+			<td style="text-align:right">749,187</td>
+			<td style="text-align:right">950</td>
+			<td style="text-align:right">713,795</td>
+			<td style="text-align:right">905</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total</strong></th>
+			<td style="text-align:right"><strong>3,657,970</strong></td>
+			<td style="text-align:right"><strong>869</strong></td>
+			<td style="text-align:right"><strong>3,018,830</strong></td>
+			<td style="text-align:right"><strong>717</strong></td>
+		</tr>
+	</tbody>
+</table>
+
+<p>Age breakdown by ethnicity and gender is available in the downloadable spreadsheet at the bottom of the page.</p>
+
+<hr/>
+<h3><a id="workforce" name="workforce"></a>Trained vaccinators and active vaccinators</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Trained vaccinators and active vaccinators" class="img-responsive" height="830" src="/web/20211027072637im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/workforce_12.png" width="1780"/></figure>
+
+<p><strong>Trained vaccinators</strong> are individuals who have completed the COVID-19 training. Many trained people are only able to offer a small number of hours to the COVID-19 vaccination programme.</p>
+
+<p><strong>Active vaccinators</strong> are trained individuals who are actively vaccinating. The number of active vaccinators does not reflect the hours worked vaccinating. For example, one vaccinator may work 40 hours in a week at one DHB and will show as 1 vaccinator in the headcount. In another DHB, 4 vaccinators may work 10 hours each (total 40 hours), but will show as 4 vaccinators in the headcount for that week.</p>
+
+<p>Both counts of trained and active vaccinators are cumulative. The difference between the two is due to a number of factors. This includes: individuals being trained in anticipation of future sites being opened (the largest factor); rostering; leave or non-availability; local health priorities; sites opening and closing.</p>
+
+<hr/>
+<h3><a id="usage" name="usage"></a>Wastage of vaccine stock</h3>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">&nbsp;</th>
+			<th scope="col">Wastage</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">New Zealand</th>
+			<td>0.29%</td>
+		</tr>
+	</tbody>
+</table>
+
+<p>Wastage is vials that have been reported as wasted since 13 July in the Inventory portal by DHBs or central warehouses divided by vials used over the same time frame.</p>
+
+<h3><a id="download" name="download"></a>Details of vaccination data</h3>
+
+<p>Download a spreadsheet containing key vaccination data. This includes HSU based population estimates for calculating vaccine uptake rates.</p>
+
+<p><a download="" href="/web/20211027072637/https://www.health.govt.nz/system/files/documents/pages/covid_vaccinations_26_10_2021.xlsx">COVID-19 vaccination data through 26 Oct 2021 (Excel, 363 KB)</a></p>
+
+<p>This spreadsheet is based on the information made available at the time of publishing and may be subject to changes. Please take note of any notes and caveats on each sheet.</p>
+
+<p>The below attachments provide some analysis on our progress on equity. The two PDF files are high level summaries of overall progress. The Excel documents are interactive and provides the ability to delve further into those overall numbers. NB: These Excel workbooks use features that are non-compatible with versions of MS Office 2016 and earlier.</p>
+
+<ul>
+	<li><a download="" href="/web/20211027072637/https://www.health.govt.nz/system/files/documents/pages/211024_-_cvip_equity_-_rate_ratios_by_ethnicity_ageband_and_dhb.pdf">Covid-19 Vaccine Rate Ratios by Ethnicity, Ageband and DHB (PDF, 642 KB)</a></li>
+	<li><a download="" href="/web/20211027072637/https://www.health.govt.nz/system/files/documents/pages/211024_-_cvip_equity_-_uptake_by_ethnicity_ageband_and_dhb.pdf">Covid-19 Vaccine Uptake by Ethnicity, Ageband and DHB (PDF, 550 KB)</a></li>
+	<li><a download="" href="/web/20211027072637/https://www.health.govt.nz/system/files/documents/pages/211024_-_cvip_equity_-_level_1_ethnicity_uptake_and_rate_ratios.xlsx">Covid-19 Vaccine Equity - Level 1 Ethnicity Uptake and Rate Ratios (Excel, 152 KB)</a></li>
+	<li><a download="" href="/web/20211027072637/https://www.health.govt.nz/system/files/documents/pages/211024_-_cvip_equity_-_level_2_ethnicity_uptake_and_rate_ratios.xlsx">Covid-19 Vaccine Equity - Level 2 Ethnicity Uptake and Rate Ratios (Excel, 378 KB)</a></li>
+	<li><a download="" href="/web/20211027072637/https://www.health.govt.nz/system/files/documents/pages/211024_-_cvip_equity_-_rate_ratios_and_uptake_over_time.xlsx">Rate Ratios and Uptake Over Time (Excel, 996 KB)</a></li>
+</ul>
+
+<hr/>
+<h3><a id="adverse-events" name="adverse-events"></a>Adverse events following&nbsp;immunisations (AEFI)</h3>
+
+<p>Like all medicines, the COVID-19 vaccine may cause side effects in some people. These are common, are usually mild, don&rsquo;t last long and won&rsquo;t stop people from having the second dose or going about daily life. Serious allergic reactions do occur but are extremely rare.</p>
+
+<p>Suspected AEFI to COVID-19 vaccines are reported to the <a href="https://web.archive.org/web/20211027072637/https://nzphvc.otago.ac.nz/">Centre for Adverse Reactions Monitoring</a> (CARM).&nbsp;<a href="https://web.archive.org/web/20211027072637/https://www.medsafe.govt.nz/">Medsafe</a> is closely monitoring the AEFI reported from the use of the COVID-19 vaccine and will report regularly on their findings.&nbsp;</p>
+
+<p><a href="https://web.archive.org/web/20211027072637/https://www.medsafe.govt.nz/COVID-19/vaccine-report-overview.asp">View Medsafe data on COVID-19 vaccine adverse effects following immunisation</a></p>
+</div></div></div>    </article>
+  </div>
+
+
+  </div>
+<div class="panel-pane pane-node-links even">
+
+
+
+  <div class="pane-content">
+          </div>
+
+
+  </div>
+
+<div class="panel-pane pane-views pane-sub-pages even">
+
+        <h2 class="pane-title h3">In this section</h2>
+
+
+  <div class="pane-content">
+        <div class="view view-sub-pages view-id-sub_pages view-display-id-block view-dom-id-57f64e67a1a31e02383a478bba22f935">
+
+
+
+      <div class="view-content">
+      <div class="item-list">    <ul>          <li class="views-row views-row-1 views-row-odd views-row-first">
+  <div class="views-field views-field-title">        <div class="field-content">
+<div class="views-field views-field-title">
+  <h3 class="field-content">
+    <a href="/web/20211027072637/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-across-nz">COVID-19 Vaccination uptake rates across NZ</a>  </h3>
+</div></div>  </div>
+  <span class="views-field views-field-body">        <span class="field-content">This page provides information related to uptake rates of the COVID-19 vaccine across the country.
+</span>  </span>
+  <span class="views-field views-field-view-node">        <span class="field-content"><a href="/web/20211027072637/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-across-nz">Read more</a></span>  </span></li>
+          <li class="views-row views-row-2 views-row-even">
+  <div class="views-field views-field-title">        <div class="field-content">
+<div class="views-field views-field-title">
+  <h3 class="field-content">
+    <a href="/web/20211027072637/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-maori-communities-across-nz">COVID-19 Vaccination uptake rates within Māori communities across NZ</a>  </h3>
+</div></div>  </div>
+  <span class="views-field views-field-body">        <span class="field-content">This page provides information related to uptake rates of the COVID-19 vaccine within Māori communities across New Zealand.
+</span>  </span>
+  <span class="views-field views-field-view-node">        <span class="field-content"><a href="/web/20211027072637/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-maori-communities-across-nz">Read more</a></span>  </span></li>
+          <li class="views-row views-row-3 views-row-odd views-row-last">
+  <div class="views-field views-field-title">        <div class="field-content">
+<div class="views-field views-field-title">
+  <h3 class="field-content">
+    <a href="/web/20211027072637/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-pacific-communities-across-nz">COVID-19 Vaccination uptake rates within Pacific communities across NZ</a>  </h3>
+</div></div>  </div>
+  <span class="views-field views-field-body">        <span class="field-content">This page provides information related to uptake rates of the COVID-19 vaccine within Pacific communities across New Zealand.
+</span>  </span>
+  <span class="views-field views-field-view-node">        <span class="field-content"><a href="/web/20211027072637/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-pacific-communities-across-nz">Read more</a></span>  </span></li>
+      </ul></div>    </div>
+
+
+
+
+
+
+</div>  </div>
+
+
+  </div>
+</div>          </div>
+
+  </div>
+
+</section>
+  </div>
+      </section>
+
+
+    </div>
+    <div id="content-footer-wrapper" class="clearfix">
+      <div id="content-footer" class="clearfix">
+                  <p class="page_updated">Page last updated: <span class="date">27 October 2021</span></p>                  <div class="region region-content-footer">
+    <section id="block-moh-tools-page-tools" class="block block-moh-tools clearfix">
+  <a href="#" data-placement="top" data-title="Share this content." data-html="true" data-content="<p>Share this page on some of the most popular social networking and content sites on the internet.</p><div class='service-links'><ul><li><a href='https://twitter.com/share?url=https%3A//www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data&amp;text=COVID-19%3A%20Vaccine%20data' title='Share this on Twitter' class='service-links-twitter' rel='nofollow'><img typeof='foaf:Image' class='img-responsive' src='https://www.health.govt.nz/sites/all/modules/contrib/service_links/images/twitter.png' alt='Twitter' /> Twitter</a></li>
+<li><a href='https://www.facebook.com/sharer.php?u=https%3A//www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data&amp;t=COVID-19%3A%20Vaccine%20data' title='Share on Facebook' class='service-links-facebook' rel='nofollow'><img typeof='foaf:Image' class='img-responsive' src='https://www.health.govt.nz/sites/all/modules/contrib/service_links/images/facebook.png' alt='Facebook' /> Facebook</a></li>
+</ul></div>" class="share-this-content"><i class="fa fa-share"></i> Share</a><a href="#" title="print this page" class="print"><i class="fa fa-print"></i> Print</a><a href="https://web.archive.org/web/20211027072637/https://www.health.govt.nz/forward?path=node/12052" title="Email this page" class="email"><i class="fa fa-envelope"></i> Email</a><a href="/web/20211027072637/https://www.health.govt.nz/feedback?ref=https%3A//www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="Feedback" class="rss"><i class="fa fa-comment"></i> Feedback</a></section>
+
+  </div>
+      </div>
+    </div>
+
+  </div>
+  <footer class="footer container">
+    <h2 class="hidden">Site Footer</h2>
+    <div class="footer-default">
+      <div class="row">
+        <div class="col-sm-6 col-md-6">
+          <div class="field field-name-field-tax-first-column-links">
+            <ul class="field-items"><li class="field-item"><a href="https://web.archive.org/web/20211027072637/https://www.health.govt.nz/node/492" class="">About this site</a></li><li class="field-item"><a href="https://web.archive.org/web/20211027072637/https://www.health.govt.nz/node/524" class="">Contact us</a></li><li class="field-item"><a href="https://web.archive.org/web/20211027072637/https://www.health.govt.nz/node/488" class="">Other Ministry of Health websites</a></li><li class="field-item"><a href="https://web.archive.org/web/20211027072637/https://www.health.govt.nz/node/7497" class="">Official Information Act requests</a></li><li class="field-item"><a href="https://web.archive.org/web/20211027072637/https://www.health.govt.nz/about-ministry/information-releases" class="">Information releases</a></li><li class="field-item"><a href="https://web.archive.org/web/20211027072637/https://consult.health.govt.nz/" class="">Consultations</a></li></ul>
+          </div>
+        </div>
+        <div class="col-sm-6 col-md-6">
+          <div class="field field-name-field-tax-footer-body field-type-text-long field-label-hidden"><div class="field-items"><div class="field-item even"><h3>Where to go for help</h3>
+
+<table>
+	<tbody>
+		<tr>
+			<th scope="row">Emergencies</th>
+			<td><strong>Dial <a href="tel:111">111</a></strong> (for ambulance, fire or police)</td>
+		</tr>
+		<tr>
+			<th scope="row">Healthline</th>
+			<td><strong>Dial <a href="tel:0800611116">0800 611 116</a></strong></td>
+		</tr>
+		<tr>
+			<th scope="row">Poisons</th>
+			<td><strong>Dial <a href="tel:0800764766">0800 POISON</a> </strong>(<a href="tel:0800764766">0800 764 766</a>)</td>
+		</tr>
+		<tr>
+			<th scope="row">Mental health crisis</th>
+			<td><strong><a href="/web/20211027072637/https://www.health.govt.nz/your-health/services-and-support/health-care-services/mental-health-services/crisis-assessment-teams">Emergency contact numbers</a></strong></td>
+		</tr>
+	</tbody>
+</table>
+</div></div></div>        </div>
+      </div>
+      <div class="row">
+        <div class="sub-footer">
+          <div class="column col-sm-12 col-md-3">
+            <a href="https://web.archive.org/web/20211027072637/https://www.govt.nz/">
+              <img src="/web/20211027072637im_/https://www.health.govt.nz/sites/all/themes/mohpub_bootstrap/images/nzgovtlogo_white.png" width="152" height="16" alt="govt.nz - connecting you to New Zealand central &amp; local government services" title="govt.nz - connecting you to New Zealand central &amp; local government services"/>
+            </a>
+          </div>
+          <div class="column col-sm-12 col-md-9">
+          <span class="bottom-menu-moh with-v-divider">&copy; Ministry of Health – Manatū Hauora</span><ul class="bottom-menu-list"><li class="bottom-menu-list-item with-v-divider"><a href="https://web.archive.org/web/20211027072637/https://www.health.govt.nz/sitemap" class="">Site map</a></li><li class="bottom-menu-list-item with-v-divider"><a href="https://web.archive.org/web/20211027072637/https://www.health.govt.nz/about-site/privacy-and-security" class="">Privacy &amp; security</a></li><li class="bottom-menu-list-item with-v-divider"><a href="https://web.archive.org/web/20211027072637/https://www.health.govt.nz/about-site/copyright" class="">Copyright</a></li></ul>          </div>
+        </div>
+      </div>
+    </div>
+    <div class="footer-print">&copy; Ministry of Health – Manatū Hauora</div>
+  </footer>
+  <a class="scrollToTop">Back to top <i class="fas fa-arrow-up"></i></a>
+</div>
+  <script src="https://web.archive.org/web/20211027072637js_/https://www.health.govt.nz/sites/default/files/js/js_akZOsKtodu3PdnQzY3_ElOfujkLxJcowmaWgHTBBLOE.js"></script>
+</body>
+</html>
+<!--
+     FILE ARCHIVED ON 07:26:37 Oct 27, 2021 AND RETRIEVED FROM THE
+     INTERNET ARCHIVE ON 03:22:50 Nov 07, 2021.
+     JAVASCRIPT APPENDED BY WAYBACK MACHINE, COPYRIGHT INTERNET ARCHIVE.
+
+     ALL OTHER CONTENT MAY ALSO BE PROTECTED BY COPYRIGHT (17 U.S.C.
+     SECTION 108(a)(3)).
+-->
+<!--
+playback timings (ms):
+  captures_list: 725.841
+  exclusion.robots: 0.166
+  exclusion.robots.policy: 0.16
+  RedisCDXSource: 54.786
+  esindex: 0.009
+  LoadShardBlock: 634.193 (3)
+  PetaboxLoader3.datanode: 649.309 (4)
+  CDXLines.iter: 24.434 (3)
+  load_resource: 181.729
+  PetaboxLoader3.resolve: 66.257
+-->

--- a/data/rawSite/2021-10-27.html
+++ b/data/rawSite/2021-10-27.html
@@ -1,0 +1,2519 @@
+
+<!DOCTYPE html>
+<html lang="en" dir="ltr" prefix="" class="no-js">
+<head><script src="//archive.org/includes/analytics.js?v=cf34f82" type="text/javascript"></script>
+<script type="text/javascript">window.addEventListener('DOMContentLoaded',function(){var v=archive_analytics.values;v.service='wb';v.server_name='wwwb-app226.us.archive.org';v.server_ms=212;archive_analytics.send_pageview({});});</script>
+<script type="text/javascript" src="/_static/js/bundle-playback.js?v=UfTkgsKx" charset="utf-8"></script>
+<script type="text/javascript" src="/_static/js/wombat.js?v=UHAOicsW" charset="utf-8"></script>
+<script type="text/javascript">
+  __wm.init("https://web.archive.org/web");
+  __wm.wombat("https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data","20211028090127","https://web.archive.org/","web","/_static/",
+	      "1635411687");
+</script>
+<link rel="stylesheet" type="text/css" href="/_static/css/banner-styles.css?v=omkqRugM" />
+<link rel="stylesheet" type="text/css" href="/_static/css/iconochive.css?v=qtvMKcIJ" />
+<!-- End Wayback Rewrite JS Include -->
+
+  <!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta name="format-detection" content="telephone=no"/>
+  <link rel="profile" href="http://www.w3.org/1999/xhtml/vocab"/>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+<link rel="shortcut icon" href="https://web.archive.org/web/20211028090127im_/https://www.health.govt.nz/sites/all/themes/mohpub_bootstrap/favicon.ico" type="image/vnd.microsoft.icon"/>
+<meta name="description" content="Dashboard of data and statistics about the rollout of COVID-19 vaccines in New Zealand"/>
+<meta name="generator" content="Drupal 7 (https://www.drupal.org)"/>
+<link rel="canonical" href="https://web.archive.org/web/20211028090127/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data"/>
+<link rel="shortlink" href="https://web.archive.org/web/20211028090127/https://www.health.govt.nz/node/12052"/>
+<meta property="og:site_name" content="Ministry of Health NZ"/>
+<meta property="og:type" content="article"/>
+<meta property="og:url" content="https://web.archive.org/web/20211028090127/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data"/>
+<meta property="og:title" content="COVID-19: Vaccine data"/>
+<meta property="og:description" content="Dashboard of data and statistics about the rollout of COVID-19 vaccines in New Zealand"/>
+  <title>COVID-19: Vaccine data | Ministry of Health NZ</title>
+  <link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211028090127cs_/https://www.health.govt.nz/sites/default/files/css/css_lQaZfjVpwP_oGNqdtWCSpJT1EMqXdMiU84ekLLxQnc4.css" media="all"/>
+<link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211028090127cs_/https://www.health.govt.nz/sites/default/files/css/css_jqUBpWfMaxMiP7LismdZVlyVv8azUJSE2yaH58nj0cE.css" media="all"/>
+<link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211028090127cs_/https://www.health.govt.nz/sites/default/files/css/css_Rb1wqFBC8VXCJC-BuNY53cvjjlj6UADGvqzo_f-1yN0.css" media="all"/>
+<link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211028090127cs_/https://www.health.govt.nz/sites/default/files/css/css_38_K1lHKg-98m4KKRfv57JBK0gvlKscexGt9MKoi0DE.css" media="all"/>
+<link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211028090127cs_/https://www.health.govt.nz/sites/default/files/css/css_r7NPyvpdYfAyZmk9zkK8OaFKEFj6er5ZJnam2H644DM.css" media="print"/>
+  <link rel="alternate stylesheet" type="text/css" href="/web/20211028090127cs_/https://www.health.govt.nz/sites/all/themes/mohpub_bootstrap/css/high-contrast.css" media="screen" title="High Contrast"/>
+  <script src="https://web.archive.org/web/20211028090127js_/https://www.health.govt.nz/sites/default/files/js/js_zS-CmNFGyegtLYJmqFRpxQvvQrfPIFrOMq_3T3C8sZE.js"></script>
+<script src="https://web.archive.org/web/20211028090127js_/https://www.health.govt.nz/sites/default/files/js/js_fNgZ4Okisfr70Q0yvAYsATgB0o_jD3-srhQQ-VHmlXE.js"></script>
+<script src="https://web.archive.org/web/20211028090127js_/https://www.health.govt.nz/sites/default/files/js/js_YAdPZfg12M1m7ROp3_gVJPS5sArqL0kYQgNRPoicvHE.js"></script>
+<script>(function(i,s,o,g,r,a,m){i["GoogleAnalyticsObject"]=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,"script","https://web.archive.org/web/20211028090127/https://www.google-analytics.com/analytics.js","ga");ga("create", "UA-3573389-24", {"cookieDomain":".www.health.govt.nz","siteSpeedSampleRate":15});ga("send", "pageview");</script>
+<script src="https://web.archive.org/web/20211028090127js_/https://www.health.govt.nz/sites/default/files/js/js_QAXZNPwLISRLHqyNpT4Vvr_iqD9foD6GTbEjlhIIjeo.js"></script>
+<script src="https://web.archive.org/web/20211028090127js_/https://www.health.govt.nz/sites/default/files/js/js_4VW9edmu3V8VjGJxFfXGAwkXeW2cJIa5h-6y7SgwVrk.js"></script>
+<script>    (function(h,o,t,j,a,r){
+        h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
+        h._hjSettings={hjid:930919,hjsv:6};
+        a=o.getElementsByTagName('head')[0];
+        r=o.createElement('script');r.async=1;
+        r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+        a.appendChild(r);
+    })(window,document,'https://web.archive.org/web/20211028090127/https://static.hotjar.com/c/hotjar-','.js?sv=');
+</script>
+<script>jQuery.extend(Drupal.settings, {"basePath":"\/","pathPrefix":"","ajaxPageState":{"theme":"mohpub_bootstrap","theme_token":"tDWKIGJ2VadhTxnk-cgWUVne8j1e5jv8jPAlmPqEXXE","js":{"sites\/all\/modules\/custom\/table_d3chart\/js\/table_d3chart.js":1,"sites\/all\/modules\/custom\/moh_d3\/moh_d3.js":1,"sites\/all\/modules\/contrib\/jquery_update\/replace\/jquery\/1.7\/jquery.min.js":1,"misc\/jquery-extend-3.4.0.js":1,"misc\/jquery-html-prefilter-3.5.0-backport.js":1,"misc\/jquery.once.js":1,"misc\/drupal.js":1,"sites\/all\/modules\/contrib\/ckeditor_accordion\/js\/ckeditor-accordion.js":1,"sites\/all\/modules\/contrib\/extlink\/extlink.js":1,"modules\/field\/modules\/text\/text.js":1,"sites\/all\/modules\/contrib\/field_group\/field_group.js":1,"sites\/all\/modules\/contrib\/google_analytics\/googleanalytics.js":1,"0":1,"sites\/all\/libraries\/c3\/c3.js":1,"sites\/all\/libraries\/d3\/d3.min.js":1,"sites\/all\/modules\/contrib\/d3\/js\/d3.js":1,"sites\/all\/libraries\/d3.helpers\/d3.helpers.js":1,"sites\/all\/libraries\/d3.c3\/d3-c3.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/assets\/ios-fix.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/affix.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/alert.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/button.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/carousel.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/collapse.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/dropdown.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/modal.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/tooltip.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/popover.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/scrollspy.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/tab.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/transition.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/jquery.cookie.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/jquery.moh.announcement.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/svgeezy.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/fitvids.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/bootstrap-tabcollapse.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/jquery.scrollTo.min.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/script.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/jquery.google_analytics.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/bootstrap-accessibility.min.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/style-switcher.js":1,"1":1},"css":{"modules\/system\/system.base.css":1,"sites\/all\/modules\/contrib\/calendar\/css\/calendar_multiday.css":1,"sites\/all\/modules\/contrib\/ckeditor_accordion\/css\/ckeditor-accordion.css":1,"modules\/field\/theme\/field.css":1,"modules\/node\/node.css":1,"sites\/all\/modules\/contrib\/extlink\/extlink.css":1,"sites\/all\/modules\/contrib\/views\/css\/views.css":1,"sites\/all\/modules\/contrib\/ckeditor\/css\/ckeditor.css":1,"sites\/all\/modules\/contrib\/ctools\/css\/ctools.css":1,"sites\/all\/modules\/contrib\/panels\/css\/panels.css":1,"sites\/all\/libraries\/c3\/c3.css":1,"sites\/all\/libraries\/d3.c3\/d3-c3.css":1,"sites\/all\/themes\/mohpub_bootstrap\/fontawesome\/css\/fontawesome.min.css":1,"sites\/all\/themes\/mohpub_bootstrap\/fontawesome\/css\/solid.min.css":1,"sites\/all\/themes\/mohpub_bootstrap\/fontawesome\/css\/brands.min.css":1,"sites\/all\/modules\/features\/site_profile\/css\/fix-rubik-multiselect-height.css":1,"sites\/all\/themes\/mohpub_bootstrap\/css\/style.css":1,"sites\/all\/themes\/mohpub_bootstrap\/css\/responsive-tables.css":1,"sites\/all\/themes\/mohpub_bootstrap\/css\/print.css":1}},"field_group":{"div":"full"},"ckeditor_accordion":{"collapseAll":1},"extlink":{"extTarget":0,"extClass":"ext","extLabel":"(link is external)","extImgClass":0,"extIconPlacement":"append","extSubdomains":0,"extExclude":"","extInclude":"","extCssExclude":"","extCssExplicit":"","extAlert":0,"extAlertText":"This link will take you to an external web site. We are not responsible for their content.","mailtoClass":"mailto","mailtoLabel":"(link sends e-mail)"},"googleanalytics":{"trackOutbound":1,"trackMailto":1,"trackDownload":1,"trackDownloadExtensions":"7z|aac|arc|arj|asf|asx|avi|bin|csv|doc|exe|flv|gif|gz|gzip|hqx|jar|jpe?g|js|mp(2|3|4|e?g)|mov(ie)?|msi|msp|pdf|phps|png|ppt|qtm?|ra(m|r)?|sea|sit|tar|tgz|torrent|txt|wav|wma|wmv|wpd|xls|xml|z|zip|docx|xlsx|pptx|pptm|ppsx|ppsm|epub"},"mohD3":{"C3Types":["line","spline","step","area","area-spline","area-step","bar","scatter","pie","donut","gauge"],"graphRender":"line","graphLegend":true,"graphDefaultColors":"#2b8cbe, #abdda4, #7f7f7f, #92cddc, #dc8b0c","graphDefaultGroupedTooltip":0,"graphDefaultGridX":0,"graphDefaultGridY":0,"graphDefaultLegendPosition":"top-right","graphDefaultTooltip":1,"graphDefaultDataLabel":0,"graphLegendStep":"5","graphInteraction":true,"graphTypes":"","graphXaxisShow":true,"graphXaxisLabel":"","graphYaxisLabel":"","graphXaxisType":"category","graphXaxisCentered":false,"graphXaxisRotation":"","graphXaxisHeight":"","graphYaxisShow":true,"graphYaxisMax":"","graphYaxisMin":"","graphYaxisInverted":false,"graphYaxisCenter":"","graphYaxisPrefix":"","graphYaxisSuffix":"","graphYaxisPosition":"","graphY2axisShow":false,"graphY2axisSource":"","graphY2axisMax":"","graphY2axisMin":"","graphGroups":"","graphRotated":false,"graphIgnoreEmpty":false,"graphLineDot":true,"graphBarRatio":"0.9","graphDot":true,"graphDotR":"2.5","graphFocus":false},"tableD3":{"show":"View table data source","hide":"Hide table data source"},"urlIsAjaxTrusted":{"\/our-work\/diseases-and-conditions\/covid-19-novel-coronavirus\/covid-19-data-and-statistics\/covid-19-vaccine-data":true},"bootstrap":{"anchorsFix":1,"anchorsSmoothScrolling":1,"formHasError":1,"popoverEnabled":1,"popoverOptions":{"animation":1,"html":0,"placement":"right","selector":"","trigger":"click","triggerAutoclose":1,"title":"","content":"","delay":0,"container":"body"},"tooltipEnabled":1,"tooltipOptions":{"animation":1,"html":0,"placement":"auto left","selector":"","trigger":"hover focus","delay":0,"container":"body"}}});</script>
+  <!-- HTML5 element support for IE6-8 -->
+  <!--[if lt IE 9]>
+    <script src="/sites/all/themes/mohpub_bootstrap/js/assets/html5shiv.js"></script>
+    <script src="/sites/all/themes/mohpub_bootstrap/js/assets/respond.min.js"></script>
+  <![endif]-->
+</head>
+<body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-12052 node-type-page node-has-intro"><!-- BEGIN WAYBACK TOOLBAR INSERT -->
+<style type="text/css">
+body {
+  margin-top:0 !important;
+  padding-top:0 !important;
+  /*min-width:800px !important;*/
+}
+</style>
+<script>__wm.rw(0);</script>
+<div id="wm-ipp-base" lang="en" style="display:none;direction:ltr;">
+<div id="wm-ipp" style="position:fixed;left:0;top:0;right:0;">
+<div id="wm-ipp-inside">
+  <div style="position:relative;">
+    <div id="wm-logo" style="float:left;width:110px;padding-top:12px;">
+      <a href="/web/" title="Wayback Machine home page"><img src="/_static/images/toolbar/wayback-toolbar-logo-200.png" srcset="/_static/images/toolbar/wayback-toolbar-logo-100.png, /_static/images/toolbar/wayback-toolbar-logo-150.png 1.5x, /_static/images/toolbar/wayback-toolbar-logo-200.png 2x" alt="Wayback Machine" style="width:100px" border="0" /></a>
+    </div>
+    <div class="r" style="float:right;">
+      <div id="wm-btns" style="text-align:right;height:25px;">
+                  <div id="wm-save-snapshot-success">success</div>
+          <div id="wm-save-snapshot-fail">fail</div>
+          <a id="wm-save-snapshot-open" href="#"
+	     title="Share via My Web Archive" >
+            <span class="iconochive-web"></span>
+          </a>
+          <a href="https://archive.org/account/login.php"
+             title="Sign In"
+             id="wm-sign-in"
+          >
+            <span class="iconochive-person"></span>
+          </a>
+          <span id="wm-save-snapshot-in-progress" class="iconochive-web"></span>
+        	<a href="http://faq.web.archive.org/" title="Get some help using the Wayback Machine" style="top:-6px;"><span class="iconochive-question" style="color:rgb(87,186,244);font-size:160%;"></span></a>
+	<a id="wm-tb-close" href="#close" onclick="__wm.h(event);return false;" style="top:-2px;" title="Close the toolbar"><span class="iconochive-remove-circle" style="color:#888888;font-size:240%;"></span></a>
+      </div>
+      <div id="wm-share">
+          <a href="/web/20211028090127/http://web.archive.org/screenshot/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data"
+             id="wm-screenshot"
+             title="screenshot">
+            <span class="wm-icon-screen-shot"></span>
+          </a>
+          <a href="#"
+            id="wm-video"
+            title="video">
+            <span class="iconochive-movies"></span>
+          </a>
+	<a id="wm-share-facebook" href="#" data-url="https://web.archive.org/web/20211028090127/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="Share on Facebook" style="margin-right:5px;" target="_blank"><span class="iconochive-facebook" style="color:#3b5998;font-size:160%;"></span></a>
+	<a id="wm-share-twitter" href="#" data-url="https://web.archive.org/web/20211028090127/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="Share on Twitter" style="margin-right:5px;" target="_blank"><span class="iconochive-twitter" style="color:#1dcaff;font-size:160%;"></span></a>
+      </div>
+    </div>
+    <table class="c" style="">
+      <tbody>
+	<tr>
+	  <td class="u" colspan="2">
+	    <form target="_top" method="get" action="/web/submit" name="wmtb" id="wmtb"><input type="text" name="url" id="wmtbURL" value="https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" onfocus="this.focus();this.select();" /><input type="hidden" name="type" value="replay" /><input type="hidden" name="date" value="20211028090127" /><input type="submit" value="Go" /></form>
+	  </td>
+	  <td class="n" rowspan="2" style="width:110px;">
+	    <table>
+	      <tbody>
+		<!-- NEXT/PREV MONTH NAV AND MONTH INDICATOR -->
+		<tr class="m">
+		  <td class="b" nowrap="nowrap"><a href="https://web.archive.org/web/20210928043511/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="28 Sep 2021"><strong>Sep</strong></a></td>
+		  <td class="c" id="displayMonthEl" title="You are here: 09:01:27 Oct 28, 2021">OCT</td>
+		  <td class="f" nowrap="nowrap">Nov</td>
+		</tr>
+		<!-- NEXT/PREV CAPTURE NAV AND DAY OF MONTH INDICATOR -->
+		<tr class="d">
+		  <td class="b" nowrap="nowrap"><a href="https://web.archive.org/web/20211027072637/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="07:26:37 Oct 27, 2021"><img src="/_static/images/toolbar/wm_tb_prv_on.png" alt="Previous capture" width="14" height="16" border="0" /></a></td>
+		  <td class="c" id="displayDayEl" style="width:34px;font-size:24px;white-space:nowrap;" title="You are here: 09:01:27 Oct 28, 2021">28</td>
+		  <td class="f" nowrap="nowrap"><a href="https://web.archive.org/web/20211029114420/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="11:44:20 Oct 29, 2021"><img src="/_static/images/toolbar/wm_tb_nxt_on.png" alt="Next capture" width="14" height="16" border="0" /></a></td>
+		</tr>
+		<!-- NEXT/PREV YEAR NAV AND YEAR INDICATOR -->
+		<tr class="y">
+		  <td class="b" nowrap="nowrap">2020</td>
+		  <td class="c" id="displayYearEl" title="You are here: 09:01:27 Oct 28, 2021">2021</td>
+		  <td class="f" nowrap="nowrap">2022</td>
+		</tr>
+	      </tbody>
+	    </table>
+	  </td>
+	</tr>
+	<tr>
+	  <td class="s">
+	    	    <div id="wm-nav-captures">
+	      	      <a class="t" href="/web/20211028090127*/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="See a list of every capture for this URL">682 captures</a>
+	      <div class="r" title="Timespan for captures of this URL">07 Apr 2021 - 06 Nov 2021</div>
+	      </div>
+	  </td>
+	  <td class="k">
+	    <a href="" id="wm-graph-anchor">
+	      <div id="wm-ipp-sparkline" title="Explore captures for this URL" style="position: relative">
+		<canvas id="wm-sparkline-canvas" width="650" height="27" border="0"></canvas>
+	      </div>
+	    </a>
+	  </td>
+	</tr>
+      </tbody>
+    </table>
+    <div style="position:absolute;bottom:0;right:2px;text-align:right;">
+      <a id="wm-expand" class="wm-btn wm-closed" href="#expand" onclick="__wm.ex(event);return false;"><span id="wm-expand-icon" class="iconochive-down-solid"></span> <span style="font-size:80%">About this capture</span></a>
+    </div>
+  </div>
+    <div id="wm-capinfo" style="border-top:1px solid #777;display:none; overflow: hidden">
+                    <div id="wm-capinfo-collected-by">
+    <div style="background-color:#666;color:#fff;font-weight:bold;text-align:center">COLLECTED BY</div>
+    <div style="padding:3px;position:relative" id="wm-collected-by-content">
+            <div style="display:inline-block;vertical-align:top;width:50%;">
+			<span class="c-logo" style="background-image:url(https://archive.org/services/img/focused_crawls);"></span>
+		Organization: <a style="color:#33f;" href="https://archive.org/details/focused_crawls" target="_new"><span class="wm-title">Internet Archive</span></a>
+		<div style="max-height:75px;overflow:hidden;position:relative;">
+	  <div style="position:absolute;top:0;left:0;width:100%;height:75px;background:linear-gradient(to bottom,rgba(255,255,255,0) 0%,rgba(255,255,255,0) 90%,rgba(255,255,255,255) 100%);"></div>
+	  Focused crawls are collections of frequently-updated webcrawl data from narrow (as opposed to broad or wide) web crawls, often focused on a single domain or subdomain.<br />
+	</div>
+	      </div>
+      <div style="display:inline-block;vertical-align:top;width:49%;">
+			<span class="c-logo" style="background-image:url(https://archive.org/services/img/abc.net.au-news)"></span>
+		<div>Collection: <a style="color:#33f;" href="https://archive.org/details/abc.net.au-news" target="_new"><span class="wm-title">abc.net.au-news</span></a></div>
+	      </div>
+    </div>
+    </div>
+    <div id="wm-capinfo-timestamps">
+    <div style="background-color:#666;color:#fff;font-weight:bold;text-align:center" title="Timestamps for the elements of this page">TIMESTAMPS</div>
+    <div>
+      <div id="wm-capresources" style="margin:0 5px 5px 5px;max-height:250px;overflow-y:scroll !important"></div>
+      <div id="wm-capresources-loading" style="text-align:left;margin:0 20px 5px 5px;display:none"><img src="/_static/images/loading.gif" alt="loading" /></div>
+    </div>
+    </div>
+  </div></div></div></div><div id="wm-ipp-print">The Wayback Machine - https://web.archive.org/web/20211028090127/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data</div>
+<div id="donato" style="position:relative;width:100%;">
+  <div id="donato-base">
+    <iframe id="donato-if" src="https://archive.org/includes/donate.php?as_page=1&amp;platform=wb&amp;referer=https%3A//web.archive.org/web/20211028090127/https%3A//www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data"
+	    scrolling="no" frameborder="0" style="width:100%; height:100%">
+    </iframe>
+  </div>
+</div><script type="text/javascript">
+__wm.bt(650,27,25,2,"web","https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data","20211028090127",1996,"/_static/",["/_static/css/banner-styles.css?v=omkqRugM","/_static/css/iconochive.css?v=qtvMKcIJ"], "False");
+  __wm.rw(1);
+</script>
+<!-- END WAYBACK TOOLBAR INSERT -->
+<!--googleoff: all-->
+  <div id="skip-link">
+    <a href="#skip-content" id="skipper" class="element-invisible element-focusable">Skip to main content</a>
+  </div>
+    <div id="page">
+  <header id="navbar" role="banner" class="navbar container navbar-default">
+          <ul class="menu nav navbar-nav secondary"><li class="first leaf jobs depth-1"><a href="https://web.archive.org/web/20211028090127/https://careers.health.govt.nz/" title="">Jobs</a></li>
+<li class="leaf news depth-1"><a href="/web/20211028090127/https://www.health.govt.nz/news-media" data-is-top-level="0" title="">News</a></li>
+<li class="leaf contact-us depth-1"><a href="/web/20211028090127/https://www.health.govt.nz/about-ministry/contact-us" title="">Contact us</a></li>
+<li class="leaf facebook depth-1"><a href="https://web.archive.org/web/20211028090127/https://www.facebook.com/minhealthnz/">Facebook</a></li>
+<li class="leaf twitter depth-1"><a href="https://web.archive.org/web/20211028090127/https://twitter.com/minhealthnz" data-is-top-level="0" title="">Twitter</a></li>
+<li class="last leaf youtube depth-1"><a href="https://web.archive.org/web/20211028090127/https://www.youtube.com/user/minhealthnz" data-is-top-level="0" title="">Youtube</a></li>
+</ul>        <div class="container">
+      <div class="navbar-header">
+                <a class="logo navbar-btn pull-left" href="/web/20211028090127/https://www.health.govt.nz/" title="Home">
+          <img src="/web/20211028090127im_/https://www.health.govt.nz/sites/all/themes/mohpub_bootstrap/images/mohlogo.svg" alt="Ministry of Health"/>
+        </a>
+                  <div class="region region-header-top">
+    <section id="block-apachesolr-panels-search-form" class="block block-apachesolr-panels clearfix">
+
+
+  <form action="/web/20211028090127/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" method="post" id="apachesolr-panels-search-block" accept-charset="UTF-8"><div><div class="form-item form-item-apachesolr-panels-search-form form-type-textfield form-group"> <label class="control-label" for="edit-apachesolr-panels-search-form">Search</label>
+<input title="Enter the terms you wish to search for." class="form-control form-text" type="text" id="edit-apachesolr-panels-search-form" name="apachesolr_panels_search_form" value="" size="15" maxlength="128"/></div><input type="hidden" name="form_build_id" value="form-rmoCSlrG9FF4jkDMn2oq3NZtm1ey61rNx4Sfwkvlwzw"/>
+<input type="hidden" name="form_id" value="apachesolr_panels_search_block"/>
+<div class="form-actions form-wrapper form-group" id="edit-actions"><button type="submit" id="edit-submit" name="op" value="Search" class="btn btn-primary form-submit">Search</button>
+</div></div></form>
+</section>
+  </div>
+        <!-- .btn-navbar is used as the toggle for collapsed navbar content -->
+        <button aria-expanded="false" aria-controls="megamenu" type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+                    <span class="menu-text">Menu</span><span class="sr-only">Toggle navigation</span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+
+        </button>
+      </div>
+
+              <div class="navbar-collapse collapse">
+          <nav id="megamenu" role="navigation">
+                          <h2 class="element-invisible">Main menu</h2><ul id="main-menu" class="menu nav navbar-nav yamm navbar"><li class="first dropdown"><a href="/web/20211028090127/https://www.health.govt.nz/your-health" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="megamenu-dropdown-780">Your health <b class="caret"></b></a>
+    <div id="megamenu-dropdown-780" class="dropdown-menu">
+    <div class="yamm-content">
+      <div class="row">
+                            <div class="col">
+            <h3><a href="/web/20211028090127/https://www.health.govt.nz/your-health/conditions-and-treatments?mega=Your%20health&amp;title=Conditions%20%26%20treatments" class="menu-header">Conditions &amp; treatments</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211028090127/https://www.health.govt.nz/your-health/conditions-and-treatments/mental-health/depression?mega=Your%20health&amp;title=Depression">Depression</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/diabetes?mega=Your%20health&amp;title=Diabetes">Diabetes</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/influenza?mega=Your%20health&amp;title=Influenza">Influenza</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/measles?mega=Your%20health&amp;title=Measles">Measles</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/meningococcal-disease-including-meningitis?mega=Your%20health&amp;title=Meningococcal%20disease">Meningococcal disease</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/mumps?mega=Your%20health&amp;title=Mumps">Mumps</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/respiratory-syncytial-virus-rsv?mega=Your%20health&amp;title=RSV">RSV</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/sore-throat?mega=Your%20health&amp;title=Sore%20throat">Sore throat</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/your-health/conditions-and-treatments?mega=Your%20health&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211028090127/https://www.health.govt.nz/your-health/healthy-living?mega=Your%20health&amp;title=Healthy%20living" class="menu-header">Healthy living</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211028090127/https://www.health.govt.nz/your-health/healthy-living/drinking-water?mega=Your%20health&amp;title=Drinking-water">Drinking-water</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/your-health/healthy-living/food-activity-and-sleep/green-prescriptions?mega=Your%20health&amp;title=Green%20Prescriptions">Green Prescriptions</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/your-health/healthy-living/food-activity-and-sleep/healthy-eating?mega=Your%20health&amp;title=Healthy%20eating">Healthy eating</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/your-health/healthy-living/immunisation?mega=Your%20health&amp;title=Immunisation">Immunisation</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/your-health/healthy-living/food-activity-and-sleep/physical-activity?mega=Your%20health&amp;title=Physical%20activity">Physical activity</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/your-health/healthy-living/addictions/quitting-smoking?mega=Your%20health&amp;title=Smoking">Smoking</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/your-health/healthy-living/teeth-and-gums?mega=Your%20health&amp;title=Teeth%20and%20gums">Teeth and gums</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/your-health/healthy-living?mega=Your%20health&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211028090127/https://www.health.govt.nz/your-health/pregnancy-and-kids?mega=Your%20health&amp;title=Pregnancy%20and%20kids" class="menu-header">Pregnancy and kids</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211028090127/https://www.health.govt.nz/your-health/pregnancy-and-kids/birth-and-afterwards?mega=Your%20health&amp;title=Birth%20and%20afterwards">Birth and afterwards</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/your-health/pregnancy-and-kids/first-year/helpful-advice-during-first-year/breastfeeding-perfect-you-and-your-baby?mega=Your%20health&amp;title=Breastfeeding">Breastfeeding</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/your-health/pregnancy-and-kids/pregnancy?mega=Your%20health&amp;title=Pregnancy">Pregnancy</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/your-health/pregnancy-and-kids/services-and-support-during-pregnancy?mega=Your%20health&amp;title=Services%20and%20support%20during%20pregnancy">Services and support during pregnancy</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/your-health/pregnancy-and-kids/services-and-support-you-and-your-child?mega=Your%20health&amp;title=Services%20and%20support%20for%20you%20and%20your%20child">Services and support for you and your child</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/your-health/pregnancy-and-kids/first-year?mega=Your%20health&amp;title=The%20first%20year">The first year</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/your-health/pregnancy-and-kids/under-fives?mega=Your%20health&amp;title=Under%20fives">Under fives</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/your-health/pregnancy-and-kids?mega=Your%20health&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211028090127/https://www.health.govt.nz/your-health/services-and-support?mega=Your%20health&amp;title=Services%20and%20support" class="menu-header">Services &amp; support</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211028090127/https://www.health.govt.nz/your-health/services-and-support/health-care-services/help-alcohol-and-drug-problems?mega=Your%20health&amp;title=Alcohol%20and%20drugs">Alcohol and drugs</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/your-health/services-and-support/disability-services?mega=Your%20health&amp;title=Disability%20services">Disability services</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/your-health/services-and-support/health-care-services/earthquake-support-line?mega=Your%20health&amp;title=Earthquake%20Support%20Line">Earthquake Support Line</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/your-health/services-and-support/health-care-services/healthline?mega=Your%20health&amp;title=Healthline">Healthline</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/your-health/services-and-support/health-care-services/mental-health-services?mega=Your%20health&amp;title=Mental%20health%20services">Mental health services</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/your-health/services-and-support/health-care-services/maori-health-provider-directory?mega=Your%20health&amp;title=M%C4%81ori%20health%20providers">Māori health providers</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/your-health/services-and-support/health-care-services/services-older-people/rest-home-certification-and-audits?mega=Your%20health&amp;title=Rest%20home%20certification">Rest home certification</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/your-health/services-and-support/health-care-services/hospitals-and-specialist-services/travel-assistance?mega=Your%20health&amp;title=Travel%20assistance">Travel assistance</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/your-health/services-and-support?mega=Your%20health&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                        </div>
+    </div>
+    <div class="feature-links">
+      <h3 class="sr-only">Other related resources</h3>
+      <a href="/web/20211028090127/https://www.health.govt.nz/your-health/full-a-z?mega=Your%20health&amp;title=A-Z">View the full A-Z</a>    </div>
+  </div>
+</li>
+<li class="dropdown"><a href="/web/20211028090127/https://www.health.govt.nz/new-zealand-health-system" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="megamenu-dropdown-6076">NZ health system <b class="caret"></b></a>
+    <div id="megamenu-dropdown-6076" class="dropdown-menu">
+    <div class="yamm-content">
+      <div class="row">
+                            <div class="col">
+            <h3><a href="/web/20211028090127/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people?mega=NZ%20health%20system&amp;title=Key%20organisations" class="menu-header">Key organisations</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211028090127/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/crown-entities-and-statutory-boards?mega=NZ%20health%20system&amp;title=Crown%20entities%20%26%20agencies">Crown entities &amp; agencies</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/district-health-boards?mega=NZ%20health%20system&amp;title=District%20health%20boards">District health boards</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/non-governmental-organisations?mega=NZ%20health%20system&amp;title=Non-governmental%20organisations">Non-governmental organisations</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/primary-health-organisations?mega=NZ%20health%20system&amp;title=Primary%20health%20organisations">Primary health organisations</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/public-health-units?mega=NZ%20health%20system&amp;title=Public%20health%20units">Public health units</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people?mega=NZ%20health%20system&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211028090127/https://www.health.govt.nz/new-zealand-health-system/health-system-indicators-framework?mega=NZ%20health%20system&amp;title=Health%20System%20Indicators%20framework" class="menu-header">Health System Indicators framework</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211028090127/https://www.health.govt.nz/new-zealand-health-system/health-system-indicators-framework?mega=NZ%20health%20system&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211028090127/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services?mega=NZ%20health%20system&amp;title=Eligibility%20for%20public%20health%20services" class="menu-header">Eligibility for public health services</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211028090127/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services/guide-eligibility-publicly-funded-health-services?mega=NZ%20health%20system&amp;title=Guide%20to%20eligibility">Guide to eligibility</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services/eligibility-questions-and-answers-consumers?mega=NZ%20health%20system&amp;title=Q%26A%20for%20consumers">Q&amp;A for consumers</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services/eligibility-questions-and-answers-service-providers?mega=NZ%20health%20system&amp;title=Q%26A%20for%20service%20providers">Q&amp;A for service providers</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services/reciprocal-health-agreements?mega=NZ%20health%20system&amp;title=Reciprocal%20health%20agreements">Reciprocal health agreements</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services?mega=NZ%20health%20system&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211028090127/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements?mega=NZ%20health%20system&amp;title=Claims%2C%20provider%20payments%20and%20entitlements" class="menu-header">Claims &amp; provider payments</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211028090127/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/carer-support-claims?mega=NZ%20health%20system&amp;title=Carer%20Support">Carer Support</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/high-use-health-card-payments?mega=NZ%20health%20system&amp;title=High%20Use%20Health%20Card%20payments">High Use Health Card payments</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/between-travel-settlement?mega=NZ%20health%20system&amp;title=In-Between%20Travel%20Settlement">In-Between Travel Settlement</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/maternity-claim-forms?mega=NZ%20health%20system&amp;title=Maternity%20claim%20forms">Maternity claim forms</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/national-travel-assistance?mega=NZ%20health%20system&amp;title=National%20travel%20assistance%20claims">National travel assistance claims</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements?mega=NZ%20health%20system&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                        </div>
+    </div>
+    <div class="feature-links">
+      <h3 class="sr-only">Other related resources</h3>
+      <a href="/web/20211028090127/https://www.health.govt.nz/new-zealand-health-system/overview-health-system?mega=NZ%20health%20system&amp;title=Overview">Overview of the health system</a>  <a href="/web/20211028090127/https://www.health.govt.nz/new-zealand-health-system/my-dhb?mega=NZ%20health%20system&amp;title=Mydhb">My DHB</a> <a href="/web/20211028090127/https://www.health.govt.nz/new-zealand-health-system/system-level-measures-framework?mega=NZ%20health%20system&amp;title=SLM">System level measures</a>  <a href="/web/20211028090127/https://www.health.govt.nz/publication/new-zealand-health-strategy-2016?mega=NZ%20health%20system&amp;title=HealthStrategy">NZ Health Strategy</a>    </div>
+  </div>
+</li>
+<li class="dropdown"><a href="/web/20211028090127/https://www.health.govt.nz/our-work" class="dropdown-toggle active-trail" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="megamenu-dropdown-776">Our work <b class="caret"></b></a>
+  <div id="megamenu-dropdown-776" class="dropdown-menu">
+    <div class="yamm-content">
+      <div class="row">
+                            <ul class="col list-unstyled no-menu-header">
+                                                                                <li>
+                <a href="/web/20211028090127/https://www.health.govt.nz/our-work/diseases-and-conditions/antimicrobial-resistance?mega=Our%20work&amp;title=Antimicrobial%20resistance" class="menu-header">Antimicrobial resistance</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211028090127/https://www.health.govt.nz/our-work/populations/asian-and-migrant-health?mega=Our%20work&amp;title=Asian%20and%20migrant%20health" class="menu-header">Asian and migrant health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211028090127/https://www.health.govt.nz/our-work/border-health?mega=Our%20work&amp;title=Border%20health" class="menu-header">Border health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211028090127/https://www.health.govt.nz/our-work/life-stages/breastfeeding?mega=Our%20work&amp;title=Breastfeeding" class="menu-header">Breastfeeding</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211028090127/https://www.health.govt.nz/our-work/diseases-and-conditions/cancer?mega=Our%20work&amp;title=Cancer" class="menu-header">Cancer</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211028090127/https://www.health.govt.nz/our-work/regulation-health-and-disability-system/certification-health-care-services?mega=Our%20work&amp;title=Certification%20of%20health%20care%20services" class="menu-header">Certification of health care services</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211028090127/https://www.health.govt.nz/our-work/life-stages/child-health?mega=Our%20work&amp;title=Child%20health" class="menu-header">Child health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211028090127/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus?mega=Our%20work&amp;title=COVID-19" class="menu-header">COVID-19 (novel coronavirus)</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211028090127/https://www.health.govt.nz/our-work/diseases-and-conditions/diabetes?mega=Our%20work&amp;title=Diabetes" class="menu-header">Diabetes</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211028090127/https://www.health.govt.nz/our-work/digital-health?mega=Our%20work&amp;title=Digital%20health" class="menu-header">Digital health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211028090127/https://www.health.govt.nz/our-work/disability-services?mega=Our%20work&amp;title=Disability%20services" class="menu-header">Disability services</a>                              </li>
+                                                                </ul>
+                            <ul class="col list-unstyled no-menu-header">
+                                                                                <li>
+                <a href="/web/20211028090127/https://www.health.govt.nz/our-work/diseases-and-conditions?mega=Our%20work&amp;title=Diseases%20and%20conditions" class="menu-header">Diseases and conditions</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211028090127/https://www.health.govt.nz/our-work/hospitals-and-specialist-care/emergency-departments?mega=Our%20work&amp;title=Emergency%20departments" class="menu-header">Emergency departments</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211028090127/https://www.health.govt.nz/our-work/emergency-management?mega=Our%20work&amp;title=Emergency%20management" class="menu-header">Emergency management</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211028090127/https://www.health.govt.nz/our-work/environmental-health?mega=Our%20work&amp;title=Environmental%20health" class="menu-header">Environmental health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211028090127/https://www.health.govt.nz/our-work/preventative-health-wellness/family-violence?mega=Our%20work&amp;title=Family%20violence" class="menu-header">Family violence</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211028090127/https://www.health.govt.nz/our-work/preventative-health-wellness/fluoride-and-oral-health?mega=Our%20work&amp;title=Fluoride%20and%20oral%20health" class="menu-header">Fluoride and oral health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211028090127/https://www.health.govt.nz/our-work/health-identity?mega=Our%20work&amp;title=Health%20identity" class="menu-header">Health identity</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211028090127/https://www.health.govt.nz/our-work/digital-health/digital-health-sector-architecture-standards-and-governance/health-information-standards-0?mega=Our%20work&amp;title=Health%20information%20standards" class="menu-header">Health information standards</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211028090127/https://www.health.govt.nz/our-work/life-stages/health-older-people?mega=Our%20work&amp;title=Health%20of%20older%20people" class="menu-header">Health of older people</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211028090127/https://www.health.govt.nz/our-work/health-workforce?mega=Our%20work&amp;title=Health%20workforce" class="menu-header">Health workforce</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211028090127/https://www.health.govt.nz/our-work/hospitals-and-specialist-care?mega=Our%20work&amp;title=Hospitals%20and%20specialist%20care" class="menu-header">Hospitals and specialist care</a>                              </li>
+                                                                </ul>
+                            <ul class="col list-unstyled no-menu-header">
+                                                                                <li>
+                <a href="/web/20211028090127/https://www.health.govt.nz/our-work/preventative-health-wellness/immunisation?mega=Our%20work&amp;title=Immunisation" class="menu-header">Immunisation</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211028090127/https://www.health.govt.nz/our-work/ionising-radiation-safety?mega=Our%20work&amp;title=Ionising%20radiation%20safety" class="menu-header">Ionising radiation safety</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211028090127/https://www.health.govt.nz/our-work/populations/maori-health?mega=Our%20work&amp;title=M%C4%81ori%20health" class="menu-header">Māori health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211028090127/https://www.health.govt.nz/our-work/life-stages/maternity-services?mega=Our%20work&amp;title=Maternity" class="menu-header">Maternity</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211028090127/https://www.health.govt.nz/our-work/regulation-health-and-disability-system/medicinal-cannabis-agency?mega=Our%20work&amp;title=Medicinal%20Cannabis%20Agency" class="menu-header">Medicinal cannabis</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211028090127/https://www.health.govt.nz/our-work/regulation-health-and-disability-system/medicines-control?mega=Our%20work&amp;title=Medicines%20control" class="menu-header">Medicines control</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211028090127/https://www.health.govt.nz/our-work/mental-health-and-addiction?mega=Our%20work&amp;title=Mental%20health%20and%20addiction" class="menu-header">Mental health and addiction</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211028090127/https://www.health.govt.nz/our-work/nursing?mega=Our%20work&amp;title=Nursing" class="menu-header">Nursing</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211028090127/https://www.health.govt.nz/our-work/preventative-health-wellness/nutrition?mega=Our%20work&amp;title=Nutrition" class="menu-header">Nutrition</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211028090127/https://www.health.govt.nz/our-work/preventative-health-wellness/oral-health?mega=Our%20work&amp;title=Oral%20health" class="menu-header">Oral health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211028090127/https://www.health.govt.nz/our-work/hospitals-and-specialist-care/organ-donation-and-transplantation?mega=Our%20work&amp;title=Organ%20donation%20and%20transplantation" class="menu-header">Organ donation and transplantation</a>                              </li>
+                                                                </ul>
+                            <ul class="col list-unstyled no-menu-header">
+                                                                                <li>
+                <a href="/web/20211028090127/https://www.health.govt.nz/our-work/populations/pacific-health?mega=Our%20work&amp;title=Pacific%20health" class="menu-header">Pacific health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211028090127/https://www.health.govt.nz/new-zealand-health-system/pay-equity-settlements?mega=Our%20work&amp;title=Pay%20equity%20settlements" class="menu-header">Pay equity</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211028090127/https://www.health.govt.nz/our-work/preventative-health-wellness/physical-activity?mega=Our%20work&amp;title=Physical%20activity" class="menu-header">Physical activity</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211028090127/https://www.health.govt.nz/our-work/hospitals-and-specialist-care/planned-care-services?mega=Our%20work&amp;title=Planned%20Care%20services" class="menu-header">Planned Care services</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211028090127/https://www.health.govt.nz/our-work/preventative-health-wellness?mega=Our%20work&amp;title=Preventative%20health/wellness" class="menu-header">Preventative health/wellness</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211028090127/https://www.health.govt.nz/our-work/primary-health-care?mega=Our%20work&amp;title=Primary%20health%20care" class="menu-header">Primary health care</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211028090127/https://www.health.govt.nz/our-work/public-health-workforce-development?mega=Our%20work&amp;title=Public%20health%20workforce%20development" class="menu-header">Public health workforce</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211028090127/https://www.health.govt.nz/our-work/regulation-health-and-disability-system?mega=Our%20work&amp;title=Regulation" class="menu-header">Regulation</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211028090127/https://www.health.govt.nz/our-work/preventative-health-wellness/tobacco-control?mega=Our%20work&amp;title=Tobacco%20control" class="menu-header">Tobacco control</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211028090127/https://www.health.govt.nz/our-work/regulation-health-and-disability-system/regulation-vaping-and-smokeless-tobacco-products?mega=Our%20work&amp;title=Vaping%20and%20smokeless%20tobacco%20products" class="menu-header">Vaping &amp; smokeless tobacco</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211028090127/https://www.health.govt.nz/our-work/who-code-nz?mega=Our%20work&amp;title=WHO%20Code%20in%20NZ" class="menu-header">WHO Code in NZ</a>                              </li>
+                      </ul>
+              </div>
+    </div>
+    <div class="feature-links">
+      <a href="/web/20211028090127/https://www.health.govt.nz/our-work?mega=Our%20work&amp;title=A-Z">View the full A-Z</a>    </div>
+  </div>
+</li>
+<li class="dropdown"><a href="/web/20211028090127/https://www.health.govt.nz/nz-health-statistics" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="megamenu-dropdown-778">Health statistics <b class="caret"></b></a>
+    <div id="megamenu-dropdown-778" class="dropdown-menu">
+    <div class="yamm-content">
+      <div class="row">
+                            <div class="col">
+            <h3><a href="/web/20211028090127/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets?mega=Health%20statistics&amp;title=Health%20statistics%20and%20data%20sets" class="menu-header">Statistics by topic</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211028090127/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/cancer-data-and-stats?mega=Health%20statistics&amp;title=Cancer">Cancer</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/diabetes-data-and-stats?mega=Health%20statistics&amp;title=Diabetes">Diabetes</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/mental-health-data-and-stats?mega=Health%20statistics&amp;title=Mental%20health">Mental health</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/maori-health-data-and-stats?mega=Health%20statistics&amp;title=M%C4%81ori%20health">Māori health</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/obesity-statistics?mega=Health%20statistics&amp;title=Obesity">Obesity</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/suicide-data-and-stats?mega=Health%20statistics&amp;title=Suicide">Suicide</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/tobacco-data-and-stats?mega=Health%20statistics&amp;title=Tobacco">Tobacco</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets?mega=Health%20statistics&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211028090127/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys?mega=Health%20statistics&amp;title=National%20collections%20and%20surveys" class="menu-header">About our surveys &amp; data collections</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211028090127/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/surveys/past-surveys/alcohol-and-drug-use-survey?mega=Health%20statistics&amp;title=Alcohol%20%26%20Drug%20Use%20Survey">Alcohol &amp; Drug Use Survey</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/national-collections-annual-maintenance-project?mega=Health%20statistics&amp;title=NCAMP">NCAMP</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/collections/new-zealand-cancer-registry-nzcr?mega=Health%20statistics&amp;title=NZ%20Cancer%20Registry">NZ Cancer Registry</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/surveys/new-zealand-health-survey?mega=Health%20statistics&amp;title=NZ%20Health%20Survey">NZ Health Survey</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/surveys/past-surveys/nutrition-survey?mega=Health%20statistics&amp;title=Nutrition%20Survey">Nutrition Survey</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/collections/primhd-mental-health-data?mega=Health%20statistics&amp;title=PRIMHD">PRIMHD</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys?mega=Health%20statistics&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211028090127/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology?mega=Health%20statistics&amp;title=Classification%20and%20Terminology" class="menu-header">Classification &amp; terminology</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211028090127/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology/using-icd-10-am-achi-acs/coding-queries/coding-query-database?mega=Health%20statistics&amp;title=Coding%20query%20database">Coding query database</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology/using-icd-10-am-achi-acs/courses-clinical-coding?mega=Health%20statistics&amp;title=Courses%20on%20clinical%20coding">Courses on clinical coding</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology/new-zealand-snomed-ct-national-release-centre?mega=Health%20statistics&amp;title=SNOMED%20CT">SNOMED CT</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology/using-icd-10-am-achi-acs?mega=Health%20statistics&amp;title=Using%20ICD-10-AM/ACHI/ACS">Using ICD-10-AM/ACHI/ACS</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology?mega=Health%20statistics&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211028090127/https://www.health.govt.nz/nz-health-statistics/data-references?mega=Health%20statistics&amp;title=Data%20references" class="menu-header">Data references</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211028090127/https://www.health.govt.nz/nz-health-statistics/data-references/code-tables?mega=Health%20statistics&amp;title=Code%20tables">Code tables</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/nz-health-statistics/data-references/data-dictionaries?mega=Health%20statistics&amp;title=Data%20dictionaries">Data dictionaries</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/nz-health-statistics/data-references/diagnosis-related-groups?mega=Health%20statistics&amp;title=Diagnosis-related%20groups">Diagnosis-related groups</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/nz-health-statistics/data-references/code-tables/common-code-tables/domicile-code-table?mega=Health%20statistics&amp;title=Domicile%20code%20table">Domicile code table</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/nz-health-statistics/data-references/mapping-tools?mega=Health%20statistics&amp;title=ICD%20mapping%20tools">ICD mapping tools</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/nz-health-statistics/data-references/weighted-inlier-equivalent-separations?mega=Health%20statistics&amp;title=Weighted%20Inlier%20Equivalent%20Separations">Weighted Inlier Equivalent Separations</a></li>
+                                  <li><a href="/web/20211028090127/https://www.health.govt.nz/nz-health-statistics/data-references?mega=Health%20statistics&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                        </div>
+    </div>
+    <div class="feature-links">
+      <h3 class="sr-only">Other related resources</h3>
+      <a href="/web/20211028090127/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/tier-1-health-statistics-release-calendar?mega=Health%20statistics&amp;title=Tier%201%20calendar">Release calendar for our Tier 1 statistics</a> <a href="/web/20211028090127/https://www.health.govt.nz/nz-health-statistics/about-data-collection?mega=Health%20statistics&amp;title=Enquiries">Data and survey enquiries</a>    </div>
+  </div>
+</li>
+<li class=""><a href="/web/20211028090127/https://www.health.govt.nz/publications" aria-haspopup="false">Publications</a></li>
+<li class=""><a href="/web/20211028090127/https://www.health.govt.nz/about-ministry" aria-haspopup="false">About us</a></li>
+<li class="visible-xs"><a href="/web/20211028090127/https://www.health.govt.nz/contactus" aria-haspopup="false">Contact us</a></li>
+</ul>
+                                  </nav>
+        </div>
+          </div>
+  </header>
+
+  <div class="main-container container">
+    <!-- announcement -->
+        <!-- /announcement -->
+
+    <header role="banner" id="page-header">
+
+          </header> <!-- /#page-header -->
+
+    <div class="row">
+
+      <section class="col-sm-12">
+                        <a id="main-content"></a>
+                                                                            <div class="breadcrumbs">
+            <ul><li><a href="/web/20211028090127/https://www.health.govt.nz/">Home</a></li><li><a href="/web/20211028090127/https://www.health.govt.nz/our-work">Our work</a></li><li><a href="/web/20211028090127/https://www.health.govt.nz/our-work/diseases-and-conditions">Diseases and conditions</a></li><li><a href="/web/20211028090127/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished" data-is-top-level="1" title="">COVID-19</a></li><li><a href="/web/20211028090127/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics" class="menu-node-unpublished menu-node-unpublished">Data and statistics</a></li><li><span class="current-breadcrumb">Vaccine data</span></li></ul>          </div>
+
+
+
+          <div class="region region-content">
+    <section id="block-system-main" class="block block-system clearfix">
+
+
+  <div class="bootstrap-threecol-stacked">
+
+      <div class="row"> <!-- @TODO: Add extra classes -->
+      <div class="panel-panel left col-xs-12 col-md-3 col-lg-3"><div class="panel-pane pane-block pane-menu-block-1 odd pane-top-link">
+
+        <span class="top-link"><a href="/web/20211028090127/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished active-trail" data-is-top-level="1">COVID-19</a></span>
+
+
+  <div class="pane-content">
+        <div class="menu-block-wrapper menu-block-1 menu-name-main-menu parent-mlid-1445 menu-level-2">
+  <ul class="menu nav"><li class="first collapsed menu-mlid-10163 health-advice depth-4"><a href="/web/20211028090127/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-health-advice-public" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished">Health advice</a></li>
+<li class="collapsed menu-mlid-10630 covid-19-vaccines- depth-4 section-overview hide-children"><a href="/web/20211028090127/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-vaccines" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished" data-is-top-level="1" title="">COVID-19 vaccines </a></li>
+<li class="collapsed menu-mlid-9997 health-professionals depth-4"><a href="/web/20211028090127/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-information-health-professionals" class="menu-node-unpublished menu-node-unpublished">Health professionals</a></li>
+<li class="collapsed menu-mlid-10019 specific-audiences depth-4"><a href="/web/20211028090127/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-information-specific-audiences" class="menu-node-unpublished">Specific audiences</a></li>
+<li class="expanded active-trail menu-mlid-10096 data-and-statistics depth-4"><a href="/web/20211028090127/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics" class="menu-node-unpublished menu-node-unpublished active-trail">Data and statistics</a><ul class="menu nav"><li class="first leaf menu-mlid-10062 current-cases depth-5 same-level-as-node"><a href="/web/20211028090127/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-current-cases" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Current cases</a></li>
+<li class="leaf menu-mlid-10146 case-demographics depth-5 same-level-as-node"><a href="/web/20211028090127/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-case-demographics">Case demographics</a></li>
+<li class="leaf menu-mlid-10097 source-of-cases depth-5 same-level-as-node"><a href="/web/20211028090127/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-source-cases" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Source of cases</a></li>
+<li class="leaf menu-mlid-10119 testing-for-covid-19 depth-5 same-level-as-node"><a href="/web/20211028090127/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/testing-covid-19" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Testing for COVID-19</a></li>
+<li class="leaf menu-mlid-10371 nz-covid-tracer-app-data depth-5 same-level-as-node"><a href="/web/20211028090127/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-nz-covid-tracer-app-data" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">NZ COVID Tracer app data</a></li>
+<li class="expanded active-trail active menu-mlid-10584 active vaccine-data depth-5 same-level-as-node"><a href="/web/20211028090127/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished active-trail active">Vaccine data</a><ul class="menu nav"><li class="first leaf menu-mlid-10867 covid-19-vaccination-uptake-rates-across-nz depth-6"><a href="/web/20211028090127/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-across-nz" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">COVID-19 Vaccination uptake rates across NZ</a></li>
+<li class="leaf menu-mlid-10868 covid-19-vaccination-uptake-rates---māori depth-6"><a href="/web/20211028090127/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-maori-communities-across-nz" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">COVID-19 Vaccination uptake rates - Māori</a></li>
+<li class="last leaf menu-mlid-10869 covid-19-vaccination-uptake-rates---pacific depth-6"><a href="/web/20211028090127/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-pacific-communities-across-nz" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">COVID-19 Vaccination uptake rates - Pacific</a></li>
+</ul></li>
+<li class="last leaf menu-mlid-10404 data-resources depth-5 same-level-as-node"><a href="/web/20211028090127/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-data-resources" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Data resources</a></li>
+</ul></li>
+<li class="collapsed menu-mlid-10369 response-planning depth-4"><a href="/web/20211028090127/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-response-planning" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Response planning</a></li>
+<li class="collapsed menu-mlid-10015 resources-and-tools depth-4"><a href="/web/20211028090127/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-resources-and-tools" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Resources and tools</a></li>
+<li class="last leaf menu-mlid-10004 news-and-media depth-4 section-overview hide-children"><a href="/web/20211028090127/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-news-and-media-updates" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">News and media</a></li>
+</ul></div>
+  </div>
+
+
+  </div>
+</div>      <div class="panel-panel middle col-xs-12 col-md-9 col-lg-9"><div class="panel-pane pane-page-title even">
+
+
+
+  <div class="pane-content">
+    <span id="skip-content" tabindex="-1"></span>    <h1>COVID-19: Vaccine data</h1>
+  </div>
+
+
+  </div>
+<div class="panel-pane pane-node-content odd">
+
+
+
+  <div class="pane-content">
+        <article id="node-12052" class="node node-page node-sticky view-mode-full clearfix" about="/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" typeof="sioc:Item foaf:Document">
+    <header>
+            <span property="dc:title" content="COVID-19: Vaccine data" class="rdf-meta element-hidden"></span>      </header>
+    <div class="field field-name-field-intro-text field-type-text-long field-label-hidden"><div class="field-items"><div class="field-item even"><p class="intro-text">Data and statistics about the rollout of COVID-19 vaccines in New Zealand.</p></div></div></div><div class="field field-name-body field-type-text-with-summary field-label-hidden"><div class="field-items"><div class="field-item even" property="content:encoded"><p>On this page:</p>
+
+<ul>
+	<li><a href="#daily">Daily updates</a>
+
+	<ul>
+		<li><a href="#total-vaccinations">Total vaccinations</a></li>
+		<li><a href="#ethnicity">Vaccinations by ethnicity</a></li>
+		<li><a href="#90pct">Vaccinations to 90% by DHB</a></li>
+	</ul>
+	</li>
+	<li><a href="#weekly-updates">Weekly updates</a>
+	<ul>
+		<li><a href="#model">Vaccinations against plan</a></li>
+		<li><a href="#uptake">Vaccinations uptake</a></li>
+		<li><a href="#by-day">Vaccinations by day</a></li>
+		<li><a href="#location">Vaccinations by DHB</a></li>
+		<li><a href="#group">Vaccinations by group</a></li>
+		<li><a href="#by_soh">Stock on hand</a></li>
+		<li><a href="#age">Vaccinations by age</a></li>
+		<li><a href="#workforce">Trained vaccinator and active vaccinator</a></li>
+		<li><a href="#group">Vaccinations by group</a></li>
+		<li><a href="#download">Details of vaccination&nbsp;data</a></li>
+	</ul>
+	</li>
+	<li><a href="#adverse-events">Adverse events from immunisations</a></li>
+</ul>
+
+<hr/><!--daily-->
+<h2><a id="daily" name="daily"></a>COVID-19 vaccinations: daily updates</h2>
+
+<div class="well well-sm">
+<p style="margin-top: 0"><strong>Data in this section is as at 11:59pm 27 October 2021 and is updated daily.</strong></p>
+</div>
+
+<h3><a id="total-vaccinations" name="total-vaccinations"></a>Total Vaccinations</h3>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">&nbsp;</th>
+			<th scope="col" style="text-align:right">Vaccinations yesterday</th>
+			<th scope="col" style="text-align:right">Cumulative total</th>
+			<th scope="col" style="text-align:right">Eligible population vaccinated %</th>
+			<th scope="col" style="text-align:right">Total population vaccinated %</th>
+			<th scope="col" style="text-align:right">Vaccinated or booked</th>
+			<th scope="col" style="text-align:right">Eligible vaccinated or booked %</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">First dose</th>
+			<td style="text-align:right">10,908</td>
+			<td style="text-align:right">3,669,216</td>
+			<td style="text-align:right">87%</td>
+			<td style="text-align:right">73%</td>
+			<td style="text-align:right">3,686,886</td>
+			<td style="text-align:right">88%</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Second dose</th>
+			<td style="text-align:right">28,312</td>
+			<td style="text-align:right">3,047,524</td>
+			<td style="text-align:right">72%</td>
+			<td style="text-align:right">61%</td>
+			<td style="text-align:right">3,340,638</td>
+			<td style="text-align:right">79%</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total doses</strong></th>
+			<td style="text-align:right"><strong>39,220</strong></td>
+			<td style="text-align:right"><strong>6,716,740</strong></td>
+		</tr>
+	</tbody>
+</table>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Total vaccinations" class="img-responsive" height="900" src="/web/20211028090127im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_summary_12_0.png" width="5340"/></figure>
+
+<h5>Definitions</h5>
+
+<ul>
+	<li><strong>Cumulative total:</strong>&nbsp;All vaccinations that have been administered and entered into the COVID-19 Immunisation Register up until midnight of the night before the data is published.</li>
+	<li><strong>Eligible population vaccinated %:</strong>&nbsp;Vaccinations administered divided by HSU population estimates for the eligible population (12+).</li>
+	<li><strong>Total population vaccinated %:</strong>&nbsp;Vaccinations administered divided by HSU population estimates for the total population (0+).</li>
+	<li><strong>Vaccinated or booked:</strong>&nbsp;Count of individuals who have either received their vaccination or have booked via Book My Vaccine to receive a vaccination.</li>
+	<li><strong>Eligible vaccinated or booked %:</strong>&nbsp;Count of individuals who have either received their vaccination or have booked via Book My Vaccine to receive a vaccination divided by HSU population estimates for the eligible population (12+).</li>
+</ul>
+
+<p>HSU population estimates are available in the downloadable spreadsheet at the bottom of the page. Throughout the rest of this sheet doses per 1,000 are based on eligible (12+) population.</p>
+
+<p>Bookings are only counted if the site is using Book My Vaccine. Bookings made through other Patient Management Systems are not counted.</p>
+
+<hr/>
+<h3><a id="by_eth" name="ethnicity"></a>Cumulative vaccinations by ethnicity</h3>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">Ethnicity *</th>
+			<th scope="col" style="text-align:right">First dose administered</th>
+			<th scope="col" style="text-align:right">First doses per 1,000 people</th>
+			<th scope="col" style="text-align:right">Second dose administered</th>
+			<th scope="col" style="text-align:right">Second doses per 1,000 people</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">Māori</th>
+			<td style="text-align:right">400,403</td>
+			<td style="text-align:right">701</td>
+			<td style="text-align:right">285,593</td>
+			<td style="text-align:right">500</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Pacific Peoples</th>
+			<td style="text-align:right">240,109</td>
+			<td style="text-align:right">838</td>
+			<td style="text-align:right">188,522</td>
+			<td style="text-align:right">658</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Asian</th>
+			<td style="text-align:right">604,199</td>
+			<td style="text-align:right">&gt;950</td>
+			<td style="text-align:right">524,971</td>
+			<td style="text-align:right">877</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">European / Other</th>
+			<td style="text-align:right">2,390,805</td>
+			<td style="text-align:right">875</td>
+			<td style="text-align:right">2,021,065</td>
+			<td style="text-align:right">740</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Unknown</th>
+			<td style="text-align:right">33,700</td>
+			<td style="text-align:right">-</td>
+			<td style="text-align:right">27,373</td>
+			<td style="text-align:right">-</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total</strong></th>
+			<td style="text-align:right"><strong>3,669,216</strong></td>
+			<td style="text-align:right"><strong>872</strong></td>
+			<td style="text-align:right"><strong>3,047,524</strong></td>
+			<td style="text-align:right"><strong>724</strong></td>
+		</tr>
+	</tbody>
+</table>
+
+<p><strong>*</strong> The prioritised ethnicity classification system allocates each person to a single ethnic group, based on the ethnic groups they identify with. Where people identify with more than one group, they are assigned in this order of priority: Māori, Pacific Peoples, Asian, and European/Other. So, if a person identifies as being Māori and New Zealand European, the person is counted as Māori. See <a href="/web/20211028090127/https://www.health.govt.nz/publication/hiso-100012017-ethnicity-data-protocols">Ethnicity Data Protocols</a> for further information.</p>
+
+<p>Ethnicity breakdown by DHB of residence is available in the downloadable spreadsheet at the bottom of the page.</p>
+
+<hr/>
+<h3><a id="90pct" name="90pct"></a>Vaccinations to 90% by DHB</h3>
+
+<h4><a id="90pct all ethnicities" name="90pct all ethnicities"></a>All Ethnicities</h4>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">&nbsp;</th>
+			<th scope="col" style="text-align:right">First doses</th>
+			<th scope="col" style="text-align:right">First doses %</th>
+			<th scope="col" style="text-align:right">First doses to 90%</th>
+			<th scope="col" style="text-align:right">Second doses</th>
+			<th scope="col" style="text-align:right">Second doses %</th>
+			<th scope="col" style="text-align:right">Second doses to 90%</th>
+			<th scope="col" style="text-align:right">Population</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">Northland</th>
+			<td style="text-align:right">126,580</td>
+			<td style="text-align:right">78%</td>
+			<td style="text-align:right">18,608</td>
+			<td style="text-align:right">101,394</td>
+			<td style="text-align:right">63%</td>
+			<td style="text-align:right">43,794</td>
+			<td style="text-align:right">161,320</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waitemata</th>
+			<td style="text-align:right">477,145</td>
+			<td style="text-align:right">91%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">410,477</td>
+			<td style="text-align:right">78%</td>
+			<td style="text-align:right">63,001</td>
+			<td style="text-align:right">526,087</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Auckland</th>
+			<td style="text-align:right">396,425</td>
+			<td style="text-align:right">94%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">348,980</td>
+			<td style="text-align:right">82%</td>
+			<td style="text-align:right">32,582</td>
+			<td style="text-align:right">423,958</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Counties Manukau</th>
+			<td style="text-align:right">425,796</td>
+			<td style="text-align:right">88%</td>
+			<td style="text-align:right">8,700</td>
+			<td style="text-align:right">360,825</td>
+			<td style="text-align:right">75%</td>
+			<td style="text-align:right">73,671</td>
+			<td style="text-align:right">482,773</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waikato</th>
+			<td style="text-align:right">306,361</td>
+			<td style="text-align:right">86%</td>
+			<td style="text-align:right">15,097</td>
+			<td style="text-align:right">248,743</td>
+			<td style="text-align:right">70%</td>
+			<td style="text-align:right">72,715</td>
+			<td style="text-align:right">357,176</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Lakes</th>
+			<td style="text-align:right">75,016</td>
+			<td style="text-align:right">79%</td>
+			<td style="text-align:right">9,961</td>
+			<td style="text-align:right">59,563</td>
+			<td style="text-align:right">63%</td>
+			<td style="text-align:right">25,414</td>
+			<td style="text-align:right">94,419</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Bay of Plenty</th>
+			<td style="text-align:right">178,418</td>
+			<td style="text-align:right">82%</td>
+			<td style="text-align:right">16,829</td>
+			<td style="text-align:right">140,261</td>
+			<td style="text-align:right">65%</td>
+			<td style="text-align:right">54,986</td>
+			<td style="text-align:right">216,941</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Tairawhiti</th>
+			<td style="text-align:right">32,294</td>
+			<td style="text-align:right">77%</td>
+			<td style="text-align:right">5,474</td>
+			<td style="text-align:right">25,934</td>
+			<td style="text-align:right">62%</td>
+			<td style="text-align:right">11,834</td>
+			<td style="text-align:right">41,965</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Taranaki</th>
+			<td style="text-align:right">84,995</td>
+			<td style="text-align:right">83%</td>
+			<td style="text-align:right">6,937</td>
+			<td style="text-align:right">64,699</td>
+			<td style="text-align:right">63%</td>
+			<td style="text-align:right">27,233</td>
+			<td style="text-align:right">102,147</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hawkes Bay</th>
+			<td style="text-align:right">121,407</td>
+			<td style="text-align:right">83%</td>
+			<td style="text-align:right">9,607</td>
+			<td style="text-align:right">100,094</td>
+			<td style="text-align:right">69%</td>
+			<td style="text-align:right">30,920</td>
+			<td style="text-align:right">145,571</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">MidCentral</th>
+			<td style="text-align:right">130,001</td>
+			<td style="text-align:right">85%</td>
+			<td style="text-align:right">7,071</td>
+			<td style="text-align:right">107,033</td>
+			<td style="text-align:right">70%</td>
+			<td style="text-align:right">30,039</td>
+			<td style="text-align:right">152,302</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Whanganui</th>
+			<td style="text-align:right">45,595</td>
+			<td style="text-align:right">80%</td>
+			<td style="text-align:right">5,927</td>
+			<td style="text-align:right">37,894</td>
+			<td style="text-align:right">66%</td>
+			<td style="text-align:right">13,628</td>
+			<td style="text-align:right">57,247</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Capital and Coast</th>
+			<td style="text-align:right">248,425</td>
+			<td style="text-align:right">92%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">210,931</td>
+			<td style="text-align:right">78%</td>
+			<td style="text-align:right">33,126</td>
+			<td style="text-align:right">271,174</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hutt Valley</th>
+			<td style="text-align:right">113,578</td>
+			<td style="text-align:right">87%</td>
+			<td style="text-align:right">3,637</td>
+			<td style="text-align:right">93,251</td>
+			<td style="text-align:right">72%</td>
+			<td style="text-align:right">23,964</td>
+			<td style="text-align:right">130,239</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Wairarapa</th>
+			<td style="text-align:right">35,045</td>
+			<td style="text-align:right">85%</td>
+			<td style="text-align:right">2,239</td>
+			<td style="text-align:right">29,159</td>
+			<td style="text-align:right">70%</td>
+			<td style="text-align:right">8,125</td>
+			<td style="text-align:right">41,427</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Nelson Marlborough</th>
+			<td style="text-align:right">116,601</td>
+			<td style="text-align:right">86%</td>
+			<td style="text-align:right">5,568</td>
+			<td style="text-align:right">100,969</td>
+			<td style="text-align:right">74%</td>
+			<td style="text-align:right">21,200</td>
+			<td style="text-align:right">135,743</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">West Coast</th>
+			<td style="text-align:right">22,281</td>
+			<td style="text-align:right">80%</td>
+			<td style="text-align:right">2,834</td>
+			<td style="text-align:right">17,917</td>
+			<td style="text-align:right">64%</td>
+			<td style="text-align:right">7,198</td>
+			<td style="text-align:right">27,906</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Canterbury</th>
+			<td style="text-align:right">431,211</td>
+			<td style="text-align:right">89%</td>
+			<td style="text-align:right">3,390</td>
+			<td style="text-align:right">333,247</td>
+			<td style="text-align:right">69%</td>
+			<td style="text-align:right">101,354</td>
+			<td style="text-align:right">482,890</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">South Canterbury</th>
+			<td style="text-align:right">44,649</td>
+			<td style="text-align:right">85%</td>
+			<td style="text-align:right">2,677</td>
+			<td style="text-align:right">37,775</td>
+			<td style="text-align:right">72%</td>
+			<td style="text-align:right">9,551</td>
+			<td style="text-align:right">52,584</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Southern</th>
+			<td style="text-align:right">255,355</td>
+			<td style="text-align:right">89%</td>
+			<td style="text-align:right">3,858</td>
+			<td style="text-align:right">216,761</td>
+			<td style="text-align:right">75%</td>
+			<td style="text-align:right">42,452</td>
+			<td style="text-align:right">288,015</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Overseas / Unknown</th>
+			<td style="text-align:right">2,038</td>
+			<td style="text-align:right">12%</td>
+			<td style="text-align:right">13,418</td>
+			<td style="text-align:right">1,617</td>
+			<td style="text-align:right">9%</td>
+			<td style="text-align:right">13,839</td>
+			<td style="text-align:right">17,173</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total</strong></th>
+			<td style="text-align:right"><strong>3,669,216</strong></td>
+			<td style="text-align:right"><strong>87%</strong></td>
+			<td style="text-align:right"><strong>118,935</strong></td>
+			<td style="text-align:right"><strong>3,047,524</strong></td>
+			<td style="text-align:right"><strong>72%</strong></td>
+			<td style="text-align:right"><strong>740,627</strong></td>
+			<td style="text-align:right"><strong>4,209,057</strong></td>
+		</tr>
+	</tbody>
+</table>
+
+<p>First/second doses % are the number of first/second doses administered divided by the eligible population. First/second doses to 90% are the number of doses required to reach 90% of the eligible population. For these two measures, the national total may not be the sum of DHB measures.</p>
+
+<h4><a id="90pct Māori" name="90pct Māori">Māori</a></h4>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">&nbsp;</th>
+			<th scope="col" style="text-align:right">First doses</th>
+			<th scope="col" style="text-align:right">First doses %</th>
+			<th scope="col" style="text-align:right">First doses to 90%</th>
+			<th scope="col" style="text-align:right">Second doses</th>
+			<th scope="col" style="text-align:right">Second doses %</th>
+			<th scope="col" style="text-align:right">Second doses to 90%</th>
+			<th scope="col" style="text-align:right">Population</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">Northland</th>
+			<td style="text-align:right">33,302</td>
+			<td style="text-align:right">66%</td>
+			<td style="text-align:right">12,137</td>
+			<td style="text-align:right">22,928</td>
+			<td style="text-align:right">45%</td>
+			<td style="text-align:right">22,511</td>
+			<td style="text-align:right">50,488</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waitemata</th>
+			<td style="text-align:right">32,375</td>
+			<td style="text-align:right">79%</td>
+			<td style="text-align:right">4,627</td>
+			<td style="text-align:right">24,358</td>
+			<td style="text-align:right">59%</td>
+			<td style="text-align:right">12,644</td>
+			<td style="text-align:right">41,113</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Auckland</th>
+			<td style="text-align:right">22,650</td>
+			<td style="text-align:right">81%</td>
+			<td style="text-align:right">2,363</td>
+			<td style="text-align:right">17,476</td>
+			<td style="text-align:right">63%</td>
+			<td style="text-align:right">7,537</td>
+			<td style="text-align:right">27,792</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Counties Manukau</th>
+			<td style="text-align:right">45,584</td>
+			<td style="text-align:right">72%</td>
+			<td style="text-align:right">11,560</td>
+			<td style="text-align:right">32,219</td>
+			<td style="text-align:right">51%</td>
+			<td style="text-align:right">24,925</td>
+			<td style="text-align:right">63,493</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waikato</th>
+			<td style="text-align:right">49,518</td>
+			<td style="text-align:right">71%</td>
+			<td style="text-align:right">13,218</td>
+			<td style="text-align:right">33,736</td>
+			<td style="text-align:right">48%</td>
+			<td style="text-align:right">29,000</td>
+			<td style="text-align:right">69,707</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Lakes</th>
+			<td style="text-align:right">19,128</td>
+			<td style="text-align:right">64%</td>
+			<td style="text-align:right">7,948</td>
+			<td style="text-align:right">13,284</td>
+			<td style="text-align:right">44%</td>
+			<td style="text-align:right">13,792</td>
+			<td style="text-align:right">30,085</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Bay of Plenty</th>
+			<td style="text-align:right">30,048</td>
+			<td style="text-align:right">63%</td>
+			<td style="text-align:right">12,913</td>
+			<td style="text-align:right">20,489</td>
+			<td style="text-align:right">43%</td>
+			<td style="text-align:right">22,472</td>
+			<td style="text-align:right">47,734</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Tairawhiti</th>
+			<td style="text-align:right">13,127</td>
+			<td style="text-align:right">66%</td>
+			<td style="text-align:right">4,728</td>
+			<td style="text-align:right">9,568</td>
+			<td style="text-align:right">48%</td>
+			<td style="text-align:right">8,287</td>
+			<td style="text-align:right">19,839</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Taranaki</th>
+			<td style="text-align:right">10,614</td>
+			<td style="text-align:right">67%</td>
+			<td style="text-align:right">3,700</td>
+			<td style="text-align:right">6,865</td>
+			<td style="text-align:right">43%</td>
+			<td style="text-align:right">7,449</td>
+			<td style="text-align:right">15,904</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hawkes Bay</th>
+			<td style="text-align:right">22,274</td>
+			<td style="text-align:right">65%</td>
+			<td style="text-align:right">8,379</td>
+			<td style="text-align:right">15,810</td>
+			<td style="text-align:right">46%</td>
+			<td style="text-align:right">14,843</td>
+			<td style="text-align:right">34,059</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">MidCentral</th>
+			<td style="text-align:right">16,902</td>
+			<td style="text-align:right">70%</td>
+			<td style="text-align:right">4,900</td>
+			<td style="text-align:right">12,107</td>
+			<td style="text-align:right">50%</td>
+			<td style="text-align:right">9,696</td>
+			<td style="text-align:right">24,225</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Whanganui</th>
+			<td style="text-align:right">8,639</td>
+			<td style="text-align:right">64%</td>
+			<td style="text-align:right">3,522</td>
+			<td style="text-align:right">6,371</td>
+			<td style="text-align:right">47%</td>
+			<td style="text-align:right">5,790</td>
+			<td style="text-align:right">13,512</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Capital and Coast</th>
+			<td style="text-align:right">21,286</td>
+			<td style="text-align:right">79%</td>
+			<td style="text-align:right">2,984</td>
+			<td style="text-align:right">16,225</td>
+			<td style="text-align:right">60%</td>
+			<td style="text-align:right">8,045</td>
+			<td style="text-align:right">26,967</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hutt Valley</th>
+			<td style="text-align:right">13,701</td>
+			<td style="text-align:right">72%</td>
+			<td style="text-align:right">3,510</td>
+			<td style="text-align:right">9,928</td>
+			<td style="text-align:right">52%</td>
+			<td style="text-align:right">7,283</td>
+			<td style="text-align:right">19,123</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Wairarapa</th>
+			<td style="text-align:right">4,324</td>
+			<td style="text-align:right">69%</td>
+			<td style="text-align:right">1,348</td>
+			<td style="text-align:right">3,033</td>
+			<td style="text-align:right">48%</td>
+			<td style="text-align:right">2,639</td>
+			<td style="text-align:right">6,302</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Nelson Marlborough</th>
+			<td style="text-align:right">7,765</td>
+			<td style="text-align:right">69%</td>
+			<td style="text-align:right">2,358</td>
+			<td style="text-align:right">5,851</td>
+			<td style="text-align:right">52%</td>
+			<td style="text-align:right">4,272</td>
+			<td style="text-align:right">11,248</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">West Coast</th>
+			<td style="text-align:right">1,943</td>
+			<td style="text-align:right">70%</td>
+			<td style="text-align:right">546</td>
+			<td style="text-align:right">1,380</td>
+			<td style="text-align:right">50%</td>
+			<td style="text-align:right">1,108</td>
+			<td style="text-align:right">2,765</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Canterbury</th>
+			<td style="text-align:right">27,254</td>
+			<td style="text-align:right">74%</td>
+			<td style="text-align:right">6,018</td>
+			<td style="text-align:right">18,731</td>
+			<td style="text-align:right">51%</td>
+			<td style="text-align:right">14,541</td>
+			<td style="text-align:right">36,969</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">South Canterbury</th>
+			<td style="text-align:right">2,357</td>
+			<td style="text-align:right">69%</td>
+			<td style="text-align:right">728</td>
+			<td style="text-align:right">1,747</td>
+			<td style="text-align:right">51%</td>
+			<td style="text-align:right">1,338</td>
+			<td style="text-align:right">3,428</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Southern</th>
+			<td style="text-align:right">17,431</td>
+			<td style="text-align:right">74%</td>
+			<td style="text-align:right">3,850</td>
+			<td style="text-align:right">13,355</td>
+			<td style="text-align:right">56%</td>
+			<td style="text-align:right">7,926</td>
+			<td style="text-align:right">23,646</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Overseas / Unknown</th>
+			<td style="text-align:right">181</td>
+			<td style="text-align:right">7%</td>
+			<td style="text-align:right">2,207</td>
+			<td style="text-align:right">132</td>
+			<td style="text-align:right">5%</td>
+			<td style="text-align:right">2,256</td>
+			<td style="text-align:right">2,653</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total</strong></th>
+			<td style="text-align:right"><strong>400,403</strong></td>
+			<td style="text-align:right"><strong>70%</strong></td>
+			<td style="text-align:right"><strong>113,544</strong></td>
+			<td style="text-align:right"><strong>285,593</strong></td>
+			<td style="text-align:right"><strong>50%</strong></td>
+			<td style="text-align:right"><strong>228,354</strong></td>
+			<td style="text-align:right"><strong>571,052</strong></td>
+		</tr>
+	</tbody>
+</table>
+
+<h4><a id="90pct Pacific Peoples" name="90pct Pacific Peoples"></a>Pacific Peoples</h4>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">&nbsp;</th>
+			<th scope="col" style="text-align:right">First doses</th>
+			<th scope="col" style="text-align:right">First doses %</th>
+			<th scope="col" style="text-align:right">First doses to 90%</th>
+			<th scope="col" style="text-align:right">Second doses</th>
+			<th scope="col" style="text-align:right">Second doses %</th>
+			<th scope="col" style="text-align:right">Second doses to 90%</th>
+			<th scope="col" style="text-align:right">Population</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">Northland</th>
+			<td style="text-align:right">2,344</td>
+			<td style="text-align:right">80%</td>
+			<td style="text-align:right">297</td>
+			<td style="text-align:right">1,677</td>
+			<td style="text-align:right">57%</td>
+			<td style="text-align:right">964</td>
+			<td style="text-align:right">2,934</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waitemata</th>
+			<td style="text-align:right">31,767</td>
+			<td style="text-align:right">85%</td>
+			<td style="text-align:right">2,049</td>
+			<td style="text-align:right">24,964</td>
+			<td style="text-align:right">66%</td>
+			<td style="text-align:right">8,852</td>
+			<td style="text-align:right">37,573</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Auckland</th>
+			<td style="text-align:right">39,079</td>
+			<td style="text-align:right">83%</td>
+			<td style="text-align:right">3,100</td>
+			<td style="text-align:right">30,984</td>
+			<td style="text-align:right">66%</td>
+			<td style="text-align:right">11,195</td>
+			<td style="text-align:right">46,866</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Counties Manukau</th>
+			<td style="text-align:right">95,671</td>
+			<td style="text-align:right">82%</td>
+			<td style="text-align:right">9,177</td>
+			<td style="text-align:right">75,414</td>
+			<td style="text-align:right">65%</td>
+			<td style="text-align:right">29,434</td>
+			<td style="text-align:right">116,498</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waikato</th>
+			<td style="text-align:right">9,043</td>
+			<td style="text-align:right">85%</td>
+			<td style="text-align:right">571</td>
+			<td style="text-align:right">6,997</td>
+			<td style="text-align:right">66%</td>
+			<td style="text-align:right">2,617</td>
+			<td style="text-align:right">10,682</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Lakes</th>
+			<td style="text-align:right">1,790</td>
+			<td style="text-align:right">78%</td>
+			<td style="text-align:right">267</td>
+			<td style="text-align:right">1,375</td>
+			<td style="text-align:right">60%</td>
+			<td style="text-align:right">682</td>
+			<td style="text-align:right">2,286</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Bay of Plenty</th>
+			<td style="text-align:right">3,974</td>
+			<td style="text-align:right">&gt;95%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">3,012</td>
+			<td style="text-align:right">82%</td>
+			<td style="text-align:right">299</td>
+			<td style="text-align:right">3,679</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Tairawhiti</th>
+			<td style="text-align:right">854</td>
+			<td style="text-align:right">88%</td>
+			<td style="text-align:right">14</td>
+			<td style="text-align:right">650</td>
+			<td style="text-align:right">67%</td>
+			<td style="text-align:right">218</td>
+			<td style="text-align:right">965</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Taranaki</th>
+			<td style="text-align:right">1,035</td>
+			<td style="text-align:right">81%</td>
+			<td style="text-align:right">108</td>
+			<td style="text-align:right">759</td>
+			<td style="text-align:right">60%</td>
+			<td style="text-align:right">384</td>
+			<td style="text-align:right">1,270</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hawkes Bay</th>
+			<td style="text-align:right">5,020</td>
+			<td style="text-align:right">&gt;95%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">4,058</td>
+			<td style="text-align:right">81%</td>
+			<td style="text-align:right">460</td>
+			<td style="text-align:right">5,020</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">MidCentral</th>
+			<td style="text-align:right">3,735</td>
+			<td style="text-align:right">84%</td>
+			<td style="text-align:right">286</td>
+			<td style="text-align:right">2,836</td>
+			<td style="text-align:right">63%</td>
+			<td style="text-align:right">1,185</td>
+			<td style="text-align:right">4,468</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Whanganui</th>
+			<td style="text-align:right">1,033</td>
+			<td style="text-align:right">75%</td>
+			<td style="text-align:right">210</td>
+			<td style="text-align:right">801</td>
+			<td style="text-align:right">58%</td>
+			<td style="text-align:right">442</td>
+			<td style="text-align:right">1,381</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Capital and Coast</th>
+			<td style="text-align:right">15,474</td>
+			<td style="text-align:right">81%</td>
+			<td style="text-align:right">1,785</td>
+			<td style="text-align:right">12,282</td>
+			<td style="text-align:right">64%</td>
+			<td style="text-align:right">4,977</td>
+			<td style="text-align:right">19,177</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hutt Valley</th>
+			<td style="text-align:right">7,860</td>
+			<td style="text-align:right">79%</td>
+			<td style="text-align:right">1,045</td>
+			<td style="text-align:right">6,120</td>
+			<td style="text-align:right">62%</td>
+			<td style="text-align:right">2,785</td>
+			<td style="text-align:right">9,894</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Wairarapa</th>
+			<td style="text-align:right">680</td>
+			<td style="text-align:right">81%</td>
+			<td style="text-align:right">73</td>
+			<td style="text-align:right">537</td>
+			<td style="text-align:right">64%</td>
+			<td style="text-align:right">216</td>
+			<td style="text-align:right">837</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Nelson Marlborough</th>
+			<td style="text-align:right">3,586</td>
+			<td style="text-align:right">&gt;95%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">3,115</td>
+			<td style="text-align:right">&gt;95%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">2,115</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">West Coast</th>
+			<td style="text-align:right">225</td>
+			<td style="text-align:right">80%</td>
+			<td style="text-align:right">29</td>
+			<td style="text-align:right">171</td>
+			<td style="text-align:right">61%</td>
+			<td style="text-align:right">83</td>
+			<td style="text-align:right">282</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Canterbury</th>
+			<td style="text-align:right">10,341</td>
+			<td style="text-align:right">81%</td>
+			<td style="text-align:right">1,122</td>
+			<td style="text-align:right">7,625</td>
+			<td style="text-align:right">60%</td>
+			<td style="text-align:right">3,838</td>
+			<td style="text-align:right">12,737</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">South Canterbury</th>
+			<td style="text-align:right">767</td>
+			<td style="text-align:right">92%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">549</td>
+			<td style="text-align:right">66%</td>
+			<td style="text-align:right">204</td>
+			<td style="text-align:right">837</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Southern</th>
+			<td style="text-align:right">5,493</td>
+			<td style="text-align:right">91%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">4,307</td>
+			<td style="text-align:right">71%</td>
+			<td style="text-align:right">1,121</td>
+			<td style="text-align:right">6,031</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Overseas / Unknown</th>
+			<td style="text-align:right">338</td>
+			<td style="text-align:right">29%</td>
+			<td style="text-align:right">696</td>
+			<td style="text-align:right">289</td>
+			<td style="text-align:right">25%</td>
+			<td style="text-align:right">745</td>
+			<td style="text-align:right">1,149</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total</strong></th>
+			<td style="text-align:right"><strong>240,109</strong></td>
+			<td style="text-align:right"><strong>84%</strong></td>
+			<td style="text-align:right"><strong>17,904</strong></td>
+			<td style="text-align:right"><strong>188,522</strong></td>
+			<td style="text-align:right"><strong>66%</strong></td>
+			<td style="text-align:right"><strong>69,491</strong></td>
+			<td style="text-align:right"><strong>286,681</strong></td>
+		</tr>
+	</tbody>
+</table>
+<!--daily_end-->
+
+<hr/>
+<h2><a id="weekly-updates" name="weekly-updates"></a>COVID-19 vaccinations: weekly updates</h2>
+
+<div class="well well-sm">
+<p style="margin-top: 0"><strong>Data in this section is as at 11:59pm 26 October 2021 and is updated weekly on Wednesdays.</strong></p>
+</div>
+
+<h3><a id="model" model="" name="id="></a>Cumulative vaccinations</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccination doses administered compared to plan doses" class="img-responsive" height="830" src="/web/20211028090127im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/vaccineplanmodel_13.png" width="1780"/></figure>
+
+<p>Production plan figures are the volumes agreed with DHBs and national providers for expected vaccinations. These figures have been matched with expected supply. Detailed plans are available in the Excel file at the bottom of this page.</p>
+
+<p>The Stock received figures are the cumulative supply of doses to date.</p>
+
+<p>DHB capacity plans for the remainder of the year are undergoing review.</p>
+
+<hr/><!--
+<h3><a id="model" model="" name="id="></a>Cumulative vaccinations for last 6 weeks</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccination doses administered compared to plan doses - 6wks" class="img-responsive" height="830" src="/vaccineplanmodel_wks.png" width="1780" /></figure>
+
+<hr />
+-->
+<h3><a id="uptake" name="uptake"></a>Vaccine uptake</h3>
+
+<p>Maps and data related to uptake rates of the COVID-19 vaccine across the country are available on the pages linked below. These show&nbsp;vaccination records aggregated by area of residence for all New Zealand residents, Māori communities, and Pacific communities.</p>
+
+<ul>
+	<li><a href="/web/20211028090127/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-across-nz">COVID-19 Vaccination uptake rates across NZ</a></li>
+	<li><a href="/web/20211028090127/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-maori-communities-across-nz">COVID-19 Vaccination uptake rates within Māori communities across NZ</a></li>
+	<li><a href="/web/20211028090127/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-pacific-communities-across-nz">COVID-19 Vaccination uptake rates within Pacific communities across NZ</a></li>
+</ul>
+
+<h4><a id="uptake" name="uptake"></a>Vaccine uptake per rate ratio (unadjusted) Māori and Pacific compared with Non-Māori non-Pacific</h4>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine Uptake per 1,000 (HSU) Rate Ratio, Showing Prioritised Ethnicity, vs Non-Māori Non-Pacific, By Age Band" class="img-responsive" height="830" src="/web/20211028090127im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_mix_8.png" width="1780"/></figure>
+
+<p>In the Chart above, rate ratios tell us the rate Māori or Pacific People per population are being vaccinated compared with non-Māori non-Pacific. This comparison can be split by age group.</p>
+
+<ul>
+	<li>A rate of one means the groups being compared are being vaccinated at the same rate.</li>
+	<li>A rate over one means Māori (or Pacific) are being vaccinated at a higher rate than non-Māori non-Pacific.</li>
+	<li>A rate under one means Māori (or Pacific) are being vaccinated at a lower rate than non-Māori non-Pacific.</li>
+</ul>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<td colspan="2" style="border-top: 0 !important; border-bottom-color: #FDD6AF !important; border-right: 0 !important;">&nbsp;</td>
+			<th colspan="6" id="ac1">Māori</th>
+			<th colspan="6" id="ac8">Pacific Peoples</th>
+		</tr>
+		<tr>
+			<th id="ar1">DHB</th>
+			<th>Dose number</th>
+			<th headers="ac1" id="ac2">65+</th>
+			<th headers="ac1" id="ac3">50-64</th>
+			<th headers="ac1" id="ac4">35-49</th>
+			<th headers="ac1" id="ac5">20-34</th>
+			<th headers="ac1" id="ac6">12-19</th>
+			<th headers="ac1" id="ac7">All ages</th>
+			<th headers="ac8" id="ac9">65+</th>
+			<th headers="ac8" id="ac10">50-64</th>
+			<th headers="ac8" id="ac11">35-49</th>
+			<th headers="ac8" id="ac12">20-34</th>
+			<th headers="ac8" id="ac13">12-19</th>
+			<th headers="ac8" id="ac14">All ages</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th headers="ar1" id="ar2" rowspan="2">National</th>
+			<th headers="ar1 ar2" id="ar3">Dose 1</th>
+			<td headers="ar1 ar2 ar3 ac1 ac2" style="background-color:green; color: #FFF;"><strong>0.99</strong></td>
+			<td headers="ar1 ar2 ar3 ac1 ac3" style="background-color:mediumseagreen"><strong>0.93</strong></td>
+			<td headers="ar1 ar2 ar3 ac1 ac4" style="background-color:yellow"><strong>0.79</strong></td>
+			<td headers="ar1 ar2 ar3 ac1 ac5" style="background-color:coral"><strong>0.67</strong></td>
+			<td headers="ar1 ar2 ar3 ac1 ac6" style="background-color:orange"><strong>0.71</strong></td>
+			<td headers="ar1 ar2 ar3 ac1 ac7" style="background-color:yellow"><strong>0.77</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac9" style="background-color:mediumseagreen"><strong>0.94</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac10" style="background-color:green; color: #FFF;"><strong>0.99</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac11" style="background-color:green; color: #FFF;"><strong>0.98</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac12" style="background-color:lightgreen"><strong>0.89</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac13" style="background-color:mediumseagreen"><strong>0.90</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac14" style="background-color:mediumseagreen"><strong>0.93</strong></td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar2" id="ar4">Dose 2</th>
+			<td headers="ar1 ar2 ar4 ac1 ac2" style="background-color:green; color: #FFF;"><strong>0.96</strong></td>
+			<td headers="ar1 ar2 ar4 ac1 ac3" style="background-color:lightgreen"><strong>0.87</strong></td>
+			<td headers="ar1 ar2 ar4 ac1 ac4" style="background-color:coral"><strong>0.68</strong></td>
+			<td headers="ar1 ar2 ar4 ac1 ac5" style="background-color:crimson; color: #FFF;"><strong>0.51</strong></td>
+			<td headers="ar1 ar2 ar4 ac1 ac6" style="background-color:crimson; color: #FFF;"><strong>0.57</strong></td>
+			<td headers="ar1 ar2 ar4 ac1 ac7" style="background-color:coral"><strong>0.65</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac9" style="background-color:mediumseagreen"><strong>0.92</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac10" style="background-color:green; color: #FFF;"><strong>0.99</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac11" style="background-color:green; color: #FFF;"><strong>0.97</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac12" style="background-color:palegreen"><strong>0.82</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac13" style="background-color:lightgreen"><strong>0.86</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac14" style="background-color:lightgreen"><strong>0.86</strong></td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar5" rowspan="2">Northland</th>
+			<th headers="ar1 ar5" id="ar6">Dose 1</th>
+			<td headers="ar1 ar5 ar6 ac1 ac2" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar5 ar6 ac1 ac3" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar5 ar6 ac1 ac4" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar5 ar6 ac1 ac5" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar5 ar6 ac1 ac6" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar5 ar6 ac1 ac7" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar5 ar6 ac8 ac9" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar5 ar6 ac8 ac10" style="background-color:green; color: #FFF;">1.06</td>
+			<td headers="ar1 ar5 ar6 ac8 ac11" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar5 ar6 ac8 ac12" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar5 ar6 ac8 ac13" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar5 ar6 ac8 ac14" style="background-color:mediumseagreen">0.94</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar5" id="ar7">Dose 2</th>
+			<td headers="ar1 ar5 ar7 ac1 ac2" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar5 ar7 ac1 ac3" style="background-color:lightgreen">0.87</td>
+			<td headers="ar1 ar5 ar7 ac1 ac4" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar5 ar7 ac1 ac5" style="background-color:crimson; color: #FFF;">0.49</td>
+			<td headers="ar1 ar5 ar7 ac1 ac6" style="background-color:crimson; color: #FFF;">0.59</td>
+			<td headers="ar1 ar5 ar7 ac1 ac7" style="background-color:tomato">0.63</td>
+			<td headers="ar1 ar5 ar7 ac8 ac9" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar5 ar7 ac8 ac10" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar5 ar7 ac8 ac11" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar5 ar7 ac8 ac12" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar5 ar7 ac8 ac13" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar5 ar7 ac8 ac14" style="background-color:palegreen">0.80</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar8" rowspan="2">Auckland Metro</th>
+			<th headers="ar1 ar8" id="ar9">Dose 1</th>
+			<td headers="ar1 ar8 ar9 ac1 ac2" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar8 ar9 ac1 ac3" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar8 ar9 ac1 ac4" style="background-color:palegreen">0.81</td>
+			<td headers="ar1 ar8 ar9 ac1 ac5" style="background-color:orange">0.72</td>
+			<td headers="ar1 ar8 ar9 ac1 ac6" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar8 ar9 ac1 ac7" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar8 ar9 ac8 ac9" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar8 ar9 ac8 ac10" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar8 ar9 ac8 ac11" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar8 ar9 ac8 ac12" style="background-color:palegreen">0.81</td>
+			<td headers="ar1 ar8 ar9 ac8 ac13" style="background-color:palegreen">0.84</td>
+			<td headers="ar1 ar8 ar9 ac8 ac14" style="background-color:lightgreen">0.88</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar8" id="ar10">Dose 2</th>
+			<td headers="ar1 ar8 ar10 ac1 ac2" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar8 ar10 ac1 ac3" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar8 ar10 ac1 ac4" style="background-color:coral">0.69</td>
+			<td headers="ar1 ar8 ar10 ac1 ac5" style="background-color:crimson; color: #FFF;">0.54</td>
+			<td headers="ar1 ar8 ar10 ac1 ac6" style="background-color:crimson; color: #FFF;">0.59</td>
+			<td headers="ar1 ar8 ar10 ac1 ac7" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar8 ar10 ac8 ac9" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar8 ar10 ac8 ac10" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar8 ar10 ac8 ac11" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar8 ar10 ac8 ac12" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar8 ar10 ac8 ac13" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar8 ar10 ac8 ac14" style="background-color:yellow">0.78</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar11" rowspan="2">Waikato</th>
+			<th headers="ar1 ar11" id="ar12">Dose 1</th>
+			<td headers="ar1 ar11 ar12 ac1 ac2" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar11 ar12 ac1 ac3" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar11 ar12 ac1 ac4" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar11 ar12 ac1 ac5" style="background-color:coral">0.69</td>
+			<td headers="ar1 ar11 ar12 ac1 ac6" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar11 ar12 ac1 ac7" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar11 ar12 ac8 ac9" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar11 ar12 ac8 ac10" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar11 ar12 ac8 ac11" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar11 ar12 ac8 ac12" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar11 ar12 ac8 ac13" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar11 ar12 ac8 ac14" style="background-color:mediumseagreen">0.94</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar11" id="ar13">Dose 2</th>
+			<td headers="ar1 ar11 ar13 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar11 ar13 ac1 ac3" style="background-color:lightgreen">0.87</td>
+			<td headers="ar1 ar11 ar13 ac1 ac4" style="background-color:coral">0.68</td>
+			<td headers="ar1 ar11 ar13 ac1 ac5" style="background-color:crimson; color: #FFF;">0.50</td>
+			<td headers="ar1 ar11 ar13 ac1 ac6" style="background-color:crimson; color: #FFF;">0.57</td>
+			<td headers="ar1 ar11 ar13 ac1 ac7" style="background-color:tomato">0.64</td>
+			<td headers="ar1 ar11 ar13 ac8 ac9" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar11 ar13 ac8 ac10" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar11 ar13 ac8 ac11" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar11 ar13 ac8 ac12" style="background-color:palegreen">0.84</td>
+			<td headers="ar1 ar11 ar13 ac8 ac13" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar11 ar13 ac8 ac14" style="background-color:lightgreen">0.87</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar14" rowspan="2">Bay of Plenty</th>
+			<th headers="ar1 ar14" id="ar15">Dose 1</th>
+			<td headers="ar1 ar14 ar15 ac1 ac2" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar14 ar15 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar14 ar15 ac1 ac4" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar14 ar15 ac1 ac5" style="background-color:crimson; color: #FFF;">0.57</td>
+			<td headers="ar1 ar14 ar15 ac1 ac6" style="background-color:tomato">0.64</td>
+			<td headers="ar1 ar14 ar15 ac1 ac7" style="background-color:orange">0.72</td>
+			<td headers="ar1 ar14 ar15 ac8 ac9" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar14 ar15 ac8 ac10" style="background-color:green; color: #FFF;">1.09</td>
+			<td headers="ar1 ar14 ar15 ac8 ac11" style="background-color:green; color: #FFF;">1.47</td>
+			<td headers="ar1 ar14 ar15 ac8 ac12" style="background-color:green; color: #FFF;">1.52</td>
+			<td headers="ar1 ar14 ar15 ac8 ac13" style="background-color:lightgreen">0.87</td>
+			<td headers="ar1 ar14 ar15 ac8 ac14" style="background-color:green; color: #FFF;">1.23</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar14" id="ar16">Dose 2</th>
+			<td headers="ar1 ar14 ar16 ac1 ac2" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar14 ar16 ac1 ac3" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar14 ar16 ac1 ac4" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar14 ar16 ac1 ac5" style="background-color:crimson; color: #FFF;">0.46</td>
+			<td headers="ar1 ar14 ar16 ac1 ac6" style="background-color:crimson; color: #FFF;">0.54</td>
+			<td headers="ar1 ar14 ar16 ac1 ac7" style="background-color:tomato">0.60</td>
+			<td headers="ar1 ar14 ar16 ac8 ac9" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar14 ar16 ac8 ac10" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar14 ar16 ac8 ac11" style="background-color:green; color: #FFF;">1.60</td>
+			<td headers="ar1 ar14 ar16 ac8 ac12" style="background-color:green; color: #FFF;">1.78</td>
+			<td headers="ar1 ar14 ar16 ac8 ac13" style="background-color:yellow">0.77</td>
+			<td headers="ar1 ar14 ar16 ac8 ac14" style="background-color:green; color: #FFF;">1.15</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar17" rowspan="2">Tairawhiti</th>
+			<th headers="ar1 ar17" id="ar18">Dose 1</th>
+			<td headers="ar1 ar17 ar18 ac1 ac2" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar17 ar18 ac1 ac3" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar17 ar18 ac1 ac4" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar17 ar18 ac1 ac5" style="background-color:tomato">0.62</td>
+			<td headers="ar1 ar17 ar18 ac1 ac6" style="background-color:coral">0.69</td>
+			<td headers="ar1 ar17 ar18 ac1 ac7" style="background-color:yellow">0.76</td>
+			<td headers="ar1 ar17 ar18 ac8 ac9" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar17 ar18 ac8 ac10" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar17 ar18 ac8 ac11" style="background-color:green; color: #FFF;">1.10</td>
+			<td headers="ar1 ar17 ar18 ac8 ac12" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar17 ar18 ac8 ac13" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar17 ar18 ac8 ac14" style="background-color:green; color: #FFF;">1.01</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar17" id="ar19">Dose 2</th>
+			<td headers="ar1 ar17 ar19 ac1 ac2" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar17 ar19 ac1 ac3" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar17 ar19 ac1 ac4" style="background-color:coral">0.68</td>
+			<td headers="ar1 ar17 ar19 ac1 ac5" style="background-color:crimson; color: #FFF;">0.49</td>
+			<td headers="ar1 ar17 ar19 ac1 ac6" style="background-color:crimson; color: #FFF;">0.55</td>
+			<td headers="ar1 ar17 ar19 ac1 ac7" style="background-color:tomato">0.64</td>
+			<td headers="ar1 ar17 ar19 ac8 ac9" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar17 ar19 ac8 ac10" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar17 ar19 ac8 ac11" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar17 ar19 ac8 ac12" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar17 ar19 ac8 ac13" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar17 ar19 ac8 ac14" style="background-color:mediumseagreen">0.90</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar20" rowspan="2">Lakes</th>
+			<th headers="ar1 ar20" id="ar21">Dose 1</th>
+			<td headers="ar1 ar20 ar21 ac1 ac2" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar20 ar21 ac1 ac3" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar20 ar21 ac1 ac4" style="background-color:yellow">0.76</td>
+			<td headers="ar1 ar20 ar21 ac1 ac5" style="background-color:crimson; color: #FFF;">0.58</td>
+			<td headers="ar1 ar20 ar21 ac1 ac6" style="background-color:coral">0.65</td>
+			<td headers="ar1 ar20 ar21 ac1 ac7" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar20 ar21 ac8 ac9" style="background-color:green; color: #FFF;">1.06</td>
+			<td headers="ar1 ar20 ar21 ac8 ac10" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar20 ar21 ac8 ac11" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar20 ar21 ac8 ac12" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar20 ar21 ac8 ac13" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar20 ar21 ac8 ac14" style="background-color:mediumseagreen">0.90</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar20" id="ar22">Dose 2</th>
+			<td headers="ar1 ar20 ar22 ac1 ac2" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar20 ar22 ac1 ac3" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar20 ar22 ac1 ac4" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar20 ar22 ac1 ac5" style="background-color:crimson; color: #FFF;">0.44</td>
+			<td headers="ar1 ar20 ar22 ac1 ac6" style="background-color:crimson; color: #FFF;">0.53</td>
+			<td headers="ar1 ar20 ar22 ac1 ac7" style="background-color:tomato">0.61</td>
+			<td headers="ar1 ar20 ar22 ac8 ac9" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar20 ar22 ac8 ac10" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar20 ar22 ac8 ac11" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar20 ar22 ac8 ac12" style="background-color:palegreen">0.83</td>
+			<td headers="ar1 ar20 ar22 ac8 ac13" style="background-color:lightgreen">0.86</td>
+			<td headers="ar1 ar20 ar22 ac8 ac14" style="background-color:palegreen">0.83</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar23" rowspan="2">Taranaki</th>
+			<th headers="ar1 ar23" id="ar24">Dose 1</th>
+			<td headers="ar1 ar23 ar24 ac1 ac2" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar23 ar24 ac1 ac3" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar23 ar24 ac1 ac4" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar23 ar24 ac1 ac5" style="background-color:coral">0.68</td>
+			<td headers="ar1 ar23 ar24 ac1 ac6" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar23 ar24 ac1 ac7" style="background-color:yellow">0.77</td>
+			<td headers="ar1 ar23 ar24 ac8 ac9" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar23 ar24 ac8 ac10" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar23 ar24 ac8 ac11" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar23 ar24 ac8 ac12" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar23 ar24 ac8 ac13" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar23 ar24 ac8 ac14" style="background-color:mediumseagreen">0.94</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar23" id="ar25">Dose 2</th>
+			<td headers="ar1 ar23 ar25 ac1 ac2" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar23 ar25 ac1 ac3" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar23 ar25 ac1 ac4" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar23 ar25 ac1 ac5" style="background-color:crimson; color: #FFF;">0.52</td>
+			<td headers="ar1 ar23 ar25 ac1 ac6" style="background-color:crimson; color: #FFF;">0.56</td>
+			<td headers="ar1 ar23 ar25 ac1 ac7" style="background-color:tomato">0.64</td>
+			<td headers="ar1 ar23 ar25 ac8 ac9" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar23 ar25 ac8 ac10" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar23 ar25 ac8 ac11" style="background-color:green; color: #FFF;">1.21</td>
+			<td headers="ar1 ar23 ar25 ac8 ac12" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar23 ar25 ac8 ac13" style="background-color:lightgreen">0.87</td>
+			<td headers="ar1 ar23 ar25 ac8 ac14" style="background-color:lightgreen">0.89</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar26" rowspan="2">Whanganui</th>
+			<th headers="ar1 ar26" id="ar27">Dose 1</th>
+			<td headers="ar1 ar26 ar27 ac1 ac2" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar26 ar27 ac1 ac3" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar26 ar27 ac1 ac4" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar26 ar27 ac1 ac5" style="background-color:coral">0.65</td>
+			<td headers="ar1 ar26 ar27 ac1 ac6" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar26 ar27 ac1 ac7" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar26 ar27 ac8 ac9" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar26 ar27 ac8 ac10" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar26 ar27 ac8 ac11" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar26 ar27 ac8 ac12" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar26 ar27 ac8 ac13" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar26 ar27 ac8 ac14" style="background-color:lightgreen">0.87</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar26" id="ar28">Dose 2</th>
+			<td headers="ar1 ar26 ar28 ac1 ac2" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar26 ar28 ac1 ac3" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar26 ar28 ac1 ac4" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar26 ar28 ac1 ac5" style="background-color:crimson; color: #FFF;">0.51</td>
+			<td headers="ar1 ar26 ar28 ac1 ac6" style="background-color:tomato">0.60</td>
+			<td headers="ar1 ar26 ar28 ac1 ac7" style="background-color:coral">0.65</td>
+			<td headers="ar1 ar26 ar28 ac8 ac9" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar26 ar28 ac8 ac10" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar26 ar28 ac8 ac11" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar26 ar28 ac8 ac12" style="background-color:palegreen">0.83</td>
+			<td headers="ar1 ar26 ar28 ac8 ac13" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar26 ar28 ac8 ac14" style="background-color:palegreen">0.80</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar29" rowspan="2">Hawke&#39;s Bay</th>
+			<th headers="ar1 ar29" id="ar30">Dose 1</th>
+			<td headers="ar1 ar29 ar30 ac1 ac2" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar29 ar30 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar29 ar30 ac1 ac4" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar29 ar30 ac1 ac5" style="background-color:crimson; color: #FFF;">0.59</td>
+			<td headers="ar1 ar29 ar30 ac1 ac6" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar29 ar30 ac1 ac7" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar29 ar30 ac8 ac9" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar29 ar30 ac8 ac10" style="background-color:green; color: #FFF;">1.05</td>
+			<td headers="ar1 ar29 ar30 ac8 ac11" style="background-color:green; color: #FFF;">1.42</td>
+			<td headers="ar1 ar29 ar30 ac8 ac12" style="background-color:green; color: #FFF;">1.32</td>
+			<td headers="ar1 ar29 ar30 ac8 ac13" style="background-color:lightgreen">0.88</td>
+			<td headers="ar1 ar29 ar30 ac8 ac14" style="background-color:green; color: #FFF;">1.16</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar29" id="ar31">Dose 2</th>
+			<td headers="ar1 ar29 ar31 ac1 ac2" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar29 ar31 ac1 ac3" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar29 ar31 ac1 ac4" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar29 ar31 ac1 ac5" style="background-color:crimson; color: #FFF;">0.47</td>
+			<td headers="ar1 ar29 ar31 ac1 ac6" style="background-color:crimson; color: #FFF;">0.57</td>
+			<td headers="ar1 ar29 ar31 ac1 ac7" style="background-color:tomato">0.61</td>
+			<td headers="ar1 ar29 ar31 ac8 ac9" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar29 ar31 ac8 ac10" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar29 ar31 ac8 ac11" style="background-color:green; color: #FFF;">1.48</td>
+			<td headers="ar1 ar29 ar31 ac8 ac12" style="background-color:green; color: #FFF;">1.48</td>
+			<td headers="ar1 ar29 ar31 ac8 ac13" style="background-color:lightgreen">0.86</td>
+			<td headers="ar1 ar29 ar31 ac8 ac14" style="background-color:green; color: #FFF;">1.10</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar32" rowspan="2">MidCentral</th>
+			<th headers="ar1 ar32" id="ar33">Dose 1</th>
+			<td headers="ar1 ar32 ar33 ac1 ac2" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar32 ar33 ac1 ac3" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar32 ar33 ac1 ac4" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar32 ar33 ac1 ac5" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar32 ar33 ac1 ac6" style="background-color:orange">0.72</td>
+			<td headers="ar1 ar32 ar33 ac1 ac7" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar32 ar33 ac8 ac9" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar32 ar33 ac8 ac10" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar32 ar33 ac8 ac11" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar32 ar33 ac8 ac12" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar32 ar33 ac8 ac13" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar32 ar33 ac8 ac14" style="background-color:mediumseagreen">0.94</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar32" id="ar34">Dose 2</th>
+			<td headers="ar1 ar32 ar34 ac1 ac2" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar32 ar34 ac1 ac3" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar32 ar34 ac1 ac4" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar32 ar34 ac1 ac5" style="background-color:crimson; color: #FFF;">0.58</td>
+			<td headers="ar1 ar32 ar34 ac1 ac6" style="background-color:tomato">0.60</td>
+			<td headers="ar1 ar32 ar34 ac1 ac7" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar32 ar34 ac8 ac9" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar32 ar34 ac8 ac10" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar32 ar34 ac8 ac11" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar32 ar34 ac8 ac12" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar32 ar34 ac8 ac13" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar32 ar34 ac8 ac14" style="background-color:lightgreen">0.85</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar35" rowspan="2">Wairarapa</th>
+			<th headers="ar1 ar35" id="ar36">Dose 1</th>
+			<td headers="ar1 ar35 ar36 ac1 ac2" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar35 ar36 ac1 ac3" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar35 ar36 ac1 ac4" style="background-color:palegreen">0.84</td>
+			<td headers="ar1 ar35 ar36 ac1 ac5" style="background-color:orange">0.72</td>
+			<td headers="ar1 ar35 ar36 ac1 ac6" style="background-color:yellow">0.77</td>
+			<td headers="ar1 ar35 ar36 ac1 ac7" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar35 ar36 ac8 ac9" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar35 ar36 ac8 ac10" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar35 ar36 ac8 ac11" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar35 ar36 ac8 ac12" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar35 ar36 ac8 ac13" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar35 ar36 ac8 ac14" style="background-color:mediumseagreen">0.92</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar35" id="ar37">Dose 2</th>
+			<td headers="ar1 ar35 ar37 ac1 ac2" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar35 ar37 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar35 ar37 ac1 ac4" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar35 ar37 ac1 ac5" style="background-color:crimson; color: #FFF;">0.55</td>
+			<td headers="ar1 ar35 ar37 ac1 ac6" style="background-color:tomato">0.63</td>
+			<td headers="ar1 ar35 ar37 ac1 ac7" style="background-color:tomato">0.64</td>
+			<td headers="ar1 ar35 ar37 ac8 ac9" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar35 ar37 ac8 ac10" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar35 ar37 ac8 ac11" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar35 ar37 ac8 ac12" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar35 ar37 ac8 ac13" style="background-color:palegreen">0.84</td>
+			<td headers="ar1 ar35 ar37 ac8 ac14" style="background-color:lightgreen">0.86</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar38" rowspan="2">Capital &amp; Coast and Hutt Valley</th>
+			<th headers="ar1 ar38" id="ar39">Dose 1</th>
+			<td headers="ar1 ar38 ar39 ac1 ac2" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar38 ar39 ac1 ac3" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar38 ar39 ac1 ac4" style="background-color:palegreen">0.83</td>
+			<td headers="ar1 ar38 ar39 ac1 ac5" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar38 ar39 ac1 ac6" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar38 ar39 ac1 ac7" style="background-color:palegreen">0.81</td>
+			<td headers="ar1 ar38 ar39 ac8 ac9" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar38 ar39 ac8 ac10" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar38 ar39 ac8 ac11" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar38 ar39 ac8 ac12" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar38 ar39 ac8 ac13" style="background-color:palegreen">0.84</td>
+			<td headers="ar1 ar38 ar39 ac8 ac14" style="background-color:lightgreen">0.86</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar38" id="ar40">Dose 2</th>
+			<td headers="ar1 ar38 ar40 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar38 ar40 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar38 ar40 ac1 ac4" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar38 ar40 ac1 ac5" style="background-color:tomato">0.63</td>
+			<td headers="ar1 ar38 ar40 ac1 ac6" style="background-color:tomato">0.62</td>
+			<td headers="ar1 ar38 ar40 ac1 ac7" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar38 ar40 ac8 ac9" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar38 ar40 ac8 ac10" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar38 ar40 ac8 ac11" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar38 ar40 ac8 ac12" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar38 ar40 ac8 ac13" style="background-color:yellow">0.76</td>
+			<td headers="ar1 ar38 ar40 ac8 ac14" style="background-color:palegreen">0.80</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar41" rowspan="2">Nelson Marlborough</th>
+			<th headers="ar1 ar41" id="ar42">Dose 1</th>
+			<td headers="ar1 ar41 ar42 ac1 ac2" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar41 ar42 ac1 ac3" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar41 ar42 ac1 ac4" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar41 ar42 ac1 ac5" style="background-color:coral">0.69</td>
+			<td headers="ar1 ar41 ar42 ac1 ac6" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar41 ar42 ac1 ac7" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar41 ar42 ac8 ac9" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar41 ar42 ac8 ac10" style="background-color:green; color: #FFF;">1.28</td>
+			<td headers="ar1 ar41 ar42 ac8 ac11" style="background-color:green; color: #FFF;">2.45</td>
+			<td headers="ar1 ar41 ar42 ac8 ac12" style="background-color:green; color: #FFF;">2.89</td>
+			<td headers="ar1 ar41 ar42 ac8 ac13" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar41 ar42 ac8 ac14" style="background-color:green; color: #FFF;">1.97</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar41" id="ar43">Dose 2</th>
+			<td headers="ar1 ar41 ar43 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar41 ar43 ac1 ac3" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar41 ar43 ac1 ac4" style="background-color:orange">0.72</td>
+			<td headers="ar1 ar41 ar43 ac1 ac5" style="background-color:crimson; color: #FFF;">0.57</td>
+			<td headers="ar1 ar41 ar43 ac1 ac6" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar41 ar43 ac1 ac7" style="background-color:coral">0.69</td>
+			<td headers="ar1 ar41 ar43 ac8 ac9" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar41 ar43 ac8 ac10" style="background-color:green; color: #FFF;">1.26</td>
+			<td headers="ar1 ar41 ar43 ac8 ac11" style="background-color:green; color: #FFF;">2.57</td>
+			<td headers="ar1 ar41 ar43 ac8 ac12" style="background-color:green; color: #FFF;">3.47</td>
+			<td headers="ar1 ar41 ar43 ac8 ac13" style="background-color:green; color: #FFF;">1.05</td>
+			<td headers="ar1 ar41 ar43 ac8 ac14" style="background-color:green; color: #FFF;">1.95</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar44" rowspan="2">West Coast</th>
+			<th headers="ar1 ar44" id="ar45">Dose 1</th>
+			<td headers="ar1 ar44 ar45 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar44 ar45 ac1 ac3" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar44 ar45 ac1 ac4" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar44 ar45 ac1 ac5" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar44 ar45 ac1 ac6" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar44 ar45 ac1 ac7" style="background-color:lightgreen">0.86</td>
+			<td headers="ar1 ar44 ar45 ac8 ac9" style="background-color:green; color: #FFF;">1.33</td>
+			<td headers="ar1 ar44 ar45 ac8 ac10" style="background-color:green; color: #FFF;">1.06</td>
+			<td headers="ar1 ar44 ar45 ac8 ac11" style="background-color:green; color: #FFF;">1.07</td>
+			<td headers="ar1 ar44 ar45 ac8 ac12" style="background-color:green; color: #FFF;">1.24</td>
+			<td headers="ar1 ar44 ar45 ac8 ac13" style="background-color:palegreen">0.83</td>
+			<td headers="ar1 ar44 ar45 ac8 ac14" style="background-color:green; color: #FFF;">0.99</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar44" id="ar46">Dose 2</th>
+			<td headers="ar1 ar44 ar46 ac1 ac2" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar44 ar46 ac1 ac3" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar44 ar46 ac1 ac4" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar44 ar46 ac1 ac5" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar44 ar46 ac1 ac6" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar44 ar46 ac1 ac7" style="background-color:yellow">0.76</td>
+			<td headers="ar1 ar44 ar46 ac8 ac9" style="background-color:green; color: #FFF;">1.33</td>
+			<td headers="ar1 ar44 ar46 ac8 ac10" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar44 ar46 ac8 ac11" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar44 ar46 ac8 ac12" style="background-color:green; color: #FFF;">1.57</td>
+			<td headers="ar1 ar44 ar46 ac8 ac13" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar44 ar46 ac8 ac14" style="background-color:mediumseagreen">0.91</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar47" rowspan="2">Canterbury</th>
+			<th headers="ar1 ar47" id="ar48">Dose 1</th>
+			<td headers="ar1 ar47 ar48 ac1 ac2" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar47 ar48 ac1 ac3" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar47 ar48 ac1 ac4" style="background-color:palegreen">0.83</td>
+			<td headers="ar1 ar47 ar48 ac1 ac5" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar47 ar48 ac1 ac6" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar47 ar48 ac1 ac7" style="background-color:palegreen">0.81</td>
+			<td headers="ar1 ar47 ar48 ac8 ac9" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar47 ar48 ac8 ac10" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar47 ar48 ac8 ac11" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar47 ar48 ac8 ac12" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar47 ar48 ac8 ac13" style="background-color:lightgreen">0.88</td>
+			<td headers="ar1 ar47 ar48 ac8 ac14" style="background-color:lightgreen">0.89</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar47" id="ar49">Dose 2</th>
+			<td headers="ar1 ar47 ar49 ac1 ac2" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar47 ar49 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar47 ar49 ac1 ac4" style="background-color:yellow">0.77</td>
+			<td headers="ar1 ar47 ar49 ac1 ac5" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar47 ar49 ac1 ac6" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar47 ar49 ac1 ac7" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar47 ar49 ac8 ac9" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar47 ar49 ac8 ac10" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar47 ar49 ac8 ac11" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar47 ar49 ac8 ac12" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar47 ar49 ac8 ac13" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar47 ar49 ac8 ac14" style="background-color:lightgreen">0.85</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar50" rowspan="2">South Canterbury</th>
+			<th headers="ar1 ar50" id="ar51">Dose 1</th>
+			<td headers="ar1 ar50 ar51 ac1 ac2" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar50 ar51 ac1 ac3" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar50 ar51 ac1 ac4" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar50 ar51 ac1 ac5" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar50 ar51 ac1 ac6" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar50 ar51 ac1 ac7" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar50 ar51 ac8 ac9" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar50 ar51 ac8 ac10" style="background-color:green; color: #FFF;">1.09</td>
+			<td headers="ar1 ar50 ar51 ac8 ac11" style="background-color:green; color: #FFF;">1.18</td>
+			<td headers="ar1 ar50 ar51 ac8 ac12" style="background-color:green; color: #FFF;">1.23</td>
+			<td headers="ar1 ar50 ar51 ac8 ac13" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar50 ar51 ac8 ac14" style="background-color:green; color: #FFF;">1.06</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar50" id="ar52">Dose 2</th>
+			<td headers="ar1 ar50 ar52 ac1 ac2" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar50 ar52 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar50 ar52 ac1 ac4" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar50 ar52 ac1 ac5" style="background-color:tomato">0.63</td>
+			<td headers="ar1 ar50 ar52 ac1 ac6" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar50 ar52 ac1 ac7" style="background-color:coral">0.69</td>
+			<td headers="ar1 ar50 ar52 ac8 ac9" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar50 ar52 ac8 ac10" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar50 ar52 ac8 ac11" style="background-color:green; color: #FFF;">1.09</td>
+			<td headers="ar1 ar50 ar52 ac8 ac12" style="background-color:green; color: #FFF;">1.15</td>
+			<td headers="ar1 ar50 ar52 ac8 ac13" style="background-color:green; color: #FFF;">1.05</td>
+			<td headers="ar1 ar50 ar52 ac8 ac14" style="background-color:lightgreen">0.89</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar53" rowspan="2">Southern</th>
+			<th headers="ar1 ar53" id="ar54">Dose 1</th>
+			<td headers="ar1 ar53 ar54 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar53 ar54 ac1 ac3" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar53 ar54 ac1 ac4" style="background-color:palegreen">0.83</td>
+			<td headers="ar1 ar53 ar54 ac1 ac5" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar53 ar54 ac1 ac6" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar53 ar54 ac1 ac7" style="background-color:palegreen">0.81</td>
+			<td headers="ar1 ar53 ar54 ac8 ac9" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar53 ar54 ac8 ac10" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar53 ar54 ac8 ac11" style="background-color:green; color: #FFF;">1.07</td>
+			<td headers="ar1 ar53 ar54 ac8 ac12" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar53 ar54 ac8 ac13" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar53 ar54 ac8 ac14" style="background-color:green; color: #FFF;">1.01</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar53" id="ar55">Dose 2</th>
+			<td headers="ar1 ar53 ar55 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar53 ar55 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar53 ar55 ac1 ac4" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar53 ar55 ac1 ac5" style="background-color:coral">0.66</td>
+			<td headers="ar1 ar53 ar55 ac1 ac6" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar53 ar55 ac1 ac7" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar53 ar55 ac8 ac9" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar53 ar55 ac8 ac10" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar53 ar55 ac8 ac11" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar53 ar55 ac8 ac12" style="background-color:green; color: #FFF;">1.05</td>
+			<td headers="ar1 ar53 ar55 ac8 ac13" style="background-color:lightgreen">0.87</td>
+			<td headers="ar1 ar53 ar55 ac8 ac14" style="background-color:mediumseagreen">0.93</td>
+		</tr>
+	</tbody>
+</table>
+
+<p>This table shows the rate of doses administered (per 1,000 population) to Māori or Pacific Peoples, relative to the rate of doses for Non-Māori and Non-Pacific groups. Less than one means the group is receiving a lower proportion of doses than would be expected if equity is being achieved. More than one means they are receiving a higher proportion of doses than would be expected if equity is being achieved. Exactly one means doses administered are in line with their proportion of population.</p>
+
+<ul>
+	<li><a download="" href="/web/20211028090127/https://www.health.govt.nz/system/files/documents/pages/rateratioexplainer_2.docx">Rate Ratio Explainer (Word, 434 KB)</a></li>
+</ul>
+
+<p>At all ages the size (weightings) of the age groups becomes a major contributing factor to comparative ratios, which is why the all ages (12+) figure may not appear to be in line with the age splits.</p>
+
+<h4><a id="uptake" name="uptake"></a>Vaccine uptake per 1,000 people by ethnicity</h4>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine uptake per 1,000 people by ethnicity" class="img-responsive" height="830" src="/web/20211028090127im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_eth_8.png" width="1780"/></figure>
+
+<h4><a id="uptake" name="uptake"></a>Vaccine uptake per 1,000 people by age band</h4>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine uptake per 1,000 people by age band" class="img-responsive" height="1030" src="/web/20211028090127im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_age_9.png" width="1780"/></figure>
+
+<h4><a id="uptake" name="location"></a>Vaccine uptake per 1,000 people by DHB of residence</h4>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine uptake per 1,000 people by DHB of residence" class="img-responsive" height="1030" src="/web/20211028090127im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_dhb_4.png" width="1780"/></figure>
+<!--
+<hr />
+<h3><a id="by_dhb_plan" name="dhb_plan"></a>Cumulative vaccination plan for DHBs</h3>
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">DHB of service</th>
+			<th scope="col" style="text-align:right">Actuals to Sunday 24 October</th>
+			<th scope="col" style="text-align:right">DHB Plan to Sunday 24 October</th>
+			<th scope="col" style="text-align:right">Variance</th>
+			<th scope="col" style="text-align:right">% of Plan</th>
+			<th scope="col" style="text-align:right">Week to date</th>
+		</tr>
+	</thead>
+	<tbody> --><!--plan--><!--
+<tr><td nowrap="nowrap">Auckland Metro</td><td>190621</td><td>205515</td><td>-14894</td><td>93%</td><td>9913</td></tr>
+<tr><td nowrap="nowrap">Bay of Plenty</td><td>22841</td><td>14255</td><td>8586</td><td>160%</td><td>1843</td></tr>
+<tr><td nowrap="nowrap">Canterbury</td><td>50558</td><td>39266</td><td>11292</td><td>129%</td><td>2769</td></tr>
+<tr><td nowrap="nowrap">Capital & Coast and Hutt Valley</td><td>48758</td><td>39742</td><td>9016</td><td>123%</td><td>1796</td></tr>
+<tr><td nowrap="nowrap">Hawke's Bay</td><td>15319</td><td>18205</td><td>-2886</td><td>84%</td><td>1351</td></tr>
+<tr><td nowrap="nowrap">Lakes</td><td>13437</td><td>12810</td><td>627</td><td>105%</td><td>731</td></tr>
+<tr><td nowrap="nowrap">MidCentral</td><td>10708</td><td>7237</td><td>3471</td><td>148%</td><td>1191</td></tr>
+<tr><td nowrap="nowrap">Nelson Marlborough</td><td>30198</td><td>18574</td><td>11624</td><td>163%</td><td>1285</td></tr>
+<tr><td nowrap="nowrap">Northland</td><td>21469</td><td>24762</td><td>-3293</td><td>87%</td><td>1257</td></tr>
+<tr><td nowrap="nowrap">South Canterbury</td><td>8106</td><td>8033</td><td>73</td><td>101%</td><td>389</td></tr>
+<tr><td nowrap="nowrap">Southern</td><td>35234</td><td>34594</td><td>640</td><td>102%</td><td>1794</td></tr>
+<tr><td nowrap="nowrap">Tairāwhiti</td><td>4579</td><td>4928</td><td>-349</td><td>93%</td><td>290</td></tr>
+<tr><td nowrap="nowrap">Taranaki</td><td>5619</td><td>5297</td><td>322</td><td>106%</td><td>168</td></tr>
+<tr><td nowrap="nowrap">Waikato</td><td>36070</td><td>32842</td><td>3228</td><td>110%</td><td>1905</td></tr>
+<tr><td nowrap="nowrap">Wairarapa</td><td>4516</td><td>4960</td><td>-444</td><td>91%</td><td>468</td></tr>
+<tr><td nowrap="nowrap">West Coast</td><td>3533</td><td>3300</td><td>233</td><td>107%</td><td>336</td></tr>
+<tr><td nowrap="nowrap">Whanganui</td><td>6982</td><td>4711</td><td>2271</td><td>148%</td><td>612</td></tr>
+<tr><td nowrap="nowrap">Other Sites</td><td>24890</td><td>14575</td><td>10315</td><td>171%</td><td>613</td></tr>
+<tr><td nowrap="nowrap">Total</td><td>533438</td><td>493606</td><td>39832</td><td>108%</td><td>28711</td></tr>
+!--plan_end--><!--	</tbody>
+</table>
+
+
+<p>The information provided in this table is based on cumulative DHB plans to the last week ending on Sunday. The final column shows vaccinations administered since Sunday by DHB of service to reconcile total actuals in this table to other total numbers shown.   On-going, and as we roll-out the vaccination programme, we anticipate that there could be a potential variance of up to ten percent (plus or minus) between DHB Plans and actual vaccination numbers. This is on the basis that, for example, an unplanned significant event could affect roll-out implementation or some DHBs might exceed their planned vaccination numbers.
+</p>
+-->
+
+<hr/>
+<h3><a id="by_dhb" name="location"></a>Cumulative vaccinations by DHB</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Cumulative vaccinations for DHBs" class="img-responsive" height="830" src="/web/20211028090127im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/dhbstacked_12.png" width="1780"/></figure>
+
+<hr/>
+<h3><a id="by-day" name="by-day"></a>Vaccinations by day</h3>
+
+<figure class="image-captioned img-responsive"><img alt="Vaccination doses administered per day" class="img-responsive" height="830" src="/web/20211028090127im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/vaccinebyday_12.png" width="1780"/></figure>
+
+<p>This chart shows the count of vaccinations administered on a given day from the COVID-19 Immunisation Register. Note some records are entered in the register at a later date than the immunisation was received. This means that the figures for a given date may move for some time after that date.</p>
+
+<hr/>
+<h3><a id="group" name="group"></a>Vaccinations by group by week</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccinations by group" class="img-responsive" height="830" src="/web/20211028090127im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/vaccinebygroupwk_12.png" width="1780"/></figure>
+
+<hr/>
+<h3><a id="group_d" name="group_d"></a>Cumulative vaccinations by group</h3>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">Priority Group</th>
+			<th scope="col" style="text-align:right">First dose administered</th>
+			<th scope="col" style="text-align:right">Second dose administered</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">Group 1</th>
+			<td style="text-align:right">66,767</td>
+			<td style="text-align:right">65,205</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Group 2</th>
+			<td style="text-align:right">661,231</td>
+			<td style="text-align:right">621,689</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Group 3</th>
+			<td style="text-align:right">793,481</td>
+			<td style="text-align:right">746,741</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Group 4</th>
+			<td style="text-align:right">2,136,491</td>
+			<td style="text-align:right">1,585,195</td>
+		</tr>
+	</tbody>
+</table>
+
+<p>For definitions of the groups and further detail see the downloadable spreadsheet at the bottom of the page.</p>
+
+<hr/>
+<h3><a id="by_soh" name="stockonhand"></a>Vaccine available for distribution at week end</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine available for distribution at week end" class="img-responsive" height="830" src="/web/20211028090127im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/stockonhand_13.png" width="1780"/></figure>
+
+<p>Vaccine available for distribution is stock (in doses) held at central warehouses. It does not include stock in transit or available at sites ready for use.</p>
+
+<hr/>
+<h3><a id="by_eth" name="ethnicity"></a>Total cumulative doses per 1,000 people by ethnicity</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Total cumulative doses per 1,000 people by ethnicity" class="img-responsive" height="830" src="/web/20211028090127im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/ethnicity_12.png" width="1780"/></figure>
+
+<p>This chart shows both first and second doses. As a result this chart may exceed 1,000 doses per 1,000 people.</p>
+
+<p><strong>*</strong> The prioritised ethnicity classification system allocates each person to a single ethnic group, based on the ethnic groups they identify with. Where people identify with more than one group, they are assigned in this order of priority: Māori, Pacific Peoples, Asian, and European/Other. So, if a person identifies as being Māori and New Zealand European, the person is counted as Māori. See <a href="/web/20211028090127/https://www.health.govt.nz/publication/hiso-100012017-ethnicity-data-protocols">Ethnicity Data Protocols</a> for further information.</p>
+
+<p>Ethnicity breakdown by DHB of residence is available in the downloadable spreadsheet at the bottom of the page.</p>
+
+<hr/>
+<h3><a id="by_age" name="age"></a>Cumulative vaccinations by age</h3>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">Age</th>
+			<th scope="col" style="text-align:right">First dose administered</th>
+			<th scope="col" style="text-align:right">First doses per 1,000 people</th>
+			<th scope="col" style="text-align:right">Fully vaccinated</th>
+			<th scope="col" style="text-align:right">Fully vaccinated per 1,000 people</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">12 - 19 years</th>
+			<td style="text-align:right">403,029</td>
+			<td style="text-align:right">802</td>
+			<td style="text-align:right">279,575</td>
+			<td style="text-align:right">557</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">20 - 34 years</th>
+			<td style="text-align:right">845,409</td>
+			<td style="text-align:right">817</td>
+			<td style="text-align:right">604,676</td>
+			<td style="text-align:right">585</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">35 - 49 years</th>
+			<td style="text-align:right">824,175</td>
+			<td style="text-align:right">862</td>
+			<td style="text-align:right">670,851</td>
+			<td style="text-align:right">701</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">50 - 64 years</th>
+			<td style="text-align:right">836,170</td>
+			<td style="text-align:right">901</td>
+			<td style="text-align:right">749,933</td>
+			<td style="text-align:right">809</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">65 and over</th>
+			<td style="text-align:right">749,187</td>
+			<td style="text-align:right">950</td>
+			<td style="text-align:right">713,795</td>
+			<td style="text-align:right">905</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total</strong></th>
+			<td style="text-align:right"><strong>3,657,970</strong></td>
+			<td style="text-align:right"><strong>869</strong></td>
+			<td style="text-align:right"><strong>3,018,830</strong></td>
+			<td style="text-align:right"><strong>717</strong></td>
+		</tr>
+	</tbody>
+</table>
+
+<p>Age breakdown by ethnicity and gender is available in the downloadable spreadsheet at the bottom of the page.</p>
+
+<hr/>
+<h3><a id="workforce" name="workforce"></a>Trained vaccinators and active vaccinators</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Trained vaccinators and active vaccinators" class="img-responsive" height="830" src="/web/20211028090127im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/workforce_12.png" width="1780"/></figure>
+
+<p><strong>Trained vaccinators</strong> are individuals who have completed the COVID-19 training. Many trained people are only able to offer a small number of hours to the COVID-19 vaccination programme.</p>
+
+<p><strong>Active vaccinators</strong> are trained individuals who are actively vaccinating. The number of active vaccinators does not reflect the hours worked vaccinating. For example, one vaccinator may work 40 hours in a week at one DHB and will show as 1 vaccinator in the headcount. In another DHB, 4 vaccinators may work 10 hours each (total 40 hours), but will show as 4 vaccinators in the headcount for that week.</p>
+
+<p>Both counts of trained and active vaccinators are cumulative. The difference between the two is due to a number of factors. This includes: individuals being trained in anticipation of future sites being opened (the largest factor); rostering; leave or non-availability; local health priorities; sites opening and closing.</p>
+
+<hr/>
+<h3><a id="usage" name="usage"></a>Wastage of vaccine stock</h3>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">&nbsp;</th>
+			<th scope="col">Wastage</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">New Zealand</th>
+			<td>0.29%</td>
+		</tr>
+	</tbody>
+</table>
+
+<p>Wastage is vials that have been reported as wasted since 13 July in the Inventory portal by DHBs or central warehouses divided by vials used over the same time frame.</p>
+
+<h3><a id="download" name="download"></a>Details of vaccination data</h3>
+
+<p>Download a spreadsheet containing key vaccination data. This includes HSU based population estimates for calculating vaccine uptake rates.</p>
+
+<p><a download="" href="/web/20211028090127/https://www.health.govt.nz/system/files/documents/pages/covid_vaccinations_26_10_2021.xlsx">COVID-19 vaccination data through 26 Oct 2021 (Excel, 363 KB)</a></p>
+
+<p>This spreadsheet is based on the information made available at the time of publishing and may be subject to changes. Please take note of any notes and caveats on each sheet.</p>
+
+<p>The below attachments provide some analysis on our progress on equity. The two PDF files are high level summaries of overall progress. The Excel documents are interactive and provides the ability to delve further into those overall numbers. NB: These Excel workbooks use features that are non-compatible with versions of MS Office 2016 and earlier.</p>
+
+<ul>
+	<li><a download="" href="/web/20211028090127/https://www.health.govt.nz/system/files/documents/pages/211024_-_cvip_equity_-_rate_ratios_by_ethnicity_ageband_and_dhb.pdf">Covid-19 Vaccine Rate Ratios by Ethnicity, Ageband and DHB (PDF, 642 KB)</a></li>
+	<li><a download="" href="/web/20211028090127/https://www.health.govt.nz/system/files/documents/pages/211024_-_cvip_equity_-_uptake_by_ethnicity_ageband_and_dhb.pdf">Covid-19 Vaccine Uptake by Ethnicity, Ageband and DHB (PDF, 550 KB)</a></li>
+	<li><a download="" href="/web/20211028090127/https://www.health.govt.nz/system/files/documents/pages/211024_-_cvip_equity_-_level_1_ethnicity_uptake_and_rate_ratios.xlsx">Covid-19 Vaccine Equity - Level 1 Ethnicity Uptake and Rate Ratios (Excel, 152 KB)</a></li>
+	<li><a download="" href="/web/20211028090127/https://www.health.govt.nz/system/files/documents/pages/211024_-_cvip_equity_-_level_2_ethnicity_uptake_and_rate_ratios.xlsx">Covid-19 Vaccine Equity - Level 2 Ethnicity Uptake and Rate Ratios (Excel, 378 KB)</a></li>
+	<li><a download="" href="/web/20211028090127/https://www.health.govt.nz/system/files/documents/pages/211024_-_cvip_equity_-_rate_ratios_and_uptake_over_time.xlsx">Rate Ratios and Uptake Over Time (Excel, 996 KB)</a></li>
+</ul>
+
+<hr/>
+<h3><a id="adverse-events" name="adverse-events"></a>Adverse events following&nbsp;immunisations (AEFI)</h3>
+
+<p>Like all medicines, the COVID-19 vaccine may cause side effects in some people. These are common, are usually mild, don&rsquo;t last long and won&rsquo;t stop people from having the second dose or going about daily life. Serious allergic reactions do occur but are extremely rare.</p>
+
+<p>Suspected AEFI to COVID-19 vaccines are reported to the <a href="https://web.archive.org/web/20211028090127/https://nzphvc.otago.ac.nz/">Centre for Adverse Reactions Monitoring</a> (CARM).&nbsp;<a href="https://web.archive.org/web/20211028090127/https://www.medsafe.govt.nz/">Medsafe</a> is closely monitoring the AEFI reported from the use of the COVID-19 vaccine and will report regularly on their findings.&nbsp;</p>
+
+<p><a href="https://web.archive.org/web/20211028090127/https://www.medsafe.govt.nz/COVID-19/vaccine-report-overview.asp">View Medsafe data on COVID-19 vaccine adverse effects following immunisation</a></p>
+</div></div></div>    </article>
+  </div>
+
+
+  </div>
+<div class="panel-pane pane-node-links even">
+
+
+
+  <div class="pane-content">
+          </div>
+
+
+  </div>
+
+<div class="panel-pane pane-views pane-sub-pages even">
+
+        <h2 class="pane-title h3">In this section</h2>
+
+
+  <div class="pane-content">
+        <div class="view view-sub-pages view-id-sub_pages view-display-id-block view-dom-id-75b02ef976685e3d4cc386380512ba41">
+
+
+
+      <div class="view-content">
+      <div class="item-list">    <ul>          <li class="views-row views-row-1 views-row-odd views-row-first">
+  <div class="views-field views-field-title">        <div class="field-content">
+<div class="views-field views-field-title">
+  <h3 class="field-content">
+    <a href="/web/20211028090127/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-across-nz">COVID-19 Vaccination uptake rates across NZ</a>  </h3>
+</div></div>  </div>
+  <span class="views-field views-field-body">        <span class="field-content">This page provides information related to uptake rates of the COVID-19 vaccine across the country.
+</span>  </span>
+  <span class="views-field views-field-view-node">        <span class="field-content"><a href="/web/20211028090127/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-across-nz">Read more</a></span>  </span></li>
+          <li class="views-row views-row-2 views-row-even">
+  <div class="views-field views-field-title">        <div class="field-content">
+<div class="views-field views-field-title">
+  <h3 class="field-content">
+    <a href="/web/20211028090127/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-maori-communities-across-nz">COVID-19 Vaccination uptake rates within Māori communities across NZ</a>  </h3>
+</div></div>  </div>
+  <span class="views-field views-field-body">        <span class="field-content">This page provides information related to uptake rates of the COVID-19 vaccine within Māori communities across New Zealand.
+</span>  </span>
+  <span class="views-field views-field-view-node">        <span class="field-content"><a href="/web/20211028090127/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-maori-communities-across-nz">Read more</a></span>  </span></li>
+          <li class="views-row views-row-3 views-row-odd views-row-last">
+  <div class="views-field views-field-title">        <div class="field-content">
+<div class="views-field views-field-title">
+  <h3 class="field-content">
+    <a href="/web/20211028090127/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-pacific-communities-across-nz">COVID-19 Vaccination uptake rates within Pacific communities across NZ</a>  </h3>
+</div></div>  </div>
+  <span class="views-field views-field-body">        <span class="field-content">This page provides information related to uptake rates of the COVID-19 vaccine within Pacific communities across New Zealand.
+</span>  </span>
+  <span class="views-field views-field-view-node">        <span class="field-content"><a href="/web/20211028090127/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-pacific-communities-across-nz">Read more</a></span>  </span></li>
+      </ul></div>    </div>
+
+
+
+
+
+
+</div>  </div>
+
+
+  </div>
+</div>          </div>
+
+  </div>
+
+</section>
+  </div>
+      </section>
+
+
+    </div>
+    <div id="content-footer-wrapper" class="clearfix">
+      <div id="content-footer" class="clearfix">
+                  <p class="page_updated">Page last updated: <span class="date">28 October 2021</span></p>                  <div class="region region-content-footer">
+    <section id="block-moh-tools-page-tools" class="block block-moh-tools clearfix">
+  <a href="#" data-placement="top" data-title="Share this content." data-html="true" data-content="<p>Share this page on some of the most popular social networking and content sites on the internet.</p><div class='service-links'><ul><li><a href='https://twitter.com/share?url=https%3A//www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data&amp;text=COVID-19%3A%20Vaccine%20data' title='Share this on Twitter' class='service-links-twitter' rel='nofollow'><img typeof='foaf:Image' class='img-responsive' src='https://www.health.govt.nz/sites/all/modules/contrib/service_links/images/twitter.png' alt='Twitter' /> Twitter</a></li>
+<li><a href='https://www.facebook.com/sharer.php?u=https%3A//www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data&amp;t=COVID-19%3A%20Vaccine%20data' title='Share on Facebook' class='service-links-facebook' rel='nofollow'><img typeof='foaf:Image' class='img-responsive' src='https://www.health.govt.nz/sites/all/modules/contrib/service_links/images/facebook.png' alt='Facebook' /> Facebook</a></li>
+</ul></div>" class="share-this-content"><i class="fa fa-share"></i> Share</a><a href="#" title="print this page" class="print"><i class="fa fa-print"></i> Print</a><a href="https://web.archive.org/web/20211028090127/https://www.health.govt.nz/forward?path=node/12052" title="Email this page" class="email"><i class="fa fa-envelope"></i> Email</a><a href="/web/20211028090127/https://www.health.govt.nz/feedback?ref=https%3A//www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="Feedback" class="rss"><i class="fa fa-comment"></i> Feedback</a></section>
+
+  </div>
+      </div>
+    </div>
+
+  </div>
+  <footer class="footer container">
+    <h2 class="hidden">Site Footer</h2>
+    <div class="footer-default">
+      <div class="row">
+        <div class="col-sm-6 col-md-6">
+          <div class="field field-name-field-tax-first-column-links">
+            <ul class="field-items"><li class="field-item"><a href="https://web.archive.org/web/20211028090127/https://www.health.govt.nz/node/492" class="">About this site</a></li><li class="field-item"><a href="https://web.archive.org/web/20211028090127/https://www.health.govt.nz/node/524" class="">Contact us</a></li><li class="field-item"><a href="https://web.archive.org/web/20211028090127/https://www.health.govt.nz/node/488" class="">Other Ministry of Health websites</a></li><li class="field-item"><a href="https://web.archive.org/web/20211028090127/https://www.health.govt.nz/node/7497" class="">Official Information Act requests</a></li><li class="field-item"><a href="https://web.archive.org/web/20211028090127/https://www.health.govt.nz/about-ministry/information-releases" class="">Information releases</a></li><li class="field-item"><a href="https://web.archive.org/web/20211028090127/https://consult.health.govt.nz/" class="">Consultations</a></li></ul>
+          </div>
+        </div>
+        <div class="col-sm-6 col-md-6">
+          <div class="field field-name-field-tax-footer-body field-type-text-long field-label-hidden"><div class="field-items"><div class="field-item even"><h3>Where to go for help</h3>
+
+<table>
+	<tbody>
+		<tr>
+			<th scope="row">Emergencies</th>
+			<td><strong>Dial <a href="tel:111">111</a></strong> (for ambulance, fire or police)</td>
+		</tr>
+		<tr>
+			<th scope="row">Healthline</th>
+			<td><strong>Dial <a href="tel:0800611116">0800 611 116</a></strong></td>
+		</tr>
+		<tr>
+			<th scope="row">Poisons</th>
+			<td><strong>Dial <a href="tel:0800764766">0800 POISON</a> </strong>(<a href="tel:0800764766">0800 764 766</a>)</td>
+		</tr>
+		<tr>
+			<th scope="row">Mental health crisis</th>
+			<td><strong><a href="/web/20211028090127/https://www.health.govt.nz/your-health/services-and-support/health-care-services/mental-health-services/crisis-assessment-teams">Emergency contact numbers</a></strong></td>
+		</tr>
+	</tbody>
+</table>
+</div></div></div>        </div>
+      </div>
+      <div class="row">
+        <div class="sub-footer">
+          <div class="column col-sm-12 col-md-3">
+            <a href="https://web.archive.org/web/20211028090127/https://www.govt.nz/">
+              <img src="/web/20211028090127im_/https://www.health.govt.nz/sites/all/themes/mohpub_bootstrap/images/nzgovtlogo_white.png" width="152" height="16" alt="govt.nz - connecting you to New Zealand central &amp; local government services" title="govt.nz - connecting you to New Zealand central &amp; local government services"/>
+            </a>
+          </div>
+          <div class="column col-sm-12 col-md-9">
+          <span class="bottom-menu-moh with-v-divider">&copy; Ministry of Health – Manatū Hauora</span><ul class="bottom-menu-list"><li class="bottom-menu-list-item with-v-divider"><a href="https://web.archive.org/web/20211028090127/https://www.health.govt.nz/sitemap" class="">Site map</a></li><li class="bottom-menu-list-item with-v-divider"><a href="https://web.archive.org/web/20211028090127/https://www.health.govt.nz/about-site/privacy-and-security" class="">Privacy &amp; security</a></li><li class="bottom-menu-list-item with-v-divider"><a href="https://web.archive.org/web/20211028090127/https://www.health.govt.nz/about-site/copyright" class="">Copyright</a></li></ul>          </div>
+        </div>
+      </div>
+    </div>
+    <div class="footer-print">&copy; Ministry of Health – Manatū Hauora</div>
+  </footer>
+  <a class="scrollToTop">Back to top <i class="fas fa-arrow-up"></i></a>
+</div>
+  <script src="https://web.archive.org/web/20211028090127js_/https://www.health.govt.nz/sites/default/files/js/js_akZOsKtodu3PdnQzY3_ElOfujkLxJcowmaWgHTBBLOE.js"></script>
+</body>
+</html>
+<!--
+     FILE ARCHIVED ON 09:01:27 Oct 28, 2021 AND RETRIEVED FROM THE
+     INTERNET ARCHIVE ON 03:22:28 Nov 07, 2021.
+     JAVASCRIPT APPENDED BY WAYBACK MACHINE, COPYRIGHT INTERNET ARCHIVE.
+
+     ALL OTHER CONTENT MAY ALSO BE PROTECTED BY COPYRIGHT (17 U.S.C.
+     SECTION 108(a)(3)).
+-->
+<!--
+playback timings (ms):
+  captures_list: 88.904
+  exclusion.robots: 0.323
+  exclusion.robots.policy: 0.311
+  RedisCDXSource: 0.826
+  esindex: 0.015
+  LoadShardBlock: 42.656 (3)
+  PetaboxLoader3.datanode: 56.447 (4)
+  CDXLines.iter: 32.895 (3)
+  load_resource: 107.803
+  PetaboxLoader3.resolve: 29.898
+-->

--- a/data/rawSite/2021-10-28.html
+++ b/data/rawSite/2021-10-28.html
@@ -1,0 +1,2523 @@
+
+<!DOCTYPE html>
+<html lang="en" dir="ltr" prefix="" class="no-js">
+<head><script src="//archive.org/includes/analytics.js?v=cf34f82" type="text/javascript"></script>
+<script type="text/javascript">window.addEventListener('DOMContentLoaded',function(){var v=archive_analytics.values;v.service='wb';v.server_name='wwwb-app214.us.archive.org';v.server_ms=172;archive_analytics.send_pageview({});});</script>
+<script type="text/javascript" src="/_static/js/bundle-playback.js?v=UfTkgsKx" charset="utf-8"></script>
+<script type="text/javascript" src="/_static/js/wombat.js?v=UHAOicsW" charset="utf-8"></script>
+<script type="text/javascript">
+  __wm.init("https://web.archive.org/web");
+  __wm.wombat("https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data","20211029114420","https://web.archive.org/","web","/_static/",
+	      "1635507860");
+</script>
+<link rel="stylesheet" type="text/css" href="/_static/css/banner-styles.css?v=omkqRugM" />
+<link rel="stylesheet" type="text/css" href="/_static/css/iconochive.css?v=qtvMKcIJ" />
+<!-- End Wayback Rewrite JS Include -->
+
+  <!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta name="format-detection" content="telephone=no"/>
+  <link rel="profile" href="http://www.w3.org/1999/xhtml/vocab"/>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+<link rel="shortcut icon" href="https://web.archive.org/web/20211029114420im_/https://www.health.govt.nz/sites/all/themes/mohpub_bootstrap/favicon.ico" type="image/vnd.microsoft.icon"/>
+<meta name="description" content="Dashboard of data and statistics about the rollout of COVID-19 vaccines in New Zealand"/>
+<meta name="generator" content="Drupal 7 (https://www.drupal.org)"/>
+<link rel="canonical" href="https://web.archive.org/web/20211029114420/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data"/>
+<link rel="shortlink" href="https://web.archive.org/web/20211029114420/https://www.health.govt.nz/node/12052"/>
+<meta property="og:site_name" content="Ministry of Health NZ"/>
+<meta property="og:type" content="article"/>
+<meta property="og:url" content="https://web.archive.org/web/20211029114420/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data"/>
+<meta property="og:title" content="COVID-19: Vaccine data"/>
+<meta property="og:description" content="Dashboard of data and statistics about the rollout of COVID-19 vaccines in New Zealand"/>
+  <title>COVID-19: Vaccine data | Ministry of Health NZ</title>
+  <link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211029114420cs_/https://www.health.govt.nz/sites/default/files/css/css_lQaZfjVpwP_oGNqdtWCSpJT1EMqXdMiU84ekLLxQnc4.css" media="all"/>
+<link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211029114420cs_/https://www.health.govt.nz/sites/default/files/css/css_jqUBpWfMaxMiP7LismdZVlyVv8azUJSE2yaH58nj0cE.css" media="all"/>
+<link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211029114420cs_/https://www.health.govt.nz/sites/default/files/css/css_Rb1wqFBC8VXCJC-BuNY53cvjjlj6UADGvqzo_f-1yN0.css" media="all"/>
+<link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211029114420cs_/https://www.health.govt.nz/sites/default/files/css/css_38_K1lHKg-98m4KKRfv57JBK0gvlKscexGt9MKoi0DE.css" media="all"/>
+<link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211029114420cs_/https://www.health.govt.nz/sites/default/files/css/css_r7NPyvpdYfAyZmk9zkK8OaFKEFj6er5ZJnam2H644DM.css" media="print"/>
+  <link rel="alternate stylesheet" type="text/css" href="/web/20211029114420cs_/https://www.health.govt.nz/sites/all/themes/mohpub_bootstrap/css/high-contrast.css" media="screen" title="High Contrast"/>
+  <script src="https://web.archive.org/web/20211029114420js_/https://www.health.govt.nz/sites/default/files/js/js_zS-CmNFGyegtLYJmqFRpxQvvQrfPIFrOMq_3T3C8sZE.js"></script>
+<script src="https://web.archive.org/web/20211029114420js_/https://www.health.govt.nz/sites/default/files/js/js_fNgZ4Okisfr70Q0yvAYsATgB0o_jD3-srhQQ-VHmlXE.js"></script>
+<script src="https://web.archive.org/web/20211029114420js_/https://www.health.govt.nz/sites/default/files/js/js_YAdPZfg12M1m7ROp3_gVJPS5sArqL0kYQgNRPoicvHE.js"></script>
+<script>(function(i,s,o,g,r,a,m){i["GoogleAnalyticsObject"]=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,"script","https://web.archive.org/web/20211029114420/https://www.google-analytics.com/analytics.js","ga");ga("create", "UA-3573389-24", {"cookieDomain":".www.health.govt.nz","siteSpeedSampleRate":15});ga("send", "pageview");</script>
+<script src="https://web.archive.org/web/20211029114420js_/https://www.health.govt.nz/sites/default/files/js/js_QAXZNPwLISRLHqyNpT4Vvr_iqD9foD6GTbEjlhIIjeo.js"></script>
+<script src="https://web.archive.org/web/20211029114420js_/https://www.health.govt.nz/sites/default/files/js/js_4VW9edmu3V8VjGJxFfXGAwkXeW2cJIa5h-6y7SgwVrk.js"></script>
+<script>    (function(h,o,t,j,a,r){
+        h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
+        h._hjSettings={hjid:930919,hjsv:6};
+        a=o.getElementsByTagName('head')[0];
+        r=o.createElement('script');r.async=1;
+        r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+        a.appendChild(r);
+    })(window,document,'https://web.archive.org/web/20211029114420/https://static.hotjar.com/c/hotjar-','.js?sv=');
+</script>
+<script>jQuery.extend(Drupal.settings, {"basePath":"\/","pathPrefix":"","ajaxPageState":{"theme":"mohpub_bootstrap","theme_token":"KjeKlRuTBCBKfbsSJf1tu7ILBUMhkBUv5BCFbe7NrTg","js":{"sites\/all\/modules\/custom\/table_d3chart\/js\/table_d3chart.js":1,"sites\/all\/modules\/custom\/moh_d3\/moh_d3.js":1,"sites\/all\/modules\/contrib\/jquery_update\/replace\/jquery\/1.7\/jquery.min.js":1,"misc\/jquery-extend-3.4.0.js":1,"misc\/jquery-html-prefilter-3.5.0-backport.js":1,"misc\/jquery.once.js":1,"misc\/drupal.js":1,"sites\/all\/modules\/contrib\/ckeditor_accordion\/js\/ckeditor-accordion.js":1,"sites\/all\/modules\/contrib\/extlink\/extlink.js":1,"modules\/field\/modules\/text\/text.js":1,"sites\/all\/modules\/contrib\/field_group\/field_group.js":1,"sites\/all\/modules\/contrib\/google_analytics\/googleanalytics.js":1,"0":1,"sites\/all\/libraries\/c3\/c3.js":1,"sites\/all\/libraries\/d3\/d3.min.js":1,"sites\/all\/modules\/contrib\/d3\/js\/d3.js":1,"sites\/all\/libraries\/d3.helpers\/d3.helpers.js":1,"sites\/all\/libraries\/d3.c3\/d3-c3.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/assets\/ios-fix.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/affix.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/alert.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/button.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/carousel.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/collapse.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/dropdown.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/modal.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/tooltip.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/popover.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/scrollspy.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/tab.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/transition.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/jquery.cookie.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/jquery.moh.announcement.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/svgeezy.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/fitvids.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/bootstrap-tabcollapse.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/jquery.scrollTo.min.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/script.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/jquery.google_analytics.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/bootstrap-accessibility.min.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/style-switcher.js":1,"1":1},"css":{"modules\/system\/system.base.css":1,"sites\/all\/modules\/contrib\/calendar\/css\/calendar_multiday.css":1,"sites\/all\/modules\/contrib\/ckeditor_accordion\/css\/ckeditor-accordion.css":1,"modules\/field\/theme\/field.css":1,"modules\/node\/node.css":1,"sites\/all\/modules\/contrib\/extlink\/extlink.css":1,"sites\/all\/modules\/contrib\/views\/css\/views.css":1,"sites\/all\/modules\/contrib\/ckeditor\/css\/ckeditor.css":1,"sites\/all\/modules\/contrib\/ctools\/css\/ctools.css":1,"sites\/all\/modules\/contrib\/panels\/css\/panels.css":1,"sites\/all\/libraries\/c3\/c3.css":1,"sites\/all\/libraries\/d3.c3\/d3-c3.css":1,"sites\/all\/themes\/mohpub_bootstrap\/fontawesome\/css\/fontawesome.min.css":1,"sites\/all\/themes\/mohpub_bootstrap\/fontawesome\/css\/solid.min.css":1,"sites\/all\/themes\/mohpub_bootstrap\/fontawesome\/css\/brands.min.css":1,"sites\/all\/modules\/features\/site_profile\/css\/fix-rubik-multiselect-height.css":1,"sites\/all\/themes\/mohpub_bootstrap\/css\/style.css":1,"sites\/all\/themes\/mohpub_bootstrap\/css\/responsive-tables.css":1,"sites\/all\/themes\/mohpub_bootstrap\/css\/print.css":1}},"field_group":{"div":"full"},"ckeditor_accordion":{"collapseAll":1},"extlink":{"extTarget":0,"extClass":"ext","extLabel":"(link is external)","extImgClass":0,"extIconPlacement":"append","extSubdomains":0,"extExclude":"","extInclude":"","extCssExclude":"","extCssExplicit":"","extAlert":0,"extAlertText":"This link will take you to an external web site. We are not responsible for their content.","mailtoClass":"mailto","mailtoLabel":"(link sends e-mail)"},"googleanalytics":{"trackOutbound":1,"trackMailto":1,"trackDownload":1,"trackDownloadExtensions":"7z|aac|arc|arj|asf|asx|avi|bin|csv|doc|exe|flv|gif|gz|gzip|hqx|jar|jpe?g|js|mp(2|3|4|e?g)|mov(ie)?|msi|msp|pdf|phps|png|ppt|qtm?|ra(m|r)?|sea|sit|tar|tgz|torrent|txt|wav|wma|wmv|wpd|xls|xml|z|zip|docx|xlsx|pptx|pptm|ppsx|ppsm|epub"},"mohD3":{"C3Types":["line","spline","step","area","area-spline","area-step","bar","scatter","pie","donut","gauge"],"graphRender":"line","graphLegend":true,"graphDefaultColors":"#2b8cbe, #abdda4, #7f7f7f, #92cddc, #dc8b0c","graphDefaultGroupedTooltip":0,"graphDefaultGridX":0,"graphDefaultGridY":0,"graphDefaultLegendPosition":"top-right","graphDefaultTooltip":1,"graphDefaultDataLabel":0,"graphLegendStep":"5","graphInteraction":true,"graphTypes":"","graphXaxisShow":true,"graphXaxisLabel":"","graphYaxisLabel":"","graphXaxisType":"category","graphXaxisCentered":false,"graphXaxisRotation":"","graphXaxisHeight":"","graphYaxisShow":true,"graphYaxisMax":"","graphYaxisMin":"","graphYaxisInverted":false,"graphYaxisCenter":"","graphYaxisPrefix":"","graphYaxisSuffix":"","graphYaxisPosition":"","graphY2axisShow":false,"graphY2axisSource":"","graphY2axisMax":"","graphY2axisMin":"","graphGroups":"","graphRotated":false,"graphIgnoreEmpty":false,"graphLineDot":true,"graphBarRatio":"0.9","graphDot":true,"graphDotR":"2.5","graphFocus":false},"tableD3":{"show":"View table data source","hide":"Hide table data source"},"urlIsAjaxTrusted":{"\/our-work\/diseases-and-conditions\/covid-19-novel-coronavirus\/covid-19-data-and-statistics\/covid-19-vaccine-data":true},"bootstrap":{"anchorsFix":1,"anchorsSmoothScrolling":1,"formHasError":1,"popoverEnabled":1,"popoverOptions":{"animation":1,"html":0,"placement":"right","selector":"","trigger":"click","triggerAutoclose":1,"title":"","content":"","delay":0,"container":"body"},"tooltipEnabled":1,"tooltipOptions":{"animation":1,"html":0,"placement":"auto left","selector":"","trigger":"hover focus","delay":0,"container":"body"}}});</script>
+  <!-- HTML5 element support for IE6-8 -->
+  <!--[if lt IE 9]>
+    <script src="/sites/all/themes/mohpub_bootstrap/js/assets/html5shiv.js"></script>
+    <script src="/sites/all/themes/mohpub_bootstrap/js/assets/respond.min.js"></script>
+  <![endif]-->
+</head>
+<body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-12052 node-type-page node-has-intro"><!-- BEGIN WAYBACK TOOLBAR INSERT -->
+<style type="text/css">
+body {
+  margin-top:0 !important;
+  padding-top:0 !important;
+  /*min-width:800px !important;*/
+}
+</style>
+<script>__wm.rw(0);</script>
+<div id="wm-ipp-base" lang="en" style="display:none;direction:ltr;">
+<div id="wm-ipp" style="position:fixed;left:0;top:0;right:0;">
+<div id="wm-ipp-inside">
+  <div style="position:relative;">
+    <div id="wm-logo" style="float:left;width:110px;padding-top:12px;">
+      <a href="/web/" title="Wayback Machine home page"><img src="/_static/images/toolbar/wayback-toolbar-logo-200.png" srcset="/_static/images/toolbar/wayback-toolbar-logo-100.png, /_static/images/toolbar/wayback-toolbar-logo-150.png 1.5x, /_static/images/toolbar/wayback-toolbar-logo-200.png 2x" alt="Wayback Machine" style="width:100px" border="0" /></a>
+    </div>
+    <div class="r" style="float:right;">
+      <div id="wm-btns" style="text-align:right;height:25px;">
+                  <div id="wm-save-snapshot-success">success</div>
+          <div id="wm-save-snapshot-fail">fail</div>
+          <a id="wm-save-snapshot-open" href="#"
+	     title="Share via My Web Archive" >
+            <span class="iconochive-web"></span>
+          </a>
+          <a href="https://archive.org/account/login.php"
+             title="Sign In"
+             id="wm-sign-in"
+          >
+            <span class="iconochive-person"></span>
+          </a>
+          <span id="wm-save-snapshot-in-progress" class="iconochive-web"></span>
+        	<a href="http://faq.web.archive.org/" title="Get some help using the Wayback Machine" style="top:-6px;"><span class="iconochive-question" style="color:rgb(87,186,244);font-size:160%;"></span></a>
+	<a id="wm-tb-close" href="#close" onclick="__wm.h(event);return false;" style="top:-2px;" title="Close the toolbar"><span class="iconochive-remove-circle" style="color:#888888;font-size:240%;"></span></a>
+      </div>
+      <div id="wm-share">
+          <a href="/web/20211029114420/http://web.archive.org/screenshot/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data"
+             id="wm-screenshot"
+             title="screenshot">
+            <span class="wm-icon-screen-shot"></span>
+          </a>
+          <a href="#"
+            id="wm-video"
+            title="video">
+            <span class="iconochive-movies"></span>
+          </a>
+	<a id="wm-share-facebook" href="#" data-url="https://web.archive.org/web/20211029114420/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="Share on Facebook" style="margin-right:5px;" target="_blank"><span class="iconochive-facebook" style="color:#3b5998;font-size:160%;"></span></a>
+	<a id="wm-share-twitter" href="#" data-url="https://web.archive.org/web/20211029114420/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="Share on Twitter" style="margin-right:5px;" target="_blank"><span class="iconochive-twitter" style="color:#1dcaff;font-size:160%;"></span></a>
+      </div>
+    </div>
+    <table class="c" style="">
+      <tbody>
+	<tr>
+	  <td class="u" colspan="2">
+	    <form target="_top" method="get" action="/web/submit" name="wmtb" id="wmtb"><input type="text" name="url" id="wmtbURL" value="https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" onfocus="this.focus();this.select();" /><input type="hidden" name="type" value="replay" /><input type="hidden" name="date" value="20211029114420" /><input type="submit" value="Go" /></form>
+	  </td>
+	  <td class="n" rowspan="2" style="width:110px;">
+	    <table>
+	      <tbody>
+		<!-- NEXT/PREV MONTH NAV AND MONTH INDICATOR -->
+		<tr class="m">
+		  <td class="b" nowrap="nowrap"><a href="https://web.archive.org/web/20210929040157/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="29 Sep 2021"><strong>Sep</strong></a></td>
+		  <td class="c" id="displayMonthEl" title="You are here: 11:44:20 Oct 29, 2021">OCT</td>
+		  <td class="f" nowrap="nowrap">Nov</td>
+		</tr>
+		<!-- NEXT/PREV CAPTURE NAV AND DAY OF MONTH INDICATOR -->
+		<tr class="d">
+		  <td class="b" nowrap="nowrap"><a href="https://web.archive.org/web/20211028090127/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="09:01:27 Oct 28, 2021"><img src="/_static/images/toolbar/wm_tb_prv_on.png" alt="Previous capture" width="14" height="16" border="0" /></a></td>
+		  <td class="c" id="displayDayEl" style="width:34px;font-size:24px;white-space:nowrap;" title="You are here: 11:44:20 Oct 29, 2021">29</td>
+		  <td class="f" nowrap="nowrap"><a href="https://web.archive.org/web/20211031053713/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="05:37:13 Oct 31, 2021"><img src="/_static/images/toolbar/wm_tb_nxt_on.png" alt="Next capture" width="14" height="16" border="0" /></a></td>
+		</tr>
+		<!-- NEXT/PREV YEAR NAV AND YEAR INDICATOR -->
+		<tr class="y">
+		  <td class="b" nowrap="nowrap">2020</td>
+		  <td class="c" id="displayYearEl" title="You are here: 11:44:20 Oct 29, 2021">2021</td>
+		  <td class="f" nowrap="nowrap">2022</td>
+		</tr>
+	      </tbody>
+	    </table>
+	  </td>
+	</tr>
+	<tr>
+	  <td class="s">
+	    	    <div id="wm-nav-captures">
+	      	      <a class="t" href="/web/20211029114420*/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="See a list of every capture for this URL">682 captures</a>
+	      <div class="r" title="Timespan for captures of this URL">07 Apr 2021 - 06 Nov 2021</div>
+	      </div>
+	  </td>
+	  <td class="k">
+	    <a href="" id="wm-graph-anchor">
+	      <div id="wm-ipp-sparkline" title="Explore captures for this URL" style="position: relative">
+		<canvas id="wm-sparkline-canvas" width="650" height="27" border="0"></canvas>
+	      </div>
+	    </a>
+	  </td>
+	</tr>
+      </tbody>
+    </table>
+    <div style="position:absolute;bottom:0;right:2px;text-align:right;">
+      <a id="wm-expand" class="wm-btn wm-closed" href="#expand" onclick="__wm.ex(event);return false;"><span id="wm-expand-icon" class="iconochive-down-solid"></span> <span style="font-size:80%">About this capture</span></a>
+    </div>
+  </div>
+    <div id="wm-capinfo" style="border-top:1px solid #777;display:none; overflow: hidden">
+                    <div id="wm-capinfo-collected-by">
+    <div style="background-color:#666;color:#fff;font-weight:bold;text-align:center">COLLECTED BY</div>
+    <div style="padding:3px;position:relative" id="wm-collected-by-content">
+            <div style="display:inline-block;vertical-align:top;width:50%;">
+			<span class="c-logo" style="background-image:url(https://archive.org/services/img/focused_crawls);"></span>
+		Organization: <a style="color:#33f;" href="https://archive.org/details/focused_crawls" target="_new"><span class="wm-title">Internet Archive</span></a>
+		<div style="max-height:75px;overflow:hidden;position:relative;">
+	  <div style="position:absolute;top:0;left:0;width:100%;height:75px;background:linear-gradient(to bottom,rgba(255,255,255,0) 0%,rgba(255,255,255,0) 90%,rgba(255,255,255,255) 100%);"></div>
+	  Focused crawls are collections of frequently-updated webcrawl data from narrow (as opposed to broad or wide) web crawls, often focused on a single domain or subdomain.<br />
+	</div>
+	      </div>
+      <div style="display:inline-block;vertical-align:top;width:49%;">
+			<span class="c-logo" style="background-image:url(https://archive.org/services/img/abc.net.au-news)"></span>
+		<div>Collection: <a style="color:#33f;" href="https://archive.org/details/abc.net.au-news" target="_new"><span class="wm-title">abc.net.au-news</span></a></div>
+	      </div>
+    </div>
+    </div>
+    <div id="wm-capinfo-timestamps">
+    <div style="background-color:#666;color:#fff;font-weight:bold;text-align:center" title="Timestamps for the elements of this page">TIMESTAMPS</div>
+    <div>
+      <div id="wm-capresources" style="margin:0 5px 5px 5px;max-height:250px;overflow-y:scroll !important"></div>
+      <div id="wm-capresources-loading" style="text-align:left;margin:0 20px 5px 5px;display:none"><img src="/_static/images/loading.gif" alt="loading" /></div>
+    </div>
+    </div>
+  </div></div></div></div><div id="wm-ipp-print">The Wayback Machine - https://web.archive.org/web/20211029114420/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data</div>
+<div id="donato" style="position:relative;width:100%;">
+  <div id="donato-base">
+    <iframe id="donato-if" src="https://archive.org/includes/donate.php?as_page=1&amp;platform=wb&amp;referer=https%3A//web.archive.org/web/20211029114420/https%3A//www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data"
+	    scrolling="no" frameborder="0" style="width:100%; height:100%">
+    </iframe>
+  </div>
+</div><script type="text/javascript">
+__wm.bt(650,27,25,2,"web","https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data","20211029114420",1996,"/_static/",["/_static/css/banner-styles.css?v=omkqRugM","/_static/css/iconochive.css?v=qtvMKcIJ"], "False");
+  __wm.rw(1);
+</script>
+<!-- END WAYBACK TOOLBAR INSERT -->
+<!--googleoff: all-->
+  <div id="skip-link">
+    <a href="#skip-content" id="skipper" class="element-invisible element-focusable">Skip to main content</a>
+  </div>
+    <div id="page">
+  <header id="navbar" role="banner" class="navbar container navbar-default">
+          <ul class="menu nav navbar-nav secondary"><li class="first leaf jobs depth-1"><a href="https://web.archive.org/web/20211029114420/https://careers.health.govt.nz/" title="">Jobs</a></li>
+<li class="leaf news depth-1"><a href="/web/20211029114420/https://www.health.govt.nz/news-media" data-is-top-level="0" title="">News</a></li>
+<li class="leaf contact-us depth-1"><a href="/web/20211029114420/https://www.health.govt.nz/about-ministry/contact-us" title="">Contact us</a></li>
+<li class="leaf facebook depth-1"><a href="https://web.archive.org/web/20211029114420/https://www.facebook.com/minhealthnz/">Facebook</a></li>
+<li class="leaf twitter depth-1"><a href="https://web.archive.org/web/20211029114420/https://twitter.com/minhealthnz" data-is-top-level="0" title="">Twitter</a></li>
+<li class="last leaf youtube depth-1"><a href="https://web.archive.org/web/20211029114420/https://www.youtube.com/user/minhealthnz" data-is-top-level="0" title="">Youtube</a></li>
+</ul>        <div class="container">
+      <div class="navbar-header">
+                <a class="logo navbar-btn pull-left" href="/web/20211029114420/https://www.health.govt.nz/" title="Home">
+          <img src="/web/20211029114420im_/https://www.health.govt.nz/sites/all/themes/mohpub_bootstrap/images/mohlogo.svg" alt="Ministry of Health"/>
+        </a>
+                  <div class="region region-header-top">
+    <section id="block-apachesolr-panels-search-form" class="block block-apachesolr-panels clearfix">
+
+
+  <form action="/web/20211029114420/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" method="post" id="apachesolr-panels-search-block" accept-charset="UTF-8"><div><div class="form-item form-item-apachesolr-panels-search-form form-type-textfield form-group"> <label class="control-label" for="edit-apachesolr-panels-search-form">Search</label>
+<input title="Enter the terms you wish to search for." class="form-control form-text" type="text" id="edit-apachesolr-panels-search-form" name="apachesolr_panels_search_form" value="" size="15" maxlength="128"/></div><input type="hidden" name="form_build_id" value="form-c7GFQkOR1Z_MxUiiLW8mg_bNJSgcEKE-VIf-21K-pF0"/>
+<input type="hidden" name="form_id" value="apachesolr_panels_search_block"/>
+<div class="form-actions form-wrapper form-group" id="edit-actions"><button type="submit" id="edit-submit" name="op" value="Search" class="btn btn-primary form-submit">Search</button>
+</div></div></form>
+</section>
+  </div>
+        <!-- .btn-navbar is used as the toggle for collapsed navbar content -->
+        <button aria-expanded="false" aria-controls="megamenu" type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+                    <span class="menu-text">Menu</span><span class="sr-only">Toggle navigation</span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+
+        </button>
+      </div>
+
+              <div class="navbar-collapse collapse">
+          <nav id="megamenu" role="navigation">
+                          <h2 class="element-invisible">Main menu</h2><ul id="main-menu" class="menu nav navbar-nav yamm navbar"><li class="first dropdown"><a href="/web/20211029114420/https://www.health.govt.nz/your-health" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="megamenu-dropdown-780">Your health <b class="caret"></b></a>
+    <div id="megamenu-dropdown-780" class="dropdown-menu">
+    <div class="yamm-content">
+      <div class="row">
+                            <div class="col">
+            <h3><a href="/web/20211029114420/https://www.health.govt.nz/your-health/conditions-and-treatments?mega=Your%20health&amp;title=Conditions%20%26%20treatments" class="menu-header">Conditions &amp; treatments</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211029114420/https://www.health.govt.nz/your-health/conditions-and-treatments/mental-health/depression?mega=Your%20health&amp;title=Depression">Depression</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/diabetes?mega=Your%20health&amp;title=Diabetes">Diabetes</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/influenza?mega=Your%20health&amp;title=Influenza">Influenza</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/measles?mega=Your%20health&amp;title=Measles">Measles</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/meningococcal-disease-including-meningitis?mega=Your%20health&amp;title=Meningococcal%20disease">Meningococcal disease</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/mumps?mega=Your%20health&amp;title=Mumps">Mumps</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/respiratory-syncytial-virus-rsv?mega=Your%20health&amp;title=RSV">RSV</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/sore-throat?mega=Your%20health&amp;title=Sore%20throat">Sore throat</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/your-health/conditions-and-treatments?mega=Your%20health&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211029114420/https://www.health.govt.nz/your-health/healthy-living?mega=Your%20health&amp;title=Healthy%20living" class="menu-header">Healthy living</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211029114420/https://www.health.govt.nz/your-health/healthy-living/drinking-water?mega=Your%20health&amp;title=Drinking-water">Drinking-water</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/your-health/healthy-living/food-activity-and-sleep/green-prescriptions?mega=Your%20health&amp;title=Green%20Prescriptions">Green Prescriptions</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/your-health/healthy-living/food-activity-and-sleep/healthy-eating?mega=Your%20health&amp;title=Healthy%20eating">Healthy eating</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/your-health/healthy-living/immunisation?mega=Your%20health&amp;title=Immunisation">Immunisation</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/your-health/healthy-living/food-activity-and-sleep/physical-activity?mega=Your%20health&amp;title=Physical%20activity">Physical activity</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/your-health/healthy-living/addictions/quitting-smoking?mega=Your%20health&amp;title=Smoking">Smoking</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/your-health/healthy-living/teeth-and-gums?mega=Your%20health&amp;title=Teeth%20and%20gums">Teeth and gums</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/your-health/healthy-living?mega=Your%20health&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211029114420/https://www.health.govt.nz/your-health/pregnancy-and-kids?mega=Your%20health&amp;title=Pregnancy%20and%20kids" class="menu-header">Pregnancy and kids</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211029114420/https://www.health.govt.nz/your-health/pregnancy-and-kids/birth-and-afterwards?mega=Your%20health&amp;title=Birth%20and%20afterwards">Birth and afterwards</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/your-health/pregnancy-and-kids/first-year/helpful-advice-during-first-year/breastfeeding-perfect-you-and-your-baby?mega=Your%20health&amp;title=Breastfeeding">Breastfeeding</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/your-health/pregnancy-and-kids/pregnancy?mega=Your%20health&amp;title=Pregnancy">Pregnancy</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/your-health/pregnancy-and-kids/services-and-support-during-pregnancy?mega=Your%20health&amp;title=Services%20and%20support%20during%20pregnancy">Services and support during pregnancy</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/your-health/pregnancy-and-kids/services-and-support-you-and-your-child?mega=Your%20health&amp;title=Services%20and%20support%20for%20you%20and%20your%20child">Services and support for you and your child</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/your-health/pregnancy-and-kids/first-year?mega=Your%20health&amp;title=The%20first%20year">The first year</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/your-health/pregnancy-and-kids/under-fives?mega=Your%20health&amp;title=Under%20fives">Under fives</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/your-health/pregnancy-and-kids?mega=Your%20health&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211029114420/https://www.health.govt.nz/your-health/services-and-support?mega=Your%20health&amp;title=Services%20and%20support" class="menu-header">Services &amp; support</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211029114420/https://www.health.govt.nz/your-health/services-and-support/health-care-services/help-alcohol-and-drug-problems?mega=Your%20health&amp;title=Alcohol%20and%20drugs">Alcohol and drugs</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/your-health/services-and-support/disability-services?mega=Your%20health&amp;title=Disability%20services">Disability services</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/your-health/services-and-support/health-care-services/earthquake-support-line?mega=Your%20health&amp;title=Earthquake%20Support%20Line">Earthquake Support Line</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/your-health/services-and-support/health-care-services/healthline?mega=Your%20health&amp;title=Healthline">Healthline</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/your-health/services-and-support/health-care-services/mental-health-services?mega=Your%20health&amp;title=Mental%20health%20services">Mental health services</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/your-health/services-and-support/health-care-services/maori-health-provider-directory?mega=Your%20health&amp;title=M%C4%81ori%20health%20providers">Māori health providers</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/your-health/services-and-support/health-care-services/services-older-people/rest-home-certification-and-audits?mega=Your%20health&amp;title=Rest%20home%20certification">Rest home certification</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/your-health/services-and-support/health-care-services/hospitals-and-specialist-services/travel-assistance?mega=Your%20health&amp;title=Travel%20assistance">Travel assistance</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/your-health/services-and-support?mega=Your%20health&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                        </div>
+    </div>
+    <div class="feature-links">
+      <h3 class="sr-only">Other related resources</h3>
+      <a href="/web/20211029114420/https://www.health.govt.nz/your-health/full-a-z?mega=Your%20health&amp;title=A-Z">View the full A-Z</a>    </div>
+  </div>
+</li>
+<li class="dropdown"><a href="/web/20211029114420/https://www.health.govt.nz/new-zealand-health-system" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="megamenu-dropdown-6076">NZ health system <b class="caret"></b></a>
+    <div id="megamenu-dropdown-6076" class="dropdown-menu">
+    <div class="yamm-content">
+      <div class="row">
+                            <div class="col">
+            <h3><a href="/web/20211029114420/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people?mega=NZ%20health%20system&amp;title=Key%20organisations" class="menu-header">Key organisations</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211029114420/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/crown-entities-and-statutory-boards?mega=NZ%20health%20system&amp;title=Crown%20entities%20%26%20agencies">Crown entities &amp; agencies</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/district-health-boards?mega=NZ%20health%20system&amp;title=District%20health%20boards">District health boards</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/non-governmental-organisations?mega=NZ%20health%20system&amp;title=Non-governmental%20organisations">Non-governmental organisations</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/primary-health-organisations?mega=NZ%20health%20system&amp;title=Primary%20health%20organisations">Primary health organisations</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/public-health-units?mega=NZ%20health%20system&amp;title=Public%20health%20units">Public health units</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people?mega=NZ%20health%20system&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211029114420/https://www.health.govt.nz/new-zealand-health-system/health-system-indicators-framework?mega=NZ%20health%20system&amp;title=Health%20System%20Indicators%20framework" class="menu-header">Health System Indicators framework</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211029114420/https://www.health.govt.nz/new-zealand-health-system/health-system-indicators-framework?mega=NZ%20health%20system&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211029114420/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services?mega=NZ%20health%20system&amp;title=Eligibility%20for%20public%20health%20services" class="menu-header">Eligibility for public health services</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211029114420/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services/guide-eligibility-publicly-funded-health-services?mega=NZ%20health%20system&amp;title=Guide%20to%20eligibility">Guide to eligibility</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services/eligibility-questions-and-answers-consumers?mega=NZ%20health%20system&amp;title=Q%26A%20for%20consumers">Q&amp;A for consumers</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services/eligibility-questions-and-answers-service-providers?mega=NZ%20health%20system&amp;title=Q%26A%20for%20service%20providers">Q&amp;A for service providers</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services/reciprocal-health-agreements?mega=NZ%20health%20system&amp;title=Reciprocal%20health%20agreements">Reciprocal health agreements</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services?mega=NZ%20health%20system&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211029114420/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements?mega=NZ%20health%20system&amp;title=Claims%2C%20provider%20payments%20and%20entitlements" class="menu-header">Claims &amp; provider payments</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211029114420/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/carer-support-claims?mega=NZ%20health%20system&amp;title=Carer%20Support">Carer Support</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/high-use-health-card-payments?mega=NZ%20health%20system&amp;title=High%20Use%20Health%20Card%20payments">High Use Health Card payments</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/between-travel-settlement?mega=NZ%20health%20system&amp;title=In-Between%20Travel%20Settlement">In-Between Travel Settlement</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/maternity-claim-forms?mega=NZ%20health%20system&amp;title=Maternity%20claim%20forms">Maternity claim forms</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/national-travel-assistance?mega=NZ%20health%20system&amp;title=National%20travel%20assistance%20claims">National travel assistance claims</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements?mega=NZ%20health%20system&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                        </div>
+    </div>
+    <div class="feature-links">
+      <h3 class="sr-only">Other related resources</h3>
+      <a href="/web/20211029114420/https://www.health.govt.nz/new-zealand-health-system/overview-health-system?mega=NZ%20health%20system&amp;title=Overview">Overview of the health system</a>  <a href="/web/20211029114420/https://www.health.govt.nz/new-zealand-health-system/my-dhb?mega=NZ%20health%20system&amp;title=Mydhb">My DHB</a> <a href="/web/20211029114420/https://www.health.govt.nz/new-zealand-health-system/system-level-measures-framework?mega=NZ%20health%20system&amp;title=SLM">System level measures</a>  <a href="/web/20211029114420/https://www.health.govt.nz/publication/new-zealand-health-strategy-2016?mega=NZ%20health%20system&amp;title=HealthStrategy">NZ Health Strategy</a>    </div>
+  </div>
+</li>
+<li class="dropdown"><a href="/web/20211029114420/https://www.health.govt.nz/our-work" class="dropdown-toggle active-trail" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="megamenu-dropdown-776">Our work <b class="caret"></b></a>
+  <div id="megamenu-dropdown-776" class="dropdown-menu">
+    <div class="yamm-content">
+      <div class="row">
+                            <ul class="col list-unstyled no-menu-header">
+                                                                                <li>
+                <a href="/web/20211029114420/https://www.health.govt.nz/our-work/hospitals-and-specialist-care/acute-care?mega=Our%20work&amp;title=Acute%20care" class="menu-header">Acute care</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211029114420/https://www.health.govt.nz/our-work/diseases-and-conditions/antimicrobial-resistance?mega=Our%20work&amp;title=Antimicrobial%20resistance" class="menu-header">Antimicrobial resistance</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211029114420/https://www.health.govt.nz/our-work/populations/asian-and-migrant-health?mega=Our%20work&amp;title=Asian%20and%20migrant%20health" class="menu-header">Asian and migrant health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211029114420/https://www.health.govt.nz/our-work/border-health?mega=Our%20work&amp;title=Border%20health" class="menu-header">Border health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211029114420/https://www.health.govt.nz/our-work/life-stages/breastfeeding?mega=Our%20work&amp;title=Breastfeeding" class="menu-header">Breastfeeding</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211029114420/https://www.health.govt.nz/our-work/diseases-and-conditions/cancer?mega=Our%20work&amp;title=Cancer" class="menu-header">Cancer</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211029114420/https://www.health.govt.nz/our-work/regulation-health-and-disability-system/certification-health-care-services?mega=Our%20work&amp;title=Certification%20of%20health%20care%20services" class="menu-header">Certification of health care services</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211029114420/https://www.health.govt.nz/our-work/life-stages/child-health?mega=Our%20work&amp;title=Child%20health" class="menu-header">Child health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211029114420/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus?mega=Our%20work&amp;title=COVID-19" class="menu-header">COVID-19 (novel coronavirus)</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211029114420/https://www.health.govt.nz/our-work/diseases-and-conditions/diabetes?mega=Our%20work&amp;title=Diabetes" class="menu-header">Diabetes</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211029114420/https://www.health.govt.nz/our-work/digital-health?mega=Our%20work&amp;title=Digital%20health" class="menu-header">Digital health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211029114420/https://www.health.govt.nz/our-work/disability-services?mega=Our%20work&amp;title=Disability%20services" class="menu-header">Disability services</a>                              </li>
+                                                                </ul>
+                            <ul class="col list-unstyled no-menu-header">
+                                                                                <li>
+                <a href="/web/20211029114420/https://www.health.govt.nz/our-work/diseases-and-conditions?mega=Our%20work&amp;title=Diseases%20and%20conditions" class="menu-header">Diseases and conditions</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211029114420/https://www.health.govt.nz/our-work/hospitals-and-specialist-care/emergency-departments?mega=Our%20work&amp;title=Emergency%20departments" class="menu-header">Emergency departments</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211029114420/https://www.health.govt.nz/our-work/emergency-management?mega=Our%20work&amp;title=Emergency%20management" class="menu-header">Emergency management</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211029114420/https://www.health.govt.nz/our-work/environmental-health?mega=Our%20work&amp;title=Environmental%20health" class="menu-header">Environmental health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211029114420/https://www.health.govt.nz/our-work/preventative-health-wellness/family-violence?mega=Our%20work&amp;title=Family%20violence" class="menu-header">Family violence</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211029114420/https://www.health.govt.nz/our-work/preventative-health-wellness/fluoride-and-oral-health?mega=Our%20work&amp;title=Fluoride%20and%20oral%20health" class="menu-header">Fluoride and oral health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211029114420/https://www.health.govt.nz/our-work/health-identity?mega=Our%20work&amp;title=Health%20identity" class="menu-header">Health identity</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211029114420/https://www.health.govt.nz/our-work/digital-health/digital-health-sector-architecture-standards-and-governance/health-information-standards-0?mega=Our%20work&amp;title=Health%20information%20standards" class="menu-header">Health information standards</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211029114420/https://www.health.govt.nz/our-work/health-infrastructure-unit-hiu?mega=Our%20work&amp;title=Health%20Infrastructure%20Unit" class="menu-header">Health Infrastructure Unit</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211029114420/https://www.health.govt.nz/our-work/life-stages/health-older-people?mega=Our%20work&amp;title=Health%20of%20older%20people" class="menu-header">Health of older people</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211029114420/https://www.health.govt.nz/our-work/health-workforce?mega=Our%20work&amp;title=Health%20workforce" class="menu-header">Health workforce</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211029114420/https://www.health.govt.nz/our-work/hospitals-and-specialist-care?mega=Our%20work&amp;title=Hospitals%20and%20specialist%20care" class="menu-header">Hospitals and specialist care</a>                              </li>
+                                                                </ul>
+                            <ul class="col list-unstyled no-menu-header">
+                                                                                <li>
+                <a href="/web/20211029114420/https://www.health.govt.nz/our-work/preventative-health-wellness/immunisation?mega=Our%20work&amp;title=Immunisation" class="menu-header">Immunisation</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211029114420/https://www.health.govt.nz/our-work/ionising-radiation-safety?mega=Our%20work&amp;title=Ionising%20radiation%20safety" class="menu-header">Ionising radiation safety</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211029114420/https://www.health.govt.nz/our-work/populations/maori-health?mega=Our%20work&amp;title=M%C4%81ori%20health" class="menu-header">Māori health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211029114420/https://www.health.govt.nz/our-work/life-stages/maternity-services?mega=Our%20work&amp;title=Maternity" class="menu-header">Maternity</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211029114420/https://www.health.govt.nz/our-work/regulation-health-and-disability-system/medicinal-cannabis-agency?mega=Our%20work&amp;title=Medicinal%20Cannabis%20Agency" class="menu-header">Medicinal cannabis</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211029114420/https://www.health.govt.nz/our-work/regulation-health-and-disability-system/medicines-control?mega=Our%20work&amp;title=Medicines%20control" class="menu-header">Medicines control</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211029114420/https://www.health.govt.nz/our-work/mental-health-and-addiction?mega=Our%20work&amp;title=Mental%20health%20and%20addiction" class="menu-header">Mental health and addiction</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211029114420/https://www.health.govt.nz/our-work/nursing?mega=Our%20work&amp;title=Nursing" class="menu-header">Nursing</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211029114420/https://www.health.govt.nz/our-work/preventative-health-wellness/nutrition?mega=Our%20work&amp;title=Nutrition" class="menu-header">Nutrition</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211029114420/https://www.health.govt.nz/our-work/preventative-health-wellness/oral-health?mega=Our%20work&amp;title=Oral%20health" class="menu-header">Oral health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211029114420/https://www.health.govt.nz/our-work/hospitals-and-specialist-care/organ-donation-and-transplantation?mega=Our%20work&amp;title=Organ%20donation%20and%20transplantation" class="menu-header">Organ donation and transplantation</a>                              </li>
+                                                                </ul>
+                            <ul class="col list-unstyled no-menu-header">
+                                                                                <li>
+                <a href="/web/20211029114420/https://www.health.govt.nz/our-work/populations/pacific-health?mega=Our%20work&amp;title=Pacific%20health" class="menu-header">Pacific health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211029114420/https://www.health.govt.nz/new-zealand-health-system/pay-equity-settlements?mega=Our%20work&amp;title=Pay%20equity%20settlements" class="menu-header">Pay equity</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211029114420/https://www.health.govt.nz/our-work/preventative-health-wellness/physical-activity?mega=Our%20work&amp;title=Physical%20activity" class="menu-header">Physical activity</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211029114420/https://www.health.govt.nz/our-work/hospitals-and-specialist-care/planned-care-services?mega=Our%20work&amp;title=Planned%20Care%20services" class="menu-header">Planned Care services</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211029114420/https://www.health.govt.nz/our-work/preventative-health-wellness?mega=Our%20work&amp;title=Preventative%20health/wellness" class="menu-header">Preventative health/wellness</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211029114420/https://www.health.govt.nz/our-work/primary-health-care?mega=Our%20work&amp;title=Primary%20health%20care" class="menu-header">Primary health care</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211029114420/https://www.health.govt.nz/our-work/public-health-workforce-development?mega=Our%20work&amp;title=Public%20health%20workforce%20development" class="menu-header">Public health workforce</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211029114420/https://www.health.govt.nz/our-work/regulation-health-and-disability-system?mega=Our%20work&amp;title=Regulation" class="menu-header">Regulation</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211029114420/https://www.health.govt.nz/our-work/preventative-health-wellness/tobacco-control?mega=Our%20work&amp;title=Tobacco%20control" class="menu-header">Tobacco control</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211029114420/https://www.health.govt.nz/our-work/regulation-health-and-disability-system/regulation-vaping-and-smokeless-tobacco-products?mega=Our%20work&amp;title=Vaping%20and%20smokeless%20tobacco%20products" class="menu-header">Vaping &amp; smokeless tobacco</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211029114420/https://www.health.govt.nz/our-work/who-code-nz?mega=Our%20work&amp;title=WHO%20Code%20in%20NZ" class="menu-header">WHO Code in NZ</a>                              </li>
+                      </ul>
+              </div>
+    </div>
+    <div class="feature-links">
+      <a href="/web/20211029114420/https://www.health.govt.nz/our-work?mega=Our%20work&amp;title=A-Z">View the full A-Z</a>    </div>
+  </div>
+</li>
+<li class="dropdown"><a href="/web/20211029114420/https://www.health.govt.nz/nz-health-statistics" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="megamenu-dropdown-778">Health statistics <b class="caret"></b></a>
+    <div id="megamenu-dropdown-778" class="dropdown-menu">
+    <div class="yamm-content">
+      <div class="row">
+                            <div class="col">
+            <h3><a href="/web/20211029114420/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets?mega=Health%20statistics&amp;title=Health%20statistics%20and%20data%20sets" class="menu-header">Statistics by topic</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211029114420/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/cancer-data-and-stats?mega=Health%20statistics&amp;title=Cancer">Cancer</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/diabetes-data-and-stats?mega=Health%20statistics&amp;title=Diabetes">Diabetes</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/mental-health-data-and-stats?mega=Health%20statistics&amp;title=Mental%20health">Mental health</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/maori-health-data-and-stats?mega=Health%20statistics&amp;title=M%C4%81ori%20health">Māori health</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/obesity-statistics?mega=Health%20statistics&amp;title=Obesity">Obesity</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/suicide-data-and-stats?mega=Health%20statistics&amp;title=Suicide">Suicide</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/tobacco-data-and-stats?mega=Health%20statistics&amp;title=Tobacco">Tobacco</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets?mega=Health%20statistics&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211029114420/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys?mega=Health%20statistics&amp;title=National%20collections%20and%20surveys" class="menu-header">About our surveys &amp; data collections</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211029114420/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/surveys/past-surveys/alcohol-and-drug-use-survey?mega=Health%20statistics&amp;title=Alcohol%20%26%20Drug%20Use%20Survey">Alcohol &amp; Drug Use Survey</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/national-collections-annual-maintenance-project?mega=Health%20statistics&amp;title=NCAMP">NCAMP</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/collections/new-zealand-cancer-registry-nzcr?mega=Health%20statistics&amp;title=NZ%20Cancer%20Registry">NZ Cancer Registry</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/surveys/new-zealand-health-survey?mega=Health%20statistics&amp;title=NZ%20Health%20Survey">NZ Health Survey</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/surveys/past-surveys/nutrition-survey?mega=Health%20statistics&amp;title=Nutrition%20Survey">Nutrition Survey</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/collections/primhd-mental-health-data?mega=Health%20statistics&amp;title=PRIMHD">PRIMHD</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys?mega=Health%20statistics&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211029114420/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology?mega=Health%20statistics&amp;title=Classification%20and%20Terminology" class="menu-header">Classification &amp; terminology</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211029114420/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology/using-icd-10-am-achi-acs/coding-queries/coding-query-database?mega=Health%20statistics&amp;title=Coding%20query%20database">Coding query database</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology/using-icd-10-am-achi-acs/courses-clinical-coding?mega=Health%20statistics&amp;title=Courses%20on%20clinical%20coding">Courses on clinical coding</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology/new-zealand-snomed-ct-national-release-centre?mega=Health%20statistics&amp;title=SNOMED%20CT">SNOMED CT</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology/using-icd-10-am-achi-acs?mega=Health%20statistics&amp;title=Using%20ICD-10-AM/ACHI/ACS">Using ICD-10-AM/ACHI/ACS</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology?mega=Health%20statistics&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211029114420/https://www.health.govt.nz/nz-health-statistics/data-references?mega=Health%20statistics&amp;title=Data%20references" class="menu-header">Data references</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211029114420/https://www.health.govt.nz/nz-health-statistics/data-references/code-tables?mega=Health%20statistics&amp;title=Code%20tables">Code tables</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/nz-health-statistics/data-references/data-dictionaries?mega=Health%20statistics&amp;title=Data%20dictionaries">Data dictionaries</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/nz-health-statistics/data-references/diagnosis-related-groups?mega=Health%20statistics&amp;title=Diagnosis-related%20groups">Diagnosis-related groups</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/nz-health-statistics/data-references/code-tables/common-code-tables/domicile-code-table?mega=Health%20statistics&amp;title=Domicile%20code%20table">Domicile code table</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/nz-health-statistics/data-references/mapping-tools?mega=Health%20statistics&amp;title=ICD%20mapping%20tools">ICD mapping tools</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/nz-health-statistics/data-references/weighted-inlier-equivalent-separations?mega=Health%20statistics&amp;title=Weighted%20Inlier%20Equivalent%20Separations">Weighted Inlier Equivalent Separations</a></li>
+                                  <li><a href="/web/20211029114420/https://www.health.govt.nz/nz-health-statistics/data-references?mega=Health%20statistics&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                        </div>
+    </div>
+    <div class="feature-links">
+      <h3 class="sr-only">Other related resources</h3>
+      <a href="/web/20211029114420/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/tier-1-health-statistics-release-calendar?mega=Health%20statistics&amp;title=Tier%201%20calendar">Release calendar for our Tier 1 statistics</a> <a href="/web/20211029114420/https://www.health.govt.nz/nz-health-statistics/about-data-collection?mega=Health%20statistics&amp;title=Enquiries">Data and survey enquiries</a>    </div>
+  </div>
+</li>
+<li class=""><a href="/web/20211029114420/https://www.health.govt.nz/publications" aria-haspopup="false">Publications</a></li>
+<li class=""><a href="/web/20211029114420/https://www.health.govt.nz/about-ministry" aria-haspopup="false">About us</a></li>
+<li class="visible-xs"><a href="/web/20211029114420/https://www.health.govt.nz/contactus" aria-haspopup="false">Contact us</a></li>
+</ul>
+                                  </nav>
+        </div>
+          </div>
+  </header>
+
+  <div class="main-container container">
+    <!-- announcement -->
+        <!-- /announcement -->
+
+    <header role="banner" id="page-header">
+
+          </header> <!-- /#page-header -->
+
+    <div class="row">
+
+      <section class="col-sm-12">
+                        <a id="main-content"></a>
+                                                                            <div class="breadcrumbs">
+            <ul><li><a href="/web/20211029114420/https://www.health.govt.nz/">Home</a></li><li><a href="/web/20211029114420/https://www.health.govt.nz/our-work">Our work</a></li><li><a href="/web/20211029114420/https://www.health.govt.nz/our-work/diseases-and-conditions">Diseases and conditions</a></li><li><a href="/web/20211029114420/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished" data-is-top-level="1" title="">COVID-19</a></li><li><a href="/web/20211029114420/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics" class="menu-node-unpublished menu-node-unpublished">Data and statistics</a></li><li><span class="current-breadcrumb">Vaccine data</span></li></ul>          </div>
+
+
+
+          <div class="region region-content">
+    <section id="block-system-main" class="block block-system clearfix">
+
+
+  <div class="bootstrap-threecol-stacked">
+
+      <div class="row"> <!-- @TODO: Add extra classes -->
+      <div class="panel-panel left col-xs-12 col-md-3 col-lg-3"><div class="panel-pane pane-block pane-menu-block-1 odd pane-top-link">
+
+        <span class="top-link"><a href="/web/20211029114420/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished active-trail" data-is-top-level="1">COVID-19</a></span>
+
+
+  <div class="pane-content">
+        <div class="menu-block-wrapper menu-block-1 menu-name-main-menu parent-mlid-1445 menu-level-2">
+  <ul class="menu nav"><li class="first collapsed menu-mlid-10163 health-advice depth-4"><a href="/web/20211029114420/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-health-advice-public" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished">Health advice</a></li>
+<li class="collapsed menu-mlid-10630 covid-19-vaccines- depth-4 section-overview hide-children"><a href="/web/20211029114420/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-vaccines" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished" data-is-top-level="1" title="">COVID-19 vaccines </a></li>
+<li class="collapsed menu-mlid-9997 health-professionals depth-4"><a href="/web/20211029114420/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-information-health-professionals" class="menu-node-unpublished menu-node-unpublished">Health professionals</a></li>
+<li class="collapsed menu-mlid-10019 specific-audiences depth-4"><a href="/web/20211029114420/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-information-specific-audiences" class="menu-node-unpublished">Specific audiences</a></li>
+<li class="expanded active-trail menu-mlid-10096 data-and-statistics depth-4"><a href="/web/20211029114420/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics" class="menu-node-unpublished menu-node-unpublished active-trail">Data and statistics</a><ul class="menu nav"><li class="first leaf menu-mlid-10062 current-cases depth-5 same-level-as-node"><a href="/web/20211029114420/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-current-cases" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Current cases</a></li>
+<li class="leaf menu-mlid-10146 case-demographics depth-5 same-level-as-node"><a href="/web/20211029114420/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-case-demographics">Case demographics</a></li>
+<li class="leaf menu-mlid-10097 source-of-cases depth-5 same-level-as-node"><a href="/web/20211029114420/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-source-cases" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Source of cases</a></li>
+<li class="leaf menu-mlid-10119 testing-for-covid-19 depth-5 same-level-as-node"><a href="/web/20211029114420/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/testing-covid-19" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Testing for COVID-19</a></li>
+<li class="leaf menu-mlid-10371 nz-covid-tracer-app-data depth-5 same-level-as-node"><a href="/web/20211029114420/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-nz-covid-tracer-app-data" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">NZ COVID Tracer app data</a></li>
+<li class="expanded active-trail active menu-mlid-10584 active vaccine-data depth-5 same-level-as-node"><a href="/web/20211029114420/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished active-trail active">Vaccine data</a><ul class="menu nav"><li class="first leaf menu-mlid-10867 covid-19-vaccination-uptake-rates-across-nz depth-6"><a href="/web/20211029114420/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-across-nz" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">COVID-19 Vaccination uptake rates across NZ</a></li>
+<li class="leaf menu-mlid-10868 covid-19-vaccination-uptake-rates---māori depth-6"><a href="/web/20211029114420/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-maori-communities-across-nz" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">COVID-19 Vaccination uptake rates - Māori</a></li>
+<li class="last leaf menu-mlid-10869 covid-19-vaccination-uptake-rates---pacific depth-6"><a href="/web/20211029114420/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-pacific-communities-across-nz" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">COVID-19 Vaccination uptake rates - Pacific</a></li>
+</ul></li>
+<li class="last leaf menu-mlid-10404 data-resources depth-5 same-level-as-node"><a href="/web/20211029114420/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-data-resources" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Data resources</a></li>
+</ul></li>
+<li class="collapsed menu-mlid-10369 response-planning depth-4"><a href="/web/20211029114420/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-response-planning" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Response planning</a></li>
+<li class="collapsed menu-mlid-10015 resources-and-tools depth-4"><a href="/web/20211029114420/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-resources-and-tools" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Resources and tools</a></li>
+<li class="last leaf menu-mlid-10004 news-and-media depth-4 section-overview hide-children"><a href="/web/20211029114420/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-news-and-media-updates" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">News and media</a></li>
+</ul></div>
+  </div>
+
+
+  </div>
+</div>      <div class="panel-panel middle col-xs-12 col-md-9 col-lg-9"><div class="panel-pane pane-page-title even">
+
+
+
+  <div class="pane-content">
+    <span id="skip-content" tabindex="-1"></span>    <h1>COVID-19: Vaccine data</h1>
+  </div>
+
+
+  </div>
+<div class="panel-pane pane-node-content odd">
+
+
+
+  <div class="pane-content">
+        <article id="node-12052" class="node node-page node-sticky view-mode-full clearfix" about="/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" typeof="sioc:Item foaf:Document">
+    <header>
+            <span property="dc:title" content="COVID-19: Vaccine data" class="rdf-meta element-hidden"></span>      </header>
+    <div class="field field-name-field-intro-text field-type-text-long field-label-hidden"><div class="field-items"><div class="field-item even"><p class="intro-text">Data and statistics about the rollout of COVID-19 vaccines in New Zealand.</p></div></div></div><div class="field field-name-body field-type-text-with-summary field-label-hidden"><div class="field-items"><div class="field-item even" property="content:encoded"><p>On this page:</p>
+
+<ul>
+	<li><a href="#daily">Daily updates</a>
+
+	<ul>
+		<li><a href="#total-vaccinations">Total vaccinations</a></li>
+		<li><a href="#ethnicity">Vaccinations by ethnicity</a></li>
+		<li><a href="#90pct">Vaccinations to 90% by DHB</a></li>
+	</ul>
+	</li>
+	<li><a href="#weekly-updates">Weekly updates</a>
+	<ul>
+		<li><a href="#model">Vaccinations against plan</a></li>
+		<li><a href="#uptake">Vaccinations uptake</a></li>
+		<li><a href="#by-day">Vaccinations by day</a></li>
+		<li><a href="#location">Vaccinations by DHB</a></li>
+		<li><a href="#group">Vaccinations by group</a></li>
+		<li><a href="#by_soh">Stock on hand</a></li>
+		<li><a href="#age">Vaccinations by age</a></li>
+		<li><a href="#workforce">Trained vaccinator and active vaccinator</a></li>
+		<li><a href="#group">Vaccinations by group</a></li>
+		<li><a href="#download">Details of vaccination&nbsp;data</a></li>
+	</ul>
+	</li>
+	<li><a href="#adverse-events">Adverse events from immunisations</a></li>
+</ul>
+
+<hr/><!--daily-->
+<h2><a id="daily" name="daily"></a>COVID-19 vaccinations: daily updates</h2>
+
+<div class="well well-sm">
+<p style="margin-top: 0"><strong>Data in this section is as at 11:59pm 28 October 2021 and is updated daily.</strong></p>
+</div>
+
+<h3><a id="total-vaccinations" name="total-vaccinations"></a>Total Vaccinations</h3>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">&nbsp;</th>
+			<th scope="col" style="text-align:right">Vaccinations yesterday</th>
+			<th scope="col" style="text-align:right">Cumulative total</th>
+			<th scope="col" style="text-align:right">Eligible population vaccinated %</th>
+			<th scope="col" style="text-align:right">Total population vaccinated %</th>
+			<th scope="col" style="text-align:right">Vaccinated or booked</th>
+			<th scope="col" style="text-align:right">Eligible vaccinated or booked %</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">First dose</th>
+			<td style="text-align:right">12,780</td>
+			<td style="text-align:right">3,682,213</td>
+			<td style="text-align:right">87%</td>
+			<td style="text-align:right">74%</td>
+			<td style="text-align:right">3,698,729</td>
+			<td style="text-align:right">88%</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Second dose</th>
+			<td style="text-align:right">31,999</td>
+			<td style="text-align:right">3,079,717</td>
+			<td style="text-align:right">73%</td>
+			<td style="text-align:right">62%</td>
+			<td style="text-align:right">3,354,703</td>
+			<td style="text-align:right">80%</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total doses</strong></th>
+			<td style="text-align:right"><strong>44,779</strong></td>
+			<td style="text-align:right"><strong>6,761,930</strong></td>
+		</tr>
+	</tbody>
+</table>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Total vaccinations" class="img-responsive" height="900" src="/web/20211029114420im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/uptake_summary_13.png" width="5340"/></figure>
+
+<h5>Definitions</h5>
+
+<ul>
+	<li><strong>Cumulative total:</strong>&nbsp;All vaccinations that have been administered and entered into the COVID-19 Immunisation Register up until midnight of the night before the data is published.</li>
+	<li><strong>Eligible population vaccinated %:</strong>&nbsp;Vaccinations administered divided by HSU population estimates for the eligible population (12+).</li>
+	<li><strong>Total population vaccinated %:</strong>&nbsp;Vaccinations administered divided by HSU population estimates for the total population (0+).</li>
+	<li><strong>Vaccinated or booked:</strong>&nbsp;Count of individuals who have either received their vaccination or have booked via Book My Vaccine to receive a vaccination.</li>
+	<li><strong>Eligible vaccinated or booked %:</strong>&nbsp;Count of individuals who have either received their vaccination or have booked via Book My Vaccine to receive a vaccination divided by HSU population estimates for the eligible population (12+).</li>
+</ul>
+
+<p>HSU population estimates are available in the downloadable spreadsheet at the bottom of the page. Throughout the rest of this sheet doses per 1,000 are based on eligible (12+) population.</p>
+
+<p>Bookings are only counted if the site is using Book My Vaccine. Bookings made through other Patient Management Systems are not counted.</p>
+
+<hr/>
+<h3><a id="by_eth" name="ethnicity"></a>Cumulative vaccinations by ethnicity</h3>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">Ethnicity *</th>
+			<th scope="col" style="text-align:right">First dose administered</th>
+			<th scope="col" style="text-align:right">First doses per 1,000 people</th>
+			<th scope="col" style="text-align:right">Second dose administered</th>
+			<th scope="col" style="text-align:right">Second doses per 1,000 people</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">Māori</th>
+			<td style="text-align:right">403,647</td>
+			<td style="text-align:right">707</td>
+			<td style="text-align:right">289,868</td>
+			<td style="text-align:right">508</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Pacific Peoples</th>
+			<td style="text-align:right">241,024</td>
+			<td style="text-align:right">841</td>
+			<td style="text-align:right">190,255</td>
+			<td style="text-align:right">664</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Asian</th>
+			<td style="text-align:right">605,177</td>
+			<td style="text-align:right">&gt;950</td>
+			<td style="text-align:right">529,144</td>
+			<td style="text-align:right">884</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">European / Other</th>
+			<td style="text-align:right">2,398,593</td>
+			<td style="text-align:right">878</td>
+			<td style="text-align:right">2,042,754</td>
+			<td style="text-align:right">748</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Unknown</th>
+			<td style="text-align:right">33,772</td>
+			<td style="text-align:right">-</td>
+			<td style="text-align:right">27,696</td>
+			<td style="text-align:right">-</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total</strong></th>
+			<td style="text-align:right"><strong>3,682,213</strong></td>
+			<td style="text-align:right"><strong>875</strong></td>
+			<td style="text-align:right"><strong>3,079,717</strong></td>
+			<td style="text-align:right"><strong>732</strong></td>
+		</tr>
+	</tbody>
+</table>
+
+<p><strong>*</strong> The prioritised ethnicity classification system allocates each person to a single ethnic group, based on the ethnic groups they identify with. Where people identify with more than one group, they are assigned in this order of priority: Māori, Pacific Peoples, Asian, and European/Other. So, if a person identifies as being Māori and New Zealand European, the person is counted as Māori. See <a href="/web/20211029114420/https://www.health.govt.nz/publication/hiso-100012017-ethnicity-data-protocols">Ethnicity Data Protocols</a> for further information.</p>
+
+<p>Ethnicity breakdown by DHB of residence is available in the downloadable spreadsheet at the bottom of the page.</p>
+
+<hr/>
+<h3><a id="90pct" name="90pct"></a>Vaccinations to 90% by DHB</h3>
+
+<h4><a id="90pct all ethnicities" name="90pct all ethnicities"></a>All Ethnicities</h4>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">&nbsp;</th>
+			<th scope="col" style="text-align:right">First doses</th>
+			<th scope="col" style="text-align:right">First doses %</th>
+			<th scope="col" style="text-align:right">First doses to 90%</th>
+			<th scope="col" style="text-align:right">Second doses</th>
+			<th scope="col" style="text-align:right">Second doses %</th>
+			<th scope="col" style="text-align:right">Second doses to 90%</th>
+			<th scope="col" style="text-align:right">Population</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">Northland</th>
+			<td style="text-align:right">126,991</td>
+			<td style="text-align:right">79%</td>
+			<td style="text-align:right">18,197</td>
+			<td style="text-align:right">102,266</td>
+			<td style="text-align:right">63%</td>
+			<td style="text-align:right">42,922</td>
+			<td style="text-align:right">161,320</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waitemata</th>
+			<td style="text-align:right">477,971</td>
+			<td style="text-align:right">91%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">413,561</td>
+			<td style="text-align:right">79%</td>
+			<td style="text-align:right">59,917</td>
+			<td style="text-align:right">526,087</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Auckland</th>
+			<td style="text-align:right">397,001</td>
+			<td style="text-align:right">94%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">351,361</td>
+			<td style="text-align:right">83%</td>
+			<td style="text-align:right">30,201</td>
+			<td style="text-align:right">423,958</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Counties Manukau</th>
+			<td style="text-align:right">426,789</td>
+			<td style="text-align:right">88%</td>
+			<td style="text-align:right">7,707</td>
+			<td style="text-align:right">363,479</td>
+			<td style="text-align:right">75%</td>
+			<td style="text-align:right">71,017</td>
+			<td style="text-align:right">482,773</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waikato</th>
+			<td style="text-align:right">307,533</td>
+			<td style="text-align:right">86%</td>
+			<td style="text-align:right">13,925</td>
+			<td style="text-align:right">251,626</td>
+			<td style="text-align:right">70%</td>
+			<td style="text-align:right">69,832</td>
+			<td style="text-align:right">357,176</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Lakes</th>
+			<td style="text-align:right">75,347</td>
+			<td style="text-align:right">80%</td>
+			<td style="text-align:right">9,630</td>
+			<td style="text-align:right">60,243</td>
+			<td style="text-align:right">64%</td>
+			<td style="text-align:right">24,734</td>
+			<td style="text-align:right">94,419</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Bay of Plenty</th>
+			<td style="text-align:right">178,935</td>
+			<td style="text-align:right">82%</td>
+			<td style="text-align:right">16,312</td>
+			<td style="text-align:right">141,800</td>
+			<td style="text-align:right">65%</td>
+			<td style="text-align:right">53,447</td>
+			<td style="text-align:right">216,941</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Tairawhiti</th>
+			<td style="text-align:right">32,492</td>
+			<td style="text-align:right">77%</td>
+			<td style="text-align:right">5,276</td>
+			<td style="text-align:right">26,146</td>
+			<td style="text-align:right">62%</td>
+			<td style="text-align:right">11,622</td>
+			<td style="text-align:right">41,965</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Taranaki</th>
+			<td style="text-align:right">85,347</td>
+			<td style="text-align:right">84%</td>
+			<td style="text-align:right">6,585</td>
+			<td style="text-align:right">65,454</td>
+			<td style="text-align:right">64%</td>
+			<td style="text-align:right">26,478</td>
+			<td style="text-align:right">102,147</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hawkes Bay</th>
+			<td style="text-align:right">121,965</td>
+			<td style="text-align:right">84%</td>
+			<td style="text-align:right">9,049</td>
+			<td style="text-align:right">101,011</td>
+			<td style="text-align:right">69%</td>
+			<td style="text-align:right">30,003</td>
+			<td style="text-align:right">145,571</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">MidCentral</th>
+			<td style="text-align:right">130,464</td>
+			<td style="text-align:right">86%</td>
+			<td style="text-align:right">6,608</td>
+			<td style="text-align:right">107,890</td>
+			<td style="text-align:right">71%</td>
+			<td style="text-align:right">29,182</td>
+			<td style="text-align:right">152,302</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Whanganui</th>
+			<td style="text-align:right">45,804</td>
+			<td style="text-align:right">80%</td>
+			<td style="text-align:right">5,718</td>
+			<td style="text-align:right">38,369</td>
+			<td style="text-align:right">67%</td>
+			<td style="text-align:right">13,153</td>
+			<td style="text-align:right">57,247</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Capital and Coast</th>
+			<td style="text-align:right">248,949</td>
+			<td style="text-align:right">92%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">213,148</td>
+			<td style="text-align:right">79%</td>
+			<td style="text-align:right">30,909</td>
+			<td style="text-align:right">271,174</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hutt Valley</th>
+			<td style="text-align:right">113,951</td>
+			<td style="text-align:right">87%</td>
+			<td style="text-align:right">3,264</td>
+			<td style="text-align:right">94,440</td>
+			<td style="text-align:right">73%</td>
+			<td style="text-align:right">22,775</td>
+			<td style="text-align:right">130,239</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Wairarapa</th>
+			<td style="text-align:right">35,155</td>
+			<td style="text-align:right">85%</td>
+			<td style="text-align:right">2,129</td>
+			<td style="text-align:right">29,380</td>
+			<td style="text-align:right">71%</td>
+			<td style="text-align:right">7,904</td>
+			<td style="text-align:right">41,427</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Nelson Marlborough</th>
+			<td style="text-align:right">116,995</td>
+			<td style="text-align:right">86%</td>
+			<td style="text-align:right">5,174</td>
+			<td style="text-align:right">101,527</td>
+			<td style="text-align:right">75%</td>
+			<td style="text-align:right">20,642</td>
+			<td style="text-align:right">135,743</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">West Coast</th>
+			<td style="text-align:right">22,411</td>
+			<td style="text-align:right">80%</td>
+			<td style="text-align:right">2,704</td>
+			<td style="text-align:right">18,122</td>
+			<td style="text-align:right">65%</td>
+			<td style="text-align:right">6,993</td>
+			<td style="text-align:right">27,906</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Canterbury</th>
+			<td style="text-align:right">434,574</td>
+			<td style="text-align:right">90%</td>
+			<td style="text-align:right">27</td>
+			<td style="text-align:right">340,807</td>
+			<td style="text-align:right">71%</td>
+			<td style="text-align:right">93,794</td>
+			<td style="text-align:right">482,890</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">South Canterbury</th>
+			<td style="text-align:right">44,901</td>
+			<td style="text-align:right">85%</td>
+			<td style="text-align:right">2,425</td>
+			<td style="text-align:right">38,211</td>
+			<td style="text-align:right">73%</td>
+			<td style="text-align:right">9,115</td>
+			<td style="text-align:right">52,584</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Southern</th>
+			<td style="text-align:right">256,602</td>
+			<td style="text-align:right">89%</td>
+			<td style="text-align:right">2,612</td>
+			<td style="text-align:right">219,241</td>
+			<td style="text-align:right">76%</td>
+			<td style="text-align:right">39,972</td>
+			<td style="text-align:right">288,015</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Overseas / Unknown</th>
+			<td style="text-align:right">2,036</td>
+			<td style="text-align:right">12%</td>
+			<td style="text-align:right">13,420</td>
+			<td style="text-align:right">1,635</td>
+			<td style="text-align:right">10%</td>
+			<td style="text-align:right">13,821</td>
+			<td style="text-align:right">17,173</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total</strong></th>
+			<td style="text-align:right"><strong>3,682,213</strong></td>
+			<td style="text-align:right"><strong>87%</strong></td>
+			<td style="text-align:right"><strong>105,938</strong></td>
+			<td style="text-align:right"><strong>3,079,717</strong></td>
+			<td style="text-align:right"><strong>73%</strong></td>
+			<td style="text-align:right"><strong>708,434</strong></td>
+			<td style="text-align:right"><strong>4,209,057</strong></td>
+		</tr>
+	</tbody>
+</table>
+
+<p>First/second doses % are the number of first/second doses administered divided by the eligible population. First/second doses to 90% are the number of doses required to reach 90% of the eligible population. For these two measures, the national total may not be the sum of DHB measures.</p>
+
+<h4><a id="90pct Māori" name="90pct Māori">Māori</a></h4>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">&nbsp;</th>
+			<th scope="col" style="text-align:right">First doses</th>
+			<th scope="col" style="text-align:right">First doses %</th>
+			<th scope="col" style="text-align:right">First doses to 90%</th>
+			<th scope="col" style="text-align:right">Second doses</th>
+			<th scope="col" style="text-align:right">Second doses %</th>
+			<th scope="col" style="text-align:right">Second doses to 90%</th>
+			<th scope="col" style="text-align:right">Population</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">Northland</th>
+			<td style="text-align:right">33,532</td>
+			<td style="text-align:right">66%</td>
+			<td style="text-align:right">11,907</td>
+			<td style="text-align:right">23,229</td>
+			<td style="text-align:right">46%</td>
+			<td style="text-align:right">22,210</td>
+			<td style="text-align:right">50,488</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waitemata</th>
+			<td style="text-align:right">32,537</td>
+			<td style="text-align:right">79%</td>
+			<td style="text-align:right">4,465</td>
+			<td style="text-align:right">24,631</td>
+			<td style="text-align:right">60%</td>
+			<td style="text-align:right">12,371</td>
+			<td style="text-align:right">41,113</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Auckland</th>
+			<td style="text-align:right">22,740</td>
+			<td style="text-align:right">82%</td>
+			<td style="text-align:right">2,273</td>
+			<td style="text-align:right">17,686</td>
+			<td style="text-align:right">64%</td>
+			<td style="text-align:right">7,327</td>
+			<td style="text-align:right">27,792</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Counties Manukau</th>
+			<td style="text-align:right">45,921</td>
+			<td style="text-align:right">72%</td>
+			<td style="text-align:right">11,223</td>
+			<td style="text-align:right">32,686</td>
+			<td style="text-align:right">51%</td>
+			<td style="text-align:right">24,458</td>
+			<td style="text-align:right">63,493</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waikato</th>
+			<td style="text-align:right">49,945</td>
+			<td style="text-align:right">72%</td>
+			<td style="text-align:right">12,791</td>
+			<td style="text-align:right">34,375</td>
+			<td style="text-align:right">49%</td>
+			<td style="text-align:right">28,361</td>
+			<td style="text-align:right">69,707</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Lakes</th>
+			<td style="text-align:right">19,270</td>
+			<td style="text-align:right">64%</td>
+			<td style="text-align:right">7,806</td>
+			<td style="text-align:right">13,500</td>
+			<td style="text-align:right">45%</td>
+			<td style="text-align:right">13,576</td>
+			<td style="text-align:right">30,085</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Bay of Plenty</th>
+			<td style="text-align:right">30,228</td>
+			<td style="text-align:right">63%</td>
+			<td style="text-align:right">12,733</td>
+			<td style="text-align:right">20,783</td>
+			<td style="text-align:right">44%</td>
+			<td style="text-align:right">22,178</td>
+			<td style="text-align:right">47,734</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Tairawhiti</th>
+			<td style="text-align:right">13,263</td>
+			<td style="text-align:right">67%</td>
+			<td style="text-align:right">4,592</td>
+			<td style="text-align:right">9,676</td>
+			<td style="text-align:right">49%</td>
+			<td style="text-align:right">8,179</td>
+			<td style="text-align:right">19,839</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Taranaki</th>
+			<td style="text-align:right">10,719</td>
+			<td style="text-align:right">67%</td>
+			<td style="text-align:right">3,595</td>
+			<td style="text-align:right">6,969</td>
+			<td style="text-align:right">44%</td>
+			<td style="text-align:right">7,345</td>
+			<td style="text-align:right">15,904</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hawkes Bay</th>
+			<td style="text-align:right">22,505</td>
+			<td style="text-align:right">66%</td>
+			<td style="text-align:right">8,148</td>
+			<td style="text-align:right">16,022</td>
+			<td style="text-align:right">47%</td>
+			<td style="text-align:right">14,631</td>
+			<td style="text-align:right">34,059</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">MidCentral</th>
+			<td style="text-align:right">17,051</td>
+			<td style="text-align:right">70%</td>
+			<td style="text-align:right">4,752</td>
+			<td style="text-align:right">12,262</td>
+			<td style="text-align:right">51%</td>
+			<td style="text-align:right">9,540</td>
+			<td style="text-align:right">24,225</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Whanganui</th>
+			<td style="text-align:right">8,715</td>
+			<td style="text-align:right">64%</td>
+			<td style="text-align:right">3,446</td>
+			<td style="text-align:right">6,484</td>
+			<td style="text-align:right">48%</td>
+			<td style="text-align:right">5,677</td>
+			<td style="text-align:right">13,512</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Capital and Coast</th>
+			<td style="text-align:right">21,371</td>
+			<td style="text-align:right">79%</td>
+			<td style="text-align:right">2,899</td>
+			<td style="text-align:right">16,440</td>
+			<td style="text-align:right">61%</td>
+			<td style="text-align:right">7,830</td>
+			<td style="text-align:right">26,967</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hutt Valley</th>
+			<td style="text-align:right">13,811</td>
+			<td style="text-align:right">72%</td>
+			<td style="text-align:right">3,400</td>
+			<td style="text-align:right">10,095</td>
+			<td style="text-align:right">53%</td>
+			<td style="text-align:right">7,116</td>
+			<td style="text-align:right">19,123</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Wairarapa</th>
+			<td style="text-align:right">4,354</td>
+			<td style="text-align:right">69%</td>
+			<td style="text-align:right">1,318</td>
+			<td style="text-align:right">3,066</td>
+			<td style="text-align:right">49%</td>
+			<td style="text-align:right">2,606</td>
+			<td style="text-align:right">6,302</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Nelson Marlborough</th>
+			<td style="text-align:right">7,814</td>
+			<td style="text-align:right">69%</td>
+			<td style="text-align:right">2,309</td>
+			<td style="text-align:right">5,899</td>
+			<td style="text-align:right">52%</td>
+			<td style="text-align:right">4,224</td>
+			<td style="text-align:right">11,248</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">West Coast</th>
+			<td style="text-align:right">1,957</td>
+			<td style="text-align:right">71%</td>
+			<td style="text-align:right">532</td>
+			<td style="text-align:right">1,403</td>
+			<td style="text-align:right">51%</td>
+			<td style="text-align:right">1,086</td>
+			<td style="text-align:right">2,765</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Canterbury</th>
+			<td style="text-align:right">27,727</td>
+			<td style="text-align:right">75%</td>
+			<td style="text-align:right">5,545</td>
+			<td style="text-align:right">19,179</td>
+			<td style="text-align:right">52%</td>
+			<td style="text-align:right">14,093</td>
+			<td style="text-align:right">36,969</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">South Canterbury</th>
+			<td style="text-align:right">2,392</td>
+			<td style="text-align:right">70%</td>
+			<td style="text-align:right">693</td>
+			<td style="text-align:right">1,774</td>
+			<td style="text-align:right">52%</td>
+			<td style="text-align:right">1,311</td>
+			<td style="text-align:right">3,428</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Southern</th>
+			<td style="text-align:right">17,610</td>
+			<td style="text-align:right">74%</td>
+			<td style="text-align:right">3,671</td>
+			<td style="text-align:right">13,575</td>
+			<td style="text-align:right">57%</td>
+			<td style="text-align:right">7,706</td>
+			<td style="text-align:right">23,646</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Overseas / Unknown</th>
+			<td style="text-align:right">185</td>
+			<td style="text-align:right">7%</td>
+			<td style="text-align:right">2,203</td>
+			<td style="text-align:right">134</td>
+			<td style="text-align:right">5%</td>
+			<td style="text-align:right">2,254</td>
+			<td style="text-align:right">2,653</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total</strong></th>
+			<td style="text-align:right"><strong>403,647</strong></td>
+			<td style="text-align:right"><strong>71%</strong></td>
+			<td style="text-align:right"><strong>110,300</strong></td>
+			<td style="text-align:right"><strong>289,868</strong></td>
+			<td style="text-align:right"><strong>51%</strong></td>
+			<td style="text-align:right"><strong>224,079</strong></td>
+			<td style="text-align:right"><strong>571,052</strong></td>
+		</tr>
+	</tbody>
+</table>
+
+<h4><a id="90pct Pacific Peoples" name="90pct Pacific Peoples"></a>Pacific Peoples</h4>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">&nbsp;</th>
+			<th scope="col" style="text-align:right">First doses</th>
+			<th scope="col" style="text-align:right">First doses %</th>
+			<th scope="col" style="text-align:right">First doses to 90%</th>
+			<th scope="col" style="text-align:right">Second doses</th>
+			<th scope="col" style="text-align:right">Second doses %</th>
+			<th scope="col" style="text-align:right">Second doses to 90%</th>
+			<th scope="col" style="text-align:right">Population</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">Northland</th>
+			<td style="text-align:right">2,358</td>
+			<td style="text-align:right">80%</td>
+			<td style="text-align:right">283</td>
+			<td style="text-align:right">1,696</td>
+			<td style="text-align:right">58%</td>
+			<td style="text-align:right">945</td>
+			<td style="text-align:right">2,934</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waitemata</th>
+			<td style="text-align:right">31,859</td>
+			<td style="text-align:right">85%</td>
+			<td style="text-align:right">1,957</td>
+			<td style="text-align:right">25,178</td>
+			<td style="text-align:right">67%</td>
+			<td style="text-align:right">8,638</td>
+			<td style="text-align:right">37,573</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Auckland</th>
+			<td style="text-align:right">39,171</td>
+			<td style="text-align:right">84%</td>
+			<td style="text-align:right">3,008</td>
+			<td style="text-align:right">31,234</td>
+			<td style="text-align:right">67%</td>
+			<td style="text-align:right">10,945</td>
+			<td style="text-align:right">46,866</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Counties Manukau</th>
+			<td style="text-align:right">95,971</td>
+			<td style="text-align:right">82%</td>
+			<td style="text-align:right">8,877</td>
+			<td style="text-align:right">76,024</td>
+			<td style="text-align:right">65%</td>
+			<td style="text-align:right">28,824</td>
+			<td style="text-align:right">116,498</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waikato</th>
+			<td style="text-align:right">9,087</td>
+			<td style="text-align:right">85%</td>
+			<td style="text-align:right">527</td>
+			<td style="text-align:right">7,090</td>
+			<td style="text-align:right">66%</td>
+			<td style="text-align:right">2,524</td>
+			<td style="text-align:right">10,682</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Lakes</th>
+			<td style="text-align:right">1,806</td>
+			<td style="text-align:right">79%</td>
+			<td style="text-align:right">251</td>
+			<td style="text-align:right">1,390</td>
+			<td style="text-align:right">61%</td>
+			<td style="text-align:right">667</td>
+			<td style="text-align:right">2,286</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Bay of Plenty</th>
+			<td style="text-align:right">3,983</td>
+			<td style="text-align:right">&gt;95%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">3,032</td>
+			<td style="text-align:right">82%</td>
+			<td style="text-align:right">279</td>
+			<td style="text-align:right">3,679</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Tairawhiti</th>
+			<td style="text-align:right">862</td>
+			<td style="text-align:right">89%</td>
+			<td style="text-align:right">6</td>
+			<td style="text-align:right">664</td>
+			<td style="text-align:right">69%</td>
+			<td style="text-align:right">204</td>
+			<td style="text-align:right">965</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Taranaki</th>
+			<td style="text-align:right">1,043</td>
+			<td style="text-align:right">82%</td>
+			<td style="text-align:right">100</td>
+			<td style="text-align:right">771</td>
+			<td style="text-align:right">61%</td>
+			<td style="text-align:right">372</td>
+			<td style="text-align:right">1,270</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hawkes Bay</th>
+			<td style="text-align:right">5,057</td>
+			<td style="text-align:right">&gt;95%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">4,101</td>
+			<td style="text-align:right">82%</td>
+			<td style="text-align:right">417</td>
+			<td style="text-align:right">5,020</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">MidCentral</th>
+			<td style="text-align:right">3,745</td>
+			<td style="text-align:right">84%</td>
+			<td style="text-align:right">276</td>
+			<td style="text-align:right">2,860</td>
+			<td style="text-align:right">64%</td>
+			<td style="text-align:right">1,161</td>
+			<td style="text-align:right">4,468</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Whanganui</th>
+			<td style="text-align:right">1,038</td>
+			<td style="text-align:right">75%</td>
+			<td style="text-align:right">205</td>
+			<td style="text-align:right">816</td>
+			<td style="text-align:right">59%</td>
+			<td style="text-align:right">427</td>
+			<td style="text-align:right">1,381</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Capital and Coast</th>
+			<td style="text-align:right">15,555</td>
+			<td style="text-align:right">81%</td>
+			<td style="text-align:right">1,704</td>
+			<td style="text-align:right">12,404</td>
+			<td style="text-align:right">65%</td>
+			<td style="text-align:right">4,855</td>
+			<td style="text-align:right">19,177</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hutt Valley</th>
+			<td style="text-align:right">7,902</td>
+			<td style="text-align:right">80%</td>
+			<td style="text-align:right">1,003</td>
+			<td style="text-align:right">6,189</td>
+			<td style="text-align:right">63%</td>
+			<td style="text-align:right">2,716</td>
+			<td style="text-align:right">9,894</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Wairarapa</th>
+			<td style="text-align:right">680</td>
+			<td style="text-align:right">81%</td>
+			<td style="text-align:right">73</td>
+			<td style="text-align:right">542</td>
+			<td style="text-align:right">65%</td>
+			<td style="text-align:right">211</td>
+			<td style="text-align:right">837</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Nelson Marlborough</th>
+			<td style="text-align:right">3,588</td>
+			<td style="text-align:right">&gt;95%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">3,125</td>
+			<td style="text-align:right">&gt;95%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">2,115</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">West Coast</th>
+			<td style="text-align:right">227</td>
+			<td style="text-align:right">80%</td>
+			<td style="text-align:right">27</td>
+			<td style="text-align:right">172</td>
+			<td style="text-align:right">61%</td>
+			<td style="text-align:right">82</td>
+			<td style="text-align:right">282</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Canterbury</th>
+			<td style="text-align:right">10,459</td>
+			<td style="text-align:right">82%</td>
+			<td style="text-align:right">1,004</td>
+			<td style="text-align:right">7,737</td>
+			<td style="text-align:right">61%</td>
+			<td style="text-align:right">3,726</td>
+			<td style="text-align:right">12,737</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">South Canterbury</th>
+			<td style="text-align:right">771</td>
+			<td style="text-align:right">92%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">559</td>
+			<td style="text-align:right">67%</td>
+			<td style="text-align:right">194</td>
+			<td style="text-align:right">837</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Southern</th>
+			<td style="text-align:right">5,526</td>
+			<td style="text-align:right">92%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">4,378</td>
+			<td style="text-align:right">73%</td>
+			<td style="text-align:right">1,050</td>
+			<td style="text-align:right">6,031</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Overseas / Unknown</th>
+			<td style="text-align:right">336</td>
+			<td style="text-align:right">29%</td>
+			<td style="text-align:right">698</td>
+			<td style="text-align:right">293</td>
+			<td style="text-align:right">26%</td>
+			<td style="text-align:right">741</td>
+			<td style="text-align:right">1,149</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total</strong></th>
+			<td style="text-align:right"><strong>241,024</strong></td>
+			<td style="text-align:right"><strong>84%</strong></td>
+			<td style="text-align:right"><strong>16,989</strong></td>
+			<td style="text-align:right"><strong>190,255</strong></td>
+			<td style="text-align:right"><strong>66%</strong></td>
+			<td style="text-align:right"><strong>67,758</strong></td>
+			<td style="text-align:right"><strong>286,681</strong></td>
+		</tr>
+	</tbody>
+</table>
+<!--daily_end-->
+
+<hr/>
+<h2><a id="weekly-updates" name="weekly-updates"></a>COVID-19 vaccinations: weekly updates</h2>
+
+<div class="well well-sm">
+<p style="margin-top: 0"><strong>Data in this section is as at 11:59pm 26 October 2021 and is updated weekly on Wednesdays.</strong></p>
+</div>
+
+<h3><a id="model" model="" name="id="></a>Cumulative vaccinations</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccination doses administered compared to plan doses" class="img-responsive" height="830" src="/web/20211029114420im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/vaccineplanmodel_13.png" width="1780"/></figure>
+
+<p>Production plan figures are the volumes agreed with DHBs and national providers for expected vaccinations. These figures have been matched with expected supply. Detailed plans are available in the Excel file at the bottom of this page.</p>
+
+<p>The Stock received figures are the cumulative supply of doses to date.</p>
+
+<p>DHB capacity plans for the remainder of the year are undergoing review.</p>
+
+<hr/><!--
+<h3><a id="model" model="" name="id="></a>Cumulative vaccinations for last 6 weeks</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccination doses administered compared to plan doses - 6wks" class="img-responsive" height="830" src="/vaccineplanmodel_wks.png" width="1780" /></figure>
+
+<hr />
+-->
+<h3><a id="uptake" name="uptake"></a>Vaccine uptake</h3>
+
+<p>Maps and data related to uptake rates of the COVID-19 vaccine across the country are available on the pages linked below. These show&nbsp;vaccination records aggregated by area of residence for all New Zealand residents, Māori communities, and Pacific communities.</p>
+
+<ul>
+	<li><a href="/web/20211029114420/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-across-nz">COVID-19 Vaccination uptake rates across NZ</a></li>
+	<li><a href="/web/20211029114420/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-maori-communities-across-nz">COVID-19 Vaccination uptake rates within Māori communities across NZ</a></li>
+	<li><a href="/web/20211029114420/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-pacific-communities-across-nz">COVID-19 Vaccination uptake rates within Pacific communities across NZ</a></li>
+</ul>
+
+<h4><a id="uptake" name="uptake"></a>Vaccine uptake per rate ratio (unadjusted) Māori and Pacific compared with Non-Māori non-Pacific</h4>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine Uptake per 1,000 (HSU) Rate Ratio, Showing Prioritised Ethnicity, vs Non-Māori Non-Pacific, By Age Band" class="img-responsive" height="830" src="/web/20211029114420im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_mix_8.png" width="1780"/></figure>
+
+<p>In the Chart above, rate ratios tell us the rate Māori or Pacific People per population are being vaccinated compared with non-Māori non-Pacific. This comparison can be split by age group.</p>
+
+<ul>
+	<li>A rate of one means the groups being compared are being vaccinated at the same rate.</li>
+	<li>A rate over one means Māori (or Pacific) are being vaccinated at a higher rate than non-Māori non-Pacific.</li>
+	<li>A rate under one means Māori (or Pacific) are being vaccinated at a lower rate than non-Māori non-Pacific.</li>
+</ul>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<td colspan="2" style="border-top: 0 !important; border-bottom-color: #FDD6AF !important; border-right: 0 !important;">&nbsp;</td>
+			<th colspan="6" id="ac1">Māori</th>
+			<th colspan="6" id="ac8">Pacific Peoples</th>
+		</tr>
+		<tr>
+			<th id="ar1">DHB</th>
+			<th>Dose number</th>
+			<th headers="ac1" id="ac2">65+</th>
+			<th headers="ac1" id="ac3">50-64</th>
+			<th headers="ac1" id="ac4">35-49</th>
+			<th headers="ac1" id="ac5">20-34</th>
+			<th headers="ac1" id="ac6">12-19</th>
+			<th headers="ac1" id="ac7">All ages</th>
+			<th headers="ac8" id="ac9">65+</th>
+			<th headers="ac8" id="ac10">50-64</th>
+			<th headers="ac8" id="ac11">35-49</th>
+			<th headers="ac8" id="ac12">20-34</th>
+			<th headers="ac8" id="ac13">12-19</th>
+			<th headers="ac8" id="ac14">All ages</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th headers="ar1" id="ar2" rowspan="2">National</th>
+			<th headers="ar1 ar2" id="ar3">Dose 1</th>
+			<td headers="ar1 ar2 ar3 ac1 ac2" style="background-color:green; color: #FFF;"><strong>0.99</strong></td>
+			<td headers="ar1 ar2 ar3 ac1 ac3" style="background-color:mediumseagreen"><strong>0.93</strong></td>
+			<td headers="ar1 ar2 ar3 ac1 ac4" style="background-color:yellow"><strong>0.79</strong></td>
+			<td headers="ar1 ar2 ar3 ac1 ac5" style="background-color:coral"><strong>0.67</strong></td>
+			<td headers="ar1 ar2 ar3 ac1 ac6" style="background-color:orange"><strong>0.71</strong></td>
+			<td headers="ar1 ar2 ar3 ac1 ac7" style="background-color:yellow"><strong>0.77</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac9" style="background-color:mediumseagreen"><strong>0.94</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac10" style="background-color:green; color: #FFF;"><strong>0.99</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac11" style="background-color:green; color: #FFF;"><strong>0.98</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac12" style="background-color:lightgreen"><strong>0.89</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac13" style="background-color:mediumseagreen"><strong>0.90</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac14" style="background-color:mediumseagreen"><strong>0.93</strong></td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar2" id="ar4">Dose 2</th>
+			<td headers="ar1 ar2 ar4 ac1 ac2" style="background-color:green; color: #FFF;"><strong>0.96</strong></td>
+			<td headers="ar1 ar2 ar4 ac1 ac3" style="background-color:lightgreen"><strong>0.87</strong></td>
+			<td headers="ar1 ar2 ar4 ac1 ac4" style="background-color:coral"><strong>0.68</strong></td>
+			<td headers="ar1 ar2 ar4 ac1 ac5" style="background-color:crimson; color: #FFF;"><strong>0.51</strong></td>
+			<td headers="ar1 ar2 ar4 ac1 ac6" style="background-color:crimson; color: #FFF;"><strong>0.57</strong></td>
+			<td headers="ar1 ar2 ar4 ac1 ac7" style="background-color:coral"><strong>0.65</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac9" style="background-color:mediumseagreen"><strong>0.92</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac10" style="background-color:green; color: #FFF;"><strong>0.99</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac11" style="background-color:green; color: #FFF;"><strong>0.97</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac12" style="background-color:palegreen"><strong>0.82</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac13" style="background-color:lightgreen"><strong>0.86</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac14" style="background-color:lightgreen"><strong>0.86</strong></td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar5" rowspan="2">Northland</th>
+			<th headers="ar1 ar5" id="ar6">Dose 1</th>
+			<td headers="ar1 ar5 ar6 ac1 ac2" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar5 ar6 ac1 ac3" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar5 ar6 ac1 ac4" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar5 ar6 ac1 ac5" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar5 ar6 ac1 ac6" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar5 ar6 ac1 ac7" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar5 ar6 ac8 ac9" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar5 ar6 ac8 ac10" style="background-color:green; color: #FFF;">1.06</td>
+			<td headers="ar1 ar5 ar6 ac8 ac11" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar5 ar6 ac8 ac12" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar5 ar6 ac8 ac13" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar5 ar6 ac8 ac14" style="background-color:mediumseagreen">0.94</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar5" id="ar7">Dose 2</th>
+			<td headers="ar1 ar5 ar7 ac1 ac2" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar5 ar7 ac1 ac3" style="background-color:lightgreen">0.87</td>
+			<td headers="ar1 ar5 ar7 ac1 ac4" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar5 ar7 ac1 ac5" style="background-color:crimson; color: #FFF;">0.49</td>
+			<td headers="ar1 ar5 ar7 ac1 ac6" style="background-color:crimson; color: #FFF;">0.59</td>
+			<td headers="ar1 ar5 ar7 ac1 ac7" style="background-color:tomato">0.63</td>
+			<td headers="ar1 ar5 ar7 ac8 ac9" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar5 ar7 ac8 ac10" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar5 ar7 ac8 ac11" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar5 ar7 ac8 ac12" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar5 ar7 ac8 ac13" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar5 ar7 ac8 ac14" style="background-color:palegreen">0.80</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar8" rowspan="2">Auckland Metro</th>
+			<th headers="ar1 ar8" id="ar9">Dose 1</th>
+			<td headers="ar1 ar8 ar9 ac1 ac2" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar8 ar9 ac1 ac3" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar8 ar9 ac1 ac4" style="background-color:palegreen">0.81</td>
+			<td headers="ar1 ar8 ar9 ac1 ac5" style="background-color:orange">0.72</td>
+			<td headers="ar1 ar8 ar9 ac1 ac6" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar8 ar9 ac1 ac7" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar8 ar9 ac8 ac9" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar8 ar9 ac8 ac10" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar8 ar9 ac8 ac11" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar8 ar9 ac8 ac12" style="background-color:palegreen">0.81</td>
+			<td headers="ar1 ar8 ar9 ac8 ac13" style="background-color:palegreen">0.84</td>
+			<td headers="ar1 ar8 ar9 ac8 ac14" style="background-color:lightgreen">0.88</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar8" id="ar10">Dose 2</th>
+			<td headers="ar1 ar8 ar10 ac1 ac2" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar8 ar10 ac1 ac3" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar8 ar10 ac1 ac4" style="background-color:coral">0.69</td>
+			<td headers="ar1 ar8 ar10 ac1 ac5" style="background-color:crimson; color: #FFF;">0.54</td>
+			<td headers="ar1 ar8 ar10 ac1 ac6" style="background-color:crimson; color: #FFF;">0.59</td>
+			<td headers="ar1 ar8 ar10 ac1 ac7" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar8 ar10 ac8 ac9" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar8 ar10 ac8 ac10" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar8 ar10 ac8 ac11" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar8 ar10 ac8 ac12" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar8 ar10 ac8 ac13" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar8 ar10 ac8 ac14" style="background-color:yellow">0.78</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar11" rowspan="2">Waikato</th>
+			<th headers="ar1 ar11" id="ar12">Dose 1</th>
+			<td headers="ar1 ar11 ar12 ac1 ac2" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar11 ar12 ac1 ac3" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar11 ar12 ac1 ac4" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar11 ar12 ac1 ac5" style="background-color:coral">0.69</td>
+			<td headers="ar1 ar11 ar12 ac1 ac6" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar11 ar12 ac1 ac7" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar11 ar12 ac8 ac9" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar11 ar12 ac8 ac10" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar11 ar12 ac8 ac11" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar11 ar12 ac8 ac12" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar11 ar12 ac8 ac13" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar11 ar12 ac8 ac14" style="background-color:mediumseagreen">0.94</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar11" id="ar13">Dose 2</th>
+			<td headers="ar1 ar11 ar13 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar11 ar13 ac1 ac3" style="background-color:lightgreen">0.87</td>
+			<td headers="ar1 ar11 ar13 ac1 ac4" style="background-color:coral">0.68</td>
+			<td headers="ar1 ar11 ar13 ac1 ac5" style="background-color:crimson; color: #FFF;">0.50</td>
+			<td headers="ar1 ar11 ar13 ac1 ac6" style="background-color:crimson; color: #FFF;">0.57</td>
+			<td headers="ar1 ar11 ar13 ac1 ac7" style="background-color:tomato">0.64</td>
+			<td headers="ar1 ar11 ar13 ac8 ac9" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar11 ar13 ac8 ac10" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar11 ar13 ac8 ac11" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar11 ar13 ac8 ac12" style="background-color:palegreen">0.84</td>
+			<td headers="ar1 ar11 ar13 ac8 ac13" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar11 ar13 ac8 ac14" style="background-color:lightgreen">0.87</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar14" rowspan="2">Bay of Plenty</th>
+			<th headers="ar1 ar14" id="ar15">Dose 1</th>
+			<td headers="ar1 ar14 ar15 ac1 ac2" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar14 ar15 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar14 ar15 ac1 ac4" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar14 ar15 ac1 ac5" style="background-color:crimson; color: #FFF;">0.57</td>
+			<td headers="ar1 ar14 ar15 ac1 ac6" style="background-color:tomato">0.64</td>
+			<td headers="ar1 ar14 ar15 ac1 ac7" style="background-color:orange">0.72</td>
+			<td headers="ar1 ar14 ar15 ac8 ac9" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar14 ar15 ac8 ac10" style="background-color:green; color: #FFF;">1.09</td>
+			<td headers="ar1 ar14 ar15 ac8 ac11" style="background-color:green; color: #FFF;">1.47</td>
+			<td headers="ar1 ar14 ar15 ac8 ac12" style="background-color:green; color: #FFF;">1.52</td>
+			<td headers="ar1 ar14 ar15 ac8 ac13" style="background-color:lightgreen">0.87</td>
+			<td headers="ar1 ar14 ar15 ac8 ac14" style="background-color:green; color: #FFF;">1.23</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar14" id="ar16">Dose 2</th>
+			<td headers="ar1 ar14 ar16 ac1 ac2" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar14 ar16 ac1 ac3" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar14 ar16 ac1 ac4" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar14 ar16 ac1 ac5" style="background-color:crimson; color: #FFF;">0.46</td>
+			<td headers="ar1 ar14 ar16 ac1 ac6" style="background-color:crimson; color: #FFF;">0.54</td>
+			<td headers="ar1 ar14 ar16 ac1 ac7" style="background-color:tomato">0.60</td>
+			<td headers="ar1 ar14 ar16 ac8 ac9" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar14 ar16 ac8 ac10" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar14 ar16 ac8 ac11" style="background-color:green; color: #FFF;">1.60</td>
+			<td headers="ar1 ar14 ar16 ac8 ac12" style="background-color:green; color: #FFF;">1.78</td>
+			<td headers="ar1 ar14 ar16 ac8 ac13" style="background-color:yellow">0.77</td>
+			<td headers="ar1 ar14 ar16 ac8 ac14" style="background-color:green; color: #FFF;">1.15</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar17" rowspan="2">Tairawhiti</th>
+			<th headers="ar1 ar17" id="ar18">Dose 1</th>
+			<td headers="ar1 ar17 ar18 ac1 ac2" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar17 ar18 ac1 ac3" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar17 ar18 ac1 ac4" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar17 ar18 ac1 ac5" style="background-color:tomato">0.62</td>
+			<td headers="ar1 ar17 ar18 ac1 ac6" style="background-color:coral">0.69</td>
+			<td headers="ar1 ar17 ar18 ac1 ac7" style="background-color:yellow">0.76</td>
+			<td headers="ar1 ar17 ar18 ac8 ac9" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar17 ar18 ac8 ac10" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar17 ar18 ac8 ac11" style="background-color:green; color: #FFF;">1.10</td>
+			<td headers="ar1 ar17 ar18 ac8 ac12" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar17 ar18 ac8 ac13" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar17 ar18 ac8 ac14" style="background-color:green; color: #FFF;">1.01</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar17" id="ar19">Dose 2</th>
+			<td headers="ar1 ar17 ar19 ac1 ac2" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar17 ar19 ac1 ac3" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar17 ar19 ac1 ac4" style="background-color:coral">0.68</td>
+			<td headers="ar1 ar17 ar19 ac1 ac5" style="background-color:crimson; color: #FFF;">0.49</td>
+			<td headers="ar1 ar17 ar19 ac1 ac6" style="background-color:crimson; color: #FFF;">0.55</td>
+			<td headers="ar1 ar17 ar19 ac1 ac7" style="background-color:tomato">0.64</td>
+			<td headers="ar1 ar17 ar19 ac8 ac9" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar17 ar19 ac8 ac10" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar17 ar19 ac8 ac11" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar17 ar19 ac8 ac12" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar17 ar19 ac8 ac13" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar17 ar19 ac8 ac14" style="background-color:mediumseagreen">0.90</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar20" rowspan="2">Lakes</th>
+			<th headers="ar1 ar20" id="ar21">Dose 1</th>
+			<td headers="ar1 ar20 ar21 ac1 ac2" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar20 ar21 ac1 ac3" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar20 ar21 ac1 ac4" style="background-color:yellow">0.76</td>
+			<td headers="ar1 ar20 ar21 ac1 ac5" style="background-color:crimson; color: #FFF;">0.58</td>
+			<td headers="ar1 ar20 ar21 ac1 ac6" style="background-color:coral">0.65</td>
+			<td headers="ar1 ar20 ar21 ac1 ac7" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar20 ar21 ac8 ac9" style="background-color:green; color: #FFF;">1.06</td>
+			<td headers="ar1 ar20 ar21 ac8 ac10" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar20 ar21 ac8 ac11" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar20 ar21 ac8 ac12" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar20 ar21 ac8 ac13" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar20 ar21 ac8 ac14" style="background-color:mediumseagreen">0.90</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar20" id="ar22">Dose 2</th>
+			<td headers="ar1 ar20 ar22 ac1 ac2" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar20 ar22 ac1 ac3" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar20 ar22 ac1 ac4" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar20 ar22 ac1 ac5" style="background-color:crimson; color: #FFF;">0.44</td>
+			<td headers="ar1 ar20 ar22 ac1 ac6" style="background-color:crimson; color: #FFF;">0.53</td>
+			<td headers="ar1 ar20 ar22 ac1 ac7" style="background-color:tomato">0.61</td>
+			<td headers="ar1 ar20 ar22 ac8 ac9" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar20 ar22 ac8 ac10" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar20 ar22 ac8 ac11" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar20 ar22 ac8 ac12" style="background-color:palegreen">0.83</td>
+			<td headers="ar1 ar20 ar22 ac8 ac13" style="background-color:lightgreen">0.86</td>
+			<td headers="ar1 ar20 ar22 ac8 ac14" style="background-color:palegreen">0.83</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar23" rowspan="2">Taranaki</th>
+			<th headers="ar1 ar23" id="ar24">Dose 1</th>
+			<td headers="ar1 ar23 ar24 ac1 ac2" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar23 ar24 ac1 ac3" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar23 ar24 ac1 ac4" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar23 ar24 ac1 ac5" style="background-color:coral">0.68</td>
+			<td headers="ar1 ar23 ar24 ac1 ac6" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar23 ar24 ac1 ac7" style="background-color:yellow">0.77</td>
+			<td headers="ar1 ar23 ar24 ac8 ac9" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar23 ar24 ac8 ac10" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar23 ar24 ac8 ac11" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar23 ar24 ac8 ac12" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar23 ar24 ac8 ac13" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar23 ar24 ac8 ac14" style="background-color:mediumseagreen">0.94</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar23" id="ar25">Dose 2</th>
+			<td headers="ar1 ar23 ar25 ac1 ac2" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar23 ar25 ac1 ac3" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar23 ar25 ac1 ac4" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar23 ar25 ac1 ac5" style="background-color:crimson; color: #FFF;">0.52</td>
+			<td headers="ar1 ar23 ar25 ac1 ac6" style="background-color:crimson; color: #FFF;">0.56</td>
+			<td headers="ar1 ar23 ar25 ac1 ac7" style="background-color:tomato">0.64</td>
+			<td headers="ar1 ar23 ar25 ac8 ac9" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar23 ar25 ac8 ac10" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar23 ar25 ac8 ac11" style="background-color:green; color: #FFF;">1.21</td>
+			<td headers="ar1 ar23 ar25 ac8 ac12" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar23 ar25 ac8 ac13" style="background-color:lightgreen">0.87</td>
+			<td headers="ar1 ar23 ar25 ac8 ac14" style="background-color:lightgreen">0.89</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar26" rowspan="2">Whanganui</th>
+			<th headers="ar1 ar26" id="ar27">Dose 1</th>
+			<td headers="ar1 ar26 ar27 ac1 ac2" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar26 ar27 ac1 ac3" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar26 ar27 ac1 ac4" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar26 ar27 ac1 ac5" style="background-color:coral">0.65</td>
+			<td headers="ar1 ar26 ar27 ac1 ac6" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar26 ar27 ac1 ac7" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar26 ar27 ac8 ac9" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar26 ar27 ac8 ac10" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar26 ar27 ac8 ac11" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar26 ar27 ac8 ac12" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar26 ar27 ac8 ac13" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar26 ar27 ac8 ac14" style="background-color:lightgreen">0.87</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar26" id="ar28">Dose 2</th>
+			<td headers="ar1 ar26 ar28 ac1 ac2" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar26 ar28 ac1 ac3" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar26 ar28 ac1 ac4" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar26 ar28 ac1 ac5" style="background-color:crimson; color: #FFF;">0.51</td>
+			<td headers="ar1 ar26 ar28 ac1 ac6" style="background-color:tomato">0.60</td>
+			<td headers="ar1 ar26 ar28 ac1 ac7" style="background-color:coral">0.65</td>
+			<td headers="ar1 ar26 ar28 ac8 ac9" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar26 ar28 ac8 ac10" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar26 ar28 ac8 ac11" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar26 ar28 ac8 ac12" style="background-color:palegreen">0.83</td>
+			<td headers="ar1 ar26 ar28 ac8 ac13" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar26 ar28 ac8 ac14" style="background-color:palegreen">0.80</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar29" rowspan="2">Hawke&#39;s Bay</th>
+			<th headers="ar1 ar29" id="ar30">Dose 1</th>
+			<td headers="ar1 ar29 ar30 ac1 ac2" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar29 ar30 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar29 ar30 ac1 ac4" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar29 ar30 ac1 ac5" style="background-color:crimson; color: #FFF;">0.59</td>
+			<td headers="ar1 ar29 ar30 ac1 ac6" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar29 ar30 ac1 ac7" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar29 ar30 ac8 ac9" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar29 ar30 ac8 ac10" style="background-color:green; color: #FFF;">1.05</td>
+			<td headers="ar1 ar29 ar30 ac8 ac11" style="background-color:green; color: #FFF;">1.42</td>
+			<td headers="ar1 ar29 ar30 ac8 ac12" style="background-color:green; color: #FFF;">1.32</td>
+			<td headers="ar1 ar29 ar30 ac8 ac13" style="background-color:lightgreen">0.88</td>
+			<td headers="ar1 ar29 ar30 ac8 ac14" style="background-color:green; color: #FFF;">1.16</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar29" id="ar31">Dose 2</th>
+			<td headers="ar1 ar29 ar31 ac1 ac2" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar29 ar31 ac1 ac3" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar29 ar31 ac1 ac4" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar29 ar31 ac1 ac5" style="background-color:crimson; color: #FFF;">0.47</td>
+			<td headers="ar1 ar29 ar31 ac1 ac6" style="background-color:crimson; color: #FFF;">0.57</td>
+			<td headers="ar1 ar29 ar31 ac1 ac7" style="background-color:tomato">0.61</td>
+			<td headers="ar1 ar29 ar31 ac8 ac9" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar29 ar31 ac8 ac10" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar29 ar31 ac8 ac11" style="background-color:green; color: #FFF;">1.48</td>
+			<td headers="ar1 ar29 ar31 ac8 ac12" style="background-color:green; color: #FFF;">1.48</td>
+			<td headers="ar1 ar29 ar31 ac8 ac13" style="background-color:lightgreen">0.86</td>
+			<td headers="ar1 ar29 ar31 ac8 ac14" style="background-color:green; color: #FFF;">1.10</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar32" rowspan="2">MidCentral</th>
+			<th headers="ar1 ar32" id="ar33">Dose 1</th>
+			<td headers="ar1 ar32 ar33 ac1 ac2" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar32 ar33 ac1 ac3" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar32 ar33 ac1 ac4" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar32 ar33 ac1 ac5" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar32 ar33 ac1 ac6" style="background-color:orange">0.72</td>
+			<td headers="ar1 ar32 ar33 ac1 ac7" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar32 ar33 ac8 ac9" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar32 ar33 ac8 ac10" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar32 ar33 ac8 ac11" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar32 ar33 ac8 ac12" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar32 ar33 ac8 ac13" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar32 ar33 ac8 ac14" style="background-color:mediumseagreen">0.94</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar32" id="ar34">Dose 2</th>
+			<td headers="ar1 ar32 ar34 ac1 ac2" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar32 ar34 ac1 ac3" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar32 ar34 ac1 ac4" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar32 ar34 ac1 ac5" style="background-color:crimson; color: #FFF;">0.58</td>
+			<td headers="ar1 ar32 ar34 ac1 ac6" style="background-color:tomato">0.60</td>
+			<td headers="ar1 ar32 ar34 ac1 ac7" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar32 ar34 ac8 ac9" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar32 ar34 ac8 ac10" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar32 ar34 ac8 ac11" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar32 ar34 ac8 ac12" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar32 ar34 ac8 ac13" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar32 ar34 ac8 ac14" style="background-color:lightgreen">0.85</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar35" rowspan="2">Wairarapa</th>
+			<th headers="ar1 ar35" id="ar36">Dose 1</th>
+			<td headers="ar1 ar35 ar36 ac1 ac2" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar35 ar36 ac1 ac3" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar35 ar36 ac1 ac4" style="background-color:palegreen">0.84</td>
+			<td headers="ar1 ar35 ar36 ac1 ac5" style="background-color:orange">0.72</td>
+			<td headers="ar1 ar35 ar36 ac1 ac6" style="background-color:yellow">0.77</td>
+			<td headers="ar1 ar35 ar36 ac1 ac7" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar35 ar36 ac8 ac9" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar35 ar36 ac8 ac10" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar35 ar36 ac8 ac11" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar35 ar36 ac8 ac12" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar35 ar36 ac8 ac13" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar35 ar36 ac8 ac14" style="background-color:mediumseagreen">0.92</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar35" id="ar37">Dose 2</th>
+			<td headers="ar1 ar35 ar37 ac1 ac2" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar35 ar37 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar35 ar37 ac1 ac4" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar35 ar37 ac1 ac5" style="background-color:crimson; color: #FFF;">0.55</td>
+			<td headers="ar1 ar35 ar37 ac1 ac6" style="background-color:tomato">0.63</td>
+			<td headers="ar1 ar35 ar37 ac1 ac7" style="background-color:tomato">0.64</td>
+			<td headers="ar1 ar35 ar37 ac8 ac9" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar35 ar37 ac8 ac10" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar35 ar37 ac8 ac11" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar35 ar37 ac8 ac12" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar35 ar37 ac8 ac13" style="background-color:palegreen">0.84</td>
+			<td headers="ar1 ar35 ar37 ac8 ac14" style="background-color:lightgreen">0.86</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar38" rowspan="2">Capital &amp; Coast and Hutt Valley</th>
+			<th headers="ar1 ar38" id="ar39">Dose 1</th>
+			<td headers="ar1 ar38 ar39 ac1 ac2" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar38 ar39 ac1 ac3" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar38 ar39 ac1 ac4" style="background-color:palegreen">0.83</td>
+			<td headers="ar1 ar38 ar39 ac1 ac5" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar38 ar39 ac1 ac6" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar38 ar39 ac1 ac7" style="background-color:palegreen">0.81</td>
+			<td headers="ar1 ar38 ar39 ac8 ac9" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar38 ar39 ac8 ac10" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar38 ar39 ac8 ac11" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar38 ar39 ac8 ac12" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar38 ar39 ac8 ac13" style="background-color:palegreen">0.84</td>
+			<td headers="ar1 ar38 ar39 ac8 ac14" style="background-color:lightgreen">0.86</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar38" id="ar40">Dose 2</th>
+			<td headers="ar1 ar38 ar40 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar38 ar40 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar38 ar40 ac1 ac4" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar38 ar40 ac1 ac5" style="background-color:tomato">0.63</td>
+			<td headers="ar1 ar38 ar40 ac1 ac6" style="background-color:tomato">0.62</td>
+			<td headers="ar1 ar38 ar40 ac1 ac7" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar38 ar40 ac8 ac9" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar38 ar40 ac8 ac10" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar38 ar40 ac8 ac11" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar38 ar40 ac8 ac12" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar38 ar40 ac8 ac13" style="background-color:yellow">0.76</td>
+			<td headers="ar1 ar38 ar40 ac8 ac14" style="background-color:palegreen">0.80</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar41" rowspan="2">Nelson Marlborough</th>
+			<th headers="ar1 ar41" id="ar42">Dose 1</th>
+			<td headers="ar1 ar41 ar42 ac1 ac2" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar41 ar42 ac1 ac3" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar41 ar42 ac1 ac4" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar41 ar42 ac1 ac5" style="background-color:coral">0.69</td>
+			<td headers="ar1 ar41 ar42 ac1 ac6" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar41 ar42 ac1 ac7" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar41 ar42 ac8 ac9" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar41 ar42 ac8 ac10" style="background-color:green; color: #FFF;">1.28</td>
+			<td headers="ar1 ar41 ar42 ac8 ac11" style="background-color:green; color: #FFF;">2.45</td>
+			<td headers="ar1 ar41 ar42 ac8 ac12" style="background-color:green; color: #FFF;">2.89</td>
+			<td headers="ar1 ar41 ar42 ac8 ac13" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar41 ar42 ac8 ac14" style="background-color:green; color: #FFF;">1.97</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar41" id="ar43">Dose 2</th>
+			<td headers="ar1 ar41 ar43 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar41 ar43 ac1 ac3" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar41 ar43 ac1 ac4" style="background-color:orange">0.72</td>
+			<td headers="ar1 ar41 ar43 ac1 ac5" style="background-color:crimson; color: #FFF;">0.57</td>
+			<td headers="ar1 ar41 ar43 ac1 ac6" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar41 ar43 ac1 ac7" style="background-color:coral">0.69</td>
+			<td headers="ar1 ar41 ar43 ac8 ac9" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar41 ar43 ac8 ac10" style="background-color:green; color: #FFF;">1.26</td>
+			<td headers="ar1 ar41 ar43 ac8 ac11" style="background-color:green; color: #FFF;">2.57</td>
+			<td headers="ar1 ar41 ar43 ac8 ac12" style="background-color:green; color: #FFF;">3.47</td>
+			<td headers="ar1 ar41 ar43 ac8 ac13" style="background-color:green; color: #FFF;">1.05</td>
+			<td headers="ar1 ar41 ar43 ac8 ac14" style="background-color:green; color: #FFF;">1.95</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar44" rowspan="2">West Coast</th>
+			<th headers="ar1 ar44" id="ar45">Dose 1</th>
+			<td headers="ar1 ar44 ar45 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar44 ar45 ac1 ac3" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar44 ar45 ac1 ac4" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar44 ar45 ac1 ac5" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar44 ar45 ac1 ac6" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar44 ar45 ac1 ac7" style="background-color:lightgreen">0.86</td>
+			<td headers="ar1 ar44 ar45 ac8 ac9" style="background-color:green; color: #FFF;">1.33</td>
+			<td headers="ar1 ar44 ar45 ac8 ac10" style="background-color:green; color: #FFF;">1.06</td>
+			<td headers="ar1 ar44 ar45 ac8 ac11" style="background-color:green; color: #FFF;">1.07</td>
+			<td headers="ar1 ar44 ar45 ac8 ac12" style="background-color:green; color: #FFF;">1.24</td>
+			<td headers="ar1 ar44 ar45 ac8 ac13" style="background-color:palegreen">0.83</td>
+			<td headers="ar1 ar44 ar45 ac8 ac14" style="background-color:green; color: #FFF;">0.99</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar44" id="ar46">Dose 2</th>
+			<td headers="ar1 ar44 ar46 ac1 ac2" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar44 ar46 ac1 ac3" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar44 ar46 ac1 ac4" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar44 ar46 ac1 ac5" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar44 ar46 ac1 ac6" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar44 ar46 ac1 ac7" style="background-color:yellow">0.76</td>
+			<td headers="ar1 ar44 ar46 ac8 ac9" style="background-color:green; color: #FFF;">1.33</td>
+			<td headers="ar1 ar44 ar46 ac8 ac10" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar44 ar46 ac8 ac11" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar44 ar46 ac8 ac12" style="background-color:green; color: #FFF;">1.57</td>
+			<td headers="ar1 ar44 ar46 ac8 ac13" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar44 ar46 ac8 ac14" style="background-color:mediumseagreen">0.91</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar47" rowspan="2">Canterbury</th>
+			<th headers="ar1 ar47" id="ar48">Dose 1</th>
+			<td headers="ar1 ar47 ar48 ac1 ac2" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar47 ar48 ac1 ac3" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar47 ar48 ac1 ac4" style="background-color:palegreen">0.83</td>
+			<td headers="ar1 ar47 ar48 ac1 ac5" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar47 ar48 ac1 ac6" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar47 ar48 ac1 ac7" style="background-color:palegreen">0.81</td>
+			<td headers="ar1 ar47 ar48 ac8 ac9" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar47 ar48 ac8 ac10" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar47 ar48 ac8 ac11" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar47 ar48 ac8 ac12" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar47 ar48 ac8 ac13" style="background-color:lightgreen">0.88</td>
+			<td headers="ar1 ar47 ar48 ac8 ac14" style="background-color:lightgreen">0.89</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar47" id="ar49">Dose 2</th>
+			<td headers="ar1 ar47 ar49 ac1 ac2" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar47 ar49 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar47 ar49 ac1 ac4" style="background-color:yellow">0.77</td>
+			<td headers="ar1 ar47 ar49 ac1 ac5" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar47 ar49 ac1 ac6" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar47 ar49 ac1 ac7" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar47 ar49 ac8 ac9" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar47 ar49 ac8 ac10" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar47 ar49 ac8 ac11" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar47 ar49 ac8 ac12" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar47 ar49 ac8 ac13" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar47 ar49 ac8 ac14" style="background-color:lightgreen">0.85</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar50" rowspan="2">South Canterbury</th>
+			<th headers="ar1 ar50" id="ar51">Dose 1</th>
+			<td headers="ar1 ar50 ar51 ac1 ac2" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar50 ar51 ac1 ac3" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar50 ar51 ac1 ac4" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar50 ar51 ac1 ac5" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar50 ar51 ac1 ac6" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar50 ar51 ac1 ac7" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar50 ar51 ac8 ac9" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar50 ar51 ac8 ac10" style="background-color:green; color: #FFF;">1.09</td>
+			<td headers="ar1 ar50 ar51 ac8 ac11" style="background-color:green; color: #FFF;">1.18</td>
+			<td headers="ar1 ar50 ar51 ac8 ac12" style="background-color:green; color: #FFF;">1.23</td>
+			<td headers="ar1 ar50 ar51 ac8 ac13" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar50 ar51 ac8 ac14" style="background-color:green; color: #FFF;">1.06</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar50" id="ar52">Dose 2</th>
+			<td headers="ar1 ar50 ar52 ac1 ac2" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar50 ar52 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar50 ar52 ac1 ac4" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar50 ar52 ac1 ac5" style="background-color:tomato">0.63</td>
+			<td headers="ar1 ar50 ar52 ac1 ac6" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar50 ar52 ac1 ac7" style="background-color:coral">0.69</td>
+			<td headers="ar1 ar50 ar52 ac8 ac9" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar50 ar52 ac8 ac10" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar50 ar52 ac8 ac11" style="background-color:green; color: #FFF;">1.09</td>
+			<td headers="ar1 ar50 ar52 ac8 ac12" style="background-color:green; color: #FFF;">1.15</td>
+			<td headers="ar1 ar50 ar52 ac8 ac13" style="background-color:green; color: #FFF;">1.05</td>
+			<td headers="ar1 ar50 ar52 ac8 ac14" style="background-color:lightgreen">0.89</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar53" rowspan="2">Southern</th>
+			<th headers="ar1 ar53" id="ar54">Dose 1</th>
+			<td headers="ar1 ar53 ar54 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar53 ar54 ac1 ac3" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar53 ar54 ac1 ac4" style="background-color:palegreen">0.83</td>
+			<td headers="ar1 ar53 ar54 ac1 ac5" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar53 ar54 ac1 ac6" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar53 ar54 ac1 ac7" style="background-color:palegreen">0.81</td>
+			<td headers="ar1 ar53 ar54 ac8 ac9" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar53 ar54 ac8 ac10" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar53 ar54 ac8 ac11" style="background-color:green; color: #FFF;">1.07</td>
+			<td headers="ar1 ar53 ar54 ac8 ac12" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar53 ar54 ac8 ac13" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar53 ar54 ac8 ac14" style="background-color:green; color: #FFF;">1.01</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar53" id="ar55">Dose 2</th>
+			<td headers="ar1 ar53 ar55 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar53 ar55 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar53 ar55 ac1 ac4" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar53 ar55 ac1 ac5" style="background-color:coral">0.66</td>
+			<td headers="ar1 ar53 ar55 ac1 ac6" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar53 ar55 ac1 ac7" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar53 ar55 ac8 ac9" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar53 ar55 ac8 ac10" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar53 ar55 ac8 ac11" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar53 ar55 ac8 ac12" style="background-color:green; color: #FFF;">1.05</td>
+			<td headers="ar1 ar53 ar55 ac8 ac13" style="background-color:lightgreen">0.87</td>
+			<td headers="ar1 ar53 ar55 ac8 ac14" style="background-color:mediumseagreen">0.93</td>
+		</tr>
+	</tbody>
+</table>
+
+<p>This table shows the rate of doses administered (per 1,000 population) to Māori or Pacific Peoples, relative to the rate of doses for Non-Māori and Non-Pacific groups. Less than one means the group is receiving a lower proportion of doses than would be expected if equity is being achieved. More than one means they are receiving a higher proportion of doses than would be expected if equity is being achieved. Exactly one means doses administered are in line with their proportion of population.</p>
+
+<ul>
+	<li><a download="" href="/web/20211029114420/https://www.health.govt.nz/system/files/documents/pages/rateratioexplainer_2.docx">Rate Ratio Explainer (Word, 434 KB)</a></li>
+</ul>
+
+<p>At all ages the size (weightings) of the age groups becomes a major contributing factor to comparative ratios, which is why the all ages (12+) figure may not appear to be in line with the age splits.</p>
+
+<h4><a id="uptake" name="uptake"></a>Vaccine uptake per 1,000 people by ethnicity</h4>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine uptake per 1,000 people by ethnicity" class="img-responsive" height="830" src="/web/20211029114420im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_eth_8.png" width="1780"/></figure>
+
+<h4><a id="uptake" name="uptake"></a>Vaccine uptake per 1,000 people by age band</h4>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine uptake per 1,000 people by age band" class="img-responsive" height="1030" src="/web/20211029114420im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_age_9.png" width="1780"/></figure>
+
+<h4><a id="uptake" name="location"></a>Vaccine uptake per 1,000 people by DHB of residence</h4>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine uptake per 1,000 people by DHB of residence" class="img-responsive" height="1030" src="/web/20211029114420im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_dhb_4.png" width="1780"/></figure>
+<!--
+<hr />
+<h3><a id="by_dhb_plan" name="dhb_plan"></a>Cumulative vaccination plan for DHBs</h3>
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">DHB of service</th>
+			<th scope="col" style="text-align:right">Actuals to Sunday 24 October</th>
+			<th scope="col" style="text-align:right">DHB Plan to Sunday 24 October</th>
+			<th scope="col" style="text-align:right">Variance</th>
+			<th scope="col" style="text-align:right">% of Plan</th>
+			<th scope="col" style="text-align:right">Week to date</th>
+		</tr>
+	</thead>
+	<tbody> --><!--plan--><!--
+<tr><td nowrap="nowrap">Auckland Metro</td><td>190621</td><td>205515</td><td>-14894</td><td>93%</td><td>9913</td></tr>
+<tr><td nowrap="nowrap">Bay of Plenty</td><td>22841</td><td>14255</td><td>8586</td><td>160%</td><td>1843</td></tr>
+<tr><td nowrap="nowrap">Canterbury</td><td>50558</td><td>39266</td><td>11292</td><td>129%</td><td>2769</td></tr>
+<tr><td nowrap="nowrap">Capital & Coast and Hutt Valley</td><td>48758</td><td>39742</td><td>9016</td><td>123%</td><td>1796</td></tr>
+<tr><td nowrap="nowrap">Hawke's Bay</td><td>15319</td><td>18205</td><td>-2886</td><td>84%</td><td>1351</td></tr>
+<tr><td nowrap="nowrap">Lakes</td><td>13437</td><td>12810</td><td>627</td><td>105%</td><td>731</td></tr>
+<tr><td nowrap="nowrap">MidCentral</td><td>10708</td><td>7237</td><td>3471</td><td>148%</td><td>1191</td></tr>
+<tr><td nowrap="nowrap">Nelson Marlborough</td><td>30198</td><td>18574</td><td>11624</td><td>163%</td><td>1285</td></tr>
+<tr><td nowrap="nowrap">Northland</td><td>21469</td><td>24762</td><td>-3293</td><td>87%</td><td>1257</td></tr>
+<tr><td nowrap="nowrap">South Canterbury</td><td>8106</td><td>8033</td><td>73</td><td>101%</td><td>389</td></tr>
+<tr><td nowrap="nowrap">Southern</td><td>35234</td><td>34594</td><td>640</td><td>102%</td><td>1794</td></tr>
+<tr><td nowrap="nowrap">Tairāwhiti</td><td>4579</td><td>4928</td><td>-349</td><td>93%</td><td>290</td></tr>
+<tr><td nowrap="nowrap">Taranaki</td><td>5619</td><td>5297</td><td>322</td><td>106%</td><td>168</td></tr>
+<tr><td nowrap="nowrap">Waikato</td><td>36070</td><td>32842</td><td>3228</td><td>110%</td><td>1905</td></tr>
+<tr><td nowrap="nowrap">Wairarapa</td><td>4516</td><td>4960</td><td>-444</td><td>91%</td><td>468</td></tr>
+<tr><td nowrap="nowrap">West Coast</td><td>3533</td><td>3300</td><td>233</td><td>107%</td><td>336</td></tr>
+<tr><td nowrap="nowrap">Whanganui</td><td>6982</td><td>4711</td><td>2271</td><td>148%</td><td>612</td></tr>
+<tr><td nowrap="nowrap">Other Sites</td><td>24890</td><td>14575</td><td>10315</td><td>171%</td><td>613</td></tr>
+<tr><td nowrap="nowrap">Total</td><td>533438</td><td>493606</td><td>39832</td><td>108%</td><td>28711</td></tr>
+!--plan_end--><!--	</tbody>
+</table>
+
+
+<p>The information provided in this table is based on cumulative DHB plans to the last week ending on Sunday. The final column shows vaccinations administered since Sunday by DHB of service to reconcile total actuals in this table to other total numbers shown.   On-going, and as we roll-out the vaccination programme, we anticipate that there could be a potential variance of up to ten percent (plus or minus) between DHB Plans and actual vaccination numbers. This is on the basis that, for example, an unplanned significant event could affect roll-out implementation or some DHBs might exceed their planned vaccination numbers.
+</p>
+-->
+
+<hr/>
+<h3><a id="by_dhb" name="location"></a>Cumulative vaccinations by DHB</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Cumulative vaccinations for DHBs" class="img-responsive" height="830" src="/web/20211029114420im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/dhbstacked_12.png" width="1780"/></figure>
+
+<hr/>
+<h3><a id="by-day" name="by-day"></a>Vaccinations by day</h3>
+
+<figure class="image-captioned img-responsive"><img alt="Vaccination doses administered per day" class="img-responsive" height="830" src="/web/20211029114420im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/vaccinebyday_12.png" width="1780"/></figure>
+
+<p>This chart shows the count of vaccinations administered on a given day from the COVID-19 Immunisation Register. Note some records are entered in the register at a later date than the immunisation was received. This means that the figures for a given date may move for some time after that date.</p>
+
+<hr/>
+<h3><a id="group" name="group"></a>Vaccinations by group by week</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccinations by group" class="img-responsive" height="830" src="/web/20211029114420im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/vaccinebygroupwk_12.png" width="1780"/></figure>
+
+<hr/>
+<h3><a id="group_d" name="group_d"></a>Cumulative vaccinations by group</h3>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">Priority Group</th>
+			<th scope="col" style="text-align:right">First dose administered</th>
+			<th scope="col" style="text-align:right">Second dose administered</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">Group 1</th>
+			<td style="text-align:right">66,767</td>
+			<td style="text-align:right">65,205</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Group 2</th>
+			<td style="text-align:right">661,231</td>
+			<td style="text-align:right">621,689</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Group 3</th>
+			<td style="text-align:right">793,481</td>
+			<td style="text-align:right">746,741</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Group 4</th>
+			<td style="text-align:right">2,136,491</td>
+			<td style="text-align:right">1,585,195</td>
+		</tr>
+	</tbody>
+</table>
+
+<p>For definitions of the groups and further detail see the downloadable spreadsheet at the bottom of the page.</p>
+
+<hr/>
+<h3><a id="by_soh" name="stockonhand"></a>Vaccine available for distribution at week end</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine available for distribution at week end" class="img-responsive" height="830" src="/web/20211029114420im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/stockonhand_13.png" width="1780"/></figure>
+
+<p>Vaccine available for distribution is stock (in doses) held at central warehouses. It does not include stock in transit or available at sites ready for use.</p>
+
+<hr/>
+<h3><a id="by_eth" name="ethnicity"></a>Total cumulative doses per 1,000 people by ethnicity</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Total cumulative doses per 1,000 people by ethnicity" class="img-responsive" height="830" src="/web/20211029114420im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/ethnicity_12.png" width="1780"/></figure>
+
+<p>This chart shows both first and second doses. As a result this chart may exceed 1,000 doses per 1,000 people.</p>
+
+<p><strong>*</strong> The prioritised ethnicity classification system allocates each person to a single ethnic group, based on the ethnic groups they identify with. Where people identify with more than one group, they are assigned in this order of priority: Māori, Pacific Peoples, Asian, and European/Other. So, if a person identifies as being Māori and New Zealand European, the person is counted as Māori. See <a href="/web/20211029114420/https://www.health.govt.nz/publication/hiso-100012017-ethnicity-data-protocols">Ethnicity Data Protocols</a> for further information.</p>
+
+<p>Ethnicity breakdown by DHB of residence is available in the downloadable spreadsheet at the bottom of the page.</p>
+
+<hr/>
+<h3><a id="by_age" name="age"></a>Cumulative vaccinations by age</h3>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">Age</th>
+			<th scope="col" style="text-align:right">First dose administered</th>
+			<th scope="col" style="text-align:right">First doses per 1,000 people</th>
+			<th scope="col" style="text-align:right">Fully vaccinated</th>
+			<th scope="col" style="text-align:right">Fully vaccinated per 1,000 people</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">12 - 19 years</th>
+			<td style="text-align:right">403,029</td>
+			<td style="text-align:right">802</td>
+			<td style="text-align:right">279,575</td>
+			<td style="text-align:right">557</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">20 - 34 years</th>
+			<td style="text-align:right">845,409</td>
+			<td style="text-align:right">817</td>
+			<td style="text-align:right">604,676</td>
+			<td style="text-align:right">585</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">35 - 49 years</th>
+			<td style="text-align:right">824,175</td>
+			<td style="text-align:right">862</td>
+			<td style="text-align:right">670,851</td>
+			<td style="text-align:right">701</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">50 - 64 years</th>
+			<td style="text-align:right">836,170</td>
+			<td style="text-align:right">901</td>
+			<td style="text-align:right">749,933</td>
+			<td style="text-align:right">809</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">65 and over</th>
+			<td style="text-align:right">749,187</td>
+			<td style="text-align:right">950</td>
+			<td style="text-align:right">713,795</td>
+			<td style="text-align:right">905</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total</strong></th>
+			<td style="text-align:right"><strong>3,657,970</strong></td>
+			<td style="text-align:right"><strong>869</strong></td>
+			<td style="text-align:right"><strong>3,018,830</strong></td>
+			<td style="text-align:right"><strong>717</strong></td>
+		</tr>
+	</tbody>
+</table>
+
+<p>Age breakdown by ethnicity and gender is available in the downloadable spreadsheet at the bottom of the page.</p>
+
+<hr/>
+<h3><a id="workforce" name="workforce"></a>Trained vaccinators and active vaccinators</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Trained vaccinators and active vaccinators" class="img-responsive" height="830" src="/web/20211029114420im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/workforce_12.png" width="1780"/></figure>
+
+<p><strong>Trained vaccinators</strong> are individuals who have completed the COVID-19 training. Many trained people are only able to offer a small number of hours to the COVID-19 vaccination programme.</p>
+
+<p><strong>Active vaccinators</strong> are trained individuals who are actively vaccinating. The number of active vaccinators does not reflect the hours worked vaccinating. For example, one vaccinator may work 40 hours in a week at one DHB and will show as 1 vaccinator in the headcount. In another DHB, 4 vaccinators may work 10 hours each (total 40 hours), but will show as 4 vaccinators in the headcount for that week.</p>
+
+<p>Both counts of trained and active vaccinators are cumulative. The difference between the two is due to a number of factors. This includes: individuals being trained in anticipation of future sites being opened (the largest factor); rostering; leave or non-availability; local health priorities; sites opening and closing.</p>
+
+<hr/>
+<h3><a id="usage" name="usage"></a>Wastage of vaccine stock</h3>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">&nbsp;</th>
+			<th scope="col">Wastage</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">New Zealand</th>
+			<td>0.29%</td>
+		</tr>
+	</tbody>
+</table>
+
+<p>Wastage is vials that have been reported as wasted since 13 July in the Inventory portal by DHBs or central warehouses divided by vials used over the same time frame.</p>
+
+<h3><a id="download" name="download"></a>Details of vaccination data</h3>
+
+<p>Download a spreadsheet containing key vaccination data. This includes HSU based population estimates for calculating vaccine uptake rates.</p>
+
+<p><a download="" href="/web/20211029114420/https://www.health.govt.nz/system/files/documents/pages/covid_vaccinations_26_10_2021.xlsx">COVID-19 vaccination data through 26 Oct 2021 (Excel, 363 KB)</a></p>
+
+<p>This spreadsheet is based on the information made available at the time of publishing and may be subject to changes. Please take note of any notes and caveats on each sheet.</p>
+
+<p>The below attachments provide some analysis on our progress on equity. The two PDF files are high level summaries of overall progress. The Excel documents are interactive and provides the ability to delve further into those overall numbers. NB: These Excel workbooks use features that are non-compatible with versions of MS Office 2016 and earlier.</p>
+
+<ul>
+	<li><a download="" href="/web/20211029114420/https://www.health.govt.nz/system/files/documents/pages/211024_-_cvip_equity_-_rate_ratios_by_ethnicity_ageband_and_dhb.pdf">Covid-19 Vaccine Rate Ratios by Ethnicity, Ageband and DHB (PDF, 642 KB)</a></li>
+	<li><a download="" href="/web/20211029114420/https://www.health.govt.nz/system/files/documents/pages/211024_-_cvip_equity_-_uptake_by_ethnicity_ageband_and_dhb.pdf">Covid-19 Vaccine Uptake by Ethnicity, Ageband and DHB (PDF, 550 KB)</a></li>
+	<li><a download="" href="/web/20211029114420/https://www.health.govt.nz/system/files/documents/pages/211024_-_cvip_equity_-_level_1_ethnicity_uptake_and_rate_ratios.xlsx">Covid-19 Vaccine Equity - Level 1 Ethnicity Uptake and Rate Ratios (Excel, 152 KB)</a></li>
+	<li><a download="" href="/web/20211029114420/https://www.health.govt.nz/system/files/documents/pages/211024_-_cvip_equity_-_level_2_ethnicity_uptake_and_rate_ratios.xlsx">Covid-19 Vaccine Equity - Level 2 Ethnicity Uptake and Rate Ratios (Excel, 378 KB)</a></li>
+	<li><a download="" href="/web/20211029114420/https://www.health.govt.nz/system/files/documents/pages/211024_-_cvip_equity_-_rate_ratios_and_uptake_over_time.xlsx">Rate Ratios and Uptake Over Time (Excel, 996 KB)</a></li>
+</ul>
+
+<hr/>
+<h3><a id="adverse-events" name="adverse-events"></a>Adverse events following&nbsp;immunisations (AEFI)</h3>
+
+<p>Like all medicines, the COVID-19 vaccine may cause side effects in some people. These are common, are usually mild, don&rsquo;t last long and won&rsquo;t stop people from having the second dose or going about daily life. Serious allergic reactions do occur but are extremely rare.</p>
+
+<p>Suspected AEFI to COVID-19 vaccines are reported to the <a href="https://web.archive.org/web/20211029114420/https://nzphvc.otago.ac.nz/">Centre for Adverse Reactions Monitoring</a> (CARM).&nbsp;<a href="https://web.archive.org/web/20211029114420/https://www.medsafe.govt.nz/">Medsafe</a> is closely monitoring the AEFI reported from the use of the COVID-19 vaccine and will report regularly on their findings.&nbsp;</p>
+
+<p><a href="https://web.archive.org/web/20211029114420/https://www.medsafe.govt.nz/COVID-19/vaccine-report-overview.asp">View Medsafe data on COVID-19 vaccine adverse effects following immunisation</a></p>
+</div></div></div>    </article>
+  </div>
+
+
+  </div>
+<div class="panel-pane pane-node-links even">
+
+
+
+  <div class="pane-content">
+          </div>
+
+
+  </div>
+
+<div class="panel-pane pane-views pane-sub-pages even">
+
+        <h2 class="pane-title h3">In this section</h2>
+
+
+  <div class="pane-content">
+        <div class="view view-sub-pages view-id-sub_pages view-display-id-block view-dom-id-1edb6e74ff56c94a5026d3c833ac9b55">
+
+
+
+      <div class="view-content">
+      <div class="item-list">    <ul>          <li class="views-row views-row-1 views-row-odd views-row-first">
+  <div class="views-field views-field-title">        <div class="field-content">
+<div class="views-field views-field-title">
+  <h3 class="field-content">
+    <a href="/web/20211029114420/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-across-nz">COVID-19 Vaccination uptake rates across NZ</a>  </h3>
+</div></div>  </div>
+  <span class="views-field views-field-body">        <span class="field-content">This page provides information related to uptake rates of the COVID-19 vaccine across the country.
+</span>  </span>
+  <span class="views-field views-field-view-node">        <span class="field-content"><a href="/web/20211029114420/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-across-nz">Read more</a></span>  </span></li>
+          <li class="views-row views-row-2 views-row-even">
+  <div class="views-field views-field-title">        <div class="field-content">
+<div class="views-field views-field-title">
+  <h3 class="field-content">
+    <a href="/web/20211029114420/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-maori-communities-across-nz">COVID-19 Vaccination uptake rates within Māori communities across NZ</a>  </h3>
+</div></div>  </div>
+  <span class="views-field views-field-body">        <span class="field-content">This page provides information related to uptake rates of the COVID-19 vaccine within Māori communities across New Zealand.
+</span>  </span>
+  <span class="views-field views-field-view-node">        <span class="field-content"><a href="/web/20211029114420/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-maori-communities-across-nz">Read more</a></span>  </span></li>
+          <li class="views-row views-row-3 views-row-odd views-row-last">
+  <div class="views-field views-field-title">        <div class="field-content">
+<div class="views-field views-field-title">
+  <h3 class="field-content">
+    <a href="/web/20211029114420/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-pacific-communities-across-nz">COVID-19 Vaccination uptake rates within Pacific communities across NZ</a>  </h3>
+</div></div>  </div>
+  <span class="views-field views-field-body">        <span class="field-content">This page provides information related to uptake rates of the COVID-19 vaccine within Pacific communities across New Zealand.
+</span>  </span>
+  <span class="views-field views-field-view-node">        <span class="field-content"><a href="/web/20211029114420/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-pacific-communities-across-nz">Read more</a></span>  </span></li>
+      </ul></div>    </div>
+
+
+
+
+
+
+</div>  </div>
+
+
+  </div>
+</div>          </div>
+
+  </div>
+
+</section>
+  </div>
+      </section>
+
+
+    </div>
+    <div id="content-footer-wrapper" class="clearfix">
+      <div id="content-footer" class="clearfix">
+                  <p class="page_updated">Page last updated: <span class="date">29 October 2021</span></p>                  <div class="region region-content-footer">
+    <section id="block-moh-tools-page-tools" class="block block-moh-tools clearfix">
+  <a href="#" data-placement="top" data-title="Share this content." data-html="true" data-content="<p>Share this page on some of the most popular social networking and content sites on the internet.</p><div class='service-links'><ul><li><a href='https://twitter.com/share?url=https%3A//www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data&amp;text=COVID-19%3A%20Vaccine%20data' title='Share this on Twitter' class='service-links-twitter' rel='nofollow'><img typeof='foaf:Image' class='img-responsive' src='https://www.health.govt.nz/sites/all/modules/contrib/service_links/images/twitter.png' alt='Twitter' /> Twitter</a></li>
+<li><a href='https://www.facebook.com/sharer.php?u=https%3A//www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data&amp;t=COVID-19%3A%20Vaccine%20data' title='Share on Facebook' class='service-links-facebook' rel='nofollow'><img typeof='foaf:Image' class='img-responsive' src='https://www.health.govt.nz/sites/all/modules/contrib/service_links/images/facebook.png' alt='Facebook' /> Facebook</a></li>
+</ul></div>" class="share-this-content"><i class="fa fa-share"></i> Share</a><a href="#" title="print this page" class="print"><i class="fa fa-print"></i> Print</a><a href="https://web.archive.org/web/20211029114420/https://www.health.govt.nz/forward?path=node/12052" title="Email this page" class="email"><i class="fa fa-envelope"></i> Email</a><a href="/web/20211029114420/https://www.health.govt.nz/feedback?ref=https%3A//www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="Feedback" class="rss"><i class="fa fa-comment"></i> Feedback</a></section>
+
+  </div>
+      </div>
+    </div>
+
+  </div>
+  <footer class="footer container">
+    <h2 class="hidden">Site Footer</h2>
+    <div class="footer-default">
+      <div class="row">
+        <div class="col-sm-6 col-md-6">
+          <div class="field field-name-field-tax-first-column-links">
+            <ul class="field-items"><li class="field-item"><a href="https://web.archive.org/web/20211029114420/https://www.health.govt.nz/node/492" class="">About this site</a></li><li class="field-item"><a href="https://web.archive.org/web/20211029114420/https://www.health.govt.nz/node/524" class="">Contact us</a></li><li class="field-item"><a href="https://web.archive.org/web/20211029114420/https://www.health.govt.nz/node/488" class="">Other Ministry of Health websites</a></li><li class="field-item"><a href="https://web.archive.org/web/20211029114420/https://www.health.govt.nz/node/7497" class="">Official Information Act requests</a></li><li class="field-item"><a href="https://web.archive.org/web/20211029114420/https://www.health.govt.nz/about-ministry/information-releases" class="">Information releases</a></li><li class="field-item"><a href="https://web.archive.org/web/20211029114420/https://consult.health.govt.nz/" class="">Consultations</a></li></ul>
+          </div>
+        </div>
+        <div class="col-sm-6 col-md-6">
+          <div class="field field-name-field-tax-footer-body field-type-text-long field-label-hidden"><div class="field-items"><div class="field-item even"><h3>Where to go for help</h3>
+
+<table>
+	<tbody>
+		<tr>
+			<th scope="row">Emergencies</th>
+			<td><strong>Dial <a href="tel:111">111</a></strong> (for ambulance, fire or police)</td>
+		</tr>
+		<tr>
+			<th scope="row">Healthline</th>
+			<td><strong>Dial <a href="tel:0800611116">0800 611 116</a></strong></td>
+		</tr>
+		<tr>
+			<th scope="row">Poisons</th>
+			<td><strong>Dial <a href="tel:0800764766">0800 POISON</a> </strong>(<a href="tel:0800764766">0800 764 766</a>)</td>
+		</tr>
+		<tr>
+			<th scope="row">Mental health crisis</th>
+			<td><strong><a href="/web/20211029114420/https://www.health.govt.nz/your-health/services-and-support/health-care-services/mental-health-services/crisis-assessment-teams">Emergency contact numbers</a></strong></td>
+		</tr>
+	</tbody>
+</table>
+</div></div></div>        </div>
+      </div>
+      <div class="row">
+        <div class="sub-footer">
+          <div class="column col-sm-12 col-md-3">
+            <a href="https://web.archive.org/web/20211029114420/https://www.govt.nz/">
+              <img src="/web/20211029114420im_/https://www.health.govt.nz/sites/all/themes/mohpub_bootstrap/images/nzgovtlogo_white.png" width="152" height="16" alt="govt.nz - connecting you to New Zealand central &amp; local government services" title="govt.nz - connecting you to New Zealand central &amp; local government services"/>
+            </a>
+          </div>
+          <div class="column col-sm-12 col-md-9">
+          <span class="bottom-menu-moh with-v-divider">&copy; Ministry of Health – Manatū Hauora</span><ul class="bottom-menu-list"><li class="bottom-menu-list-item with-v-divider"><a href="https://web.archive.org/web/20211029114420/https://www.health.govt.nz/sitemap" class="">Site map</a></li><li class="bottom-menu-list-item with-v-divider"><a href="https://web.archive.org/web/20211029114420/https://www.health.govt.nz/about-site/privacy-and-security" class="">Privacy &amp; security</a></li><li class="bottom-menu-list-item with-v-divider"><a href="https://web.archive.org/web/20211029114420/https://www.health.govt.nz/about-site/copyright" class="">Copyright</a></li></ul>          </div>
+        </div>
+      </div>
+    </div>
+    <div class="footer-print">&copy; Ministry of Health – Manatū Hauora</div>
+  </footer>
+  <a class="scrollToTop">Back to top <i class="fas fa-arrow-up"></i></a>
+</div>
+  <script src="https://web.archive.org/web/20211029114420js_/https://www.health.govt.nz/sites/default/files/js/js_akZOsKtodu3PdnQzY3_ElOfujkLxJcowmaWgHTBBLOE.js"></script>
+</body>
+</html>
+<!--
+     FILE ARCHIVED ON 11:44:20 Oct 29, 2021 AND RETRIEVED FROM THE
+     INTERNET ARCHIVE ON 03:19:29 Nov 07, 2021.
+     JAVASCRIPT APPENDED BY WAYBACK MACHINE, COPYRIGHT INTERNET ARCHIVE.
+
+     ALL OTHER CONTENT MAY ALSO BE PROTECTED BY COPYRIGHT (17 U.S.C.
+     SECTION 108(a)(3)).
+-->
+<!--
+playback timings (ms):
+  captures_list: 84.933
+  exclusion.robots: 0.148
+  exclusion.robots.policy: 0.142
+  RedisCDXSource: 0.436
+  esindex: 0.007
+  LoadShardBlock: 42.521 (3)
+  PetaboxLoader3.datanode: 66.307 (4)
+  CDXLines.iter: 29.138 (3)
+  load_resource: 71.537
+  PetaboxLoader3.resolve: 25.652
+-->

--- a/data/rawSite/2021-10-29.html
+++ b/data/rawSite/2021-10-29.html
@@ -1,0 +1,2523 @@
+
+<!DOCTYPE html>
+<html lang="en" dir="ltr" prefix="" class="no-js">
+<head><script src="//archive.org/includes/analytics.js?v=cf34f82" type="text/javascript"></script>
+<script type="text/javascript">window.addEventListener('DOMContentLoaded',function(){var v=archive_analytics.values;v.service='wb';v.server_name='wwwb-app214.us.archive.org';v.server_ms=413;archive_analytics.send_pageview({});});</script>
+<script type="text/javascript" src="/_static/js/bundle-playback.js?v=UfTkgsKx" charset="utf-8"></script>
+<script type="text/javascript" src="/_static/js/wombat.js?v=UHAOicsW" charset="utf-8"></script>
+<script type="text/javascript">
+  __wm.init("https://web.archive.org/web");
+  __wm.wombat("https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data","20211030111302","https://web.archive.org/","web","/_static/",
+	      "1635592382");
+</script>
+<link rel="stylesheet" type="text/css" href="/_static/css/banner-styles.css?v=omkqRugM" />
+<link rel="stylesheet" type="text/css" href="/_static/css/iconochive.css?v=qtvMKcIJ" />
+<!-- End Wayback Rewrite JS Include -->
+
+  <!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta name="format-detection" content="telephone=no"/>
+  <link rel="profile" href="http://www.w3.org/1999/xhtml/vocab"/>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+<link rel="shortcut icon" href="https://web.archive.org/web/20211030111302im_/https://www.health.govt.nz/sites/all/themes/mohpub_bootstrap/favicon.ico" type="image/vnd.microsoft.icon"/>
+<meta name="description" content="Dashboard of data and statistics about the rollout of COVID-19 vaccines in New Zealand"/>
+<meta name="generator" content="Drupal 7 (https://www.drupal.org)"/>
+<link rel="canonical" href="https://web.archive.org/web/20211030111302/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data"/>
+<link rel="shortlink" href="https://web.archive.org/web/20211030111302/https://www.health.govt.nz/node/12052"/>
+<meta property="og:site_name" content="Ministry of Health NZ"/>
+<meta property="og:type" content="article"/>
+<meta property="og:url" content="https://web.archive.org/web/20211030111302/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data"/>
+<meta property="og:title" content="COVID-19: Vaccine data"/>
+<meta property="og:description" content="Dashboard of data and statistics about the rollout of COVID-19 vaccines in New Zealand"/>
+  <title>COVID-19: Vaccine data | Ministry of Health NZ</title>
+  <link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211030111302cs_/https://www.health.govt.nz/sites/default/files/css/css_lQaZfjVpwP_oGNqdtWCSpJT1EMqXdMiU84ekLLxQnc4.css" media="all"/>
+<link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211030111302cs_/https://www.health.govt.nz/sites/default/files/css/css_jqUBpWfMaxMiP7LismdZVlyVv8azUJSE2yaH58nj0cE.css" media="all"/>
+<link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211030111302cs_/https://www.health.govt.nz/sites/default/files/css/css_Rb1wqFBC8VXCJC-BuNY53cvjjlj6UADGvqzo_f-1yN0.css" media="all"/>
+<link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211030111302cs_/https://www.health.govt.nz/sites/default/files/css/css_38_K1lHKg-98m4KKRfv57JBK0gvlKscexGt9MKoi0DE.css" media="all"/>
+<link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211030111302cs_/https://www.health.govt.nz/sites/default/files/css/css_r7NPyvpdYfAyZmk9zkK8OaFKEFj6er5ZJnam2H644DM.css" media="print"/>
+  <link rel="alternate stylesheet" type="text/css" href="/web/20211030111302cs_/https://www.health.govt.nz/sites/all/themes/mohpub_bootstrap/css/high-contrast.css" media="screen" title="High Contrast"/>
+  <script src="https://web.archive.org/web/20211030111302js_/https://www.health.govt.nz/sites/default/files/js/js_zS-CmNFGyegtLYJmqFRpxQvvQrfPIFrOMq_3T3C8sZE.js"></script>
+<script src="https://web.archive.org/web/20211030111302js_/https://www.health.govt.nz/sites/default/files/js/js_fNgZ4Okisfr70Q0yvAYsATgB0o_jD3-srhQQ-VHmlXE.js"></script>
+<script src="https://web.archive.org/web/20211030111302js_/https://www.health.govt.nz/sites/default/files/js/js_YAdPZfg12M1m7ROp3_gVJPS5sArqL0kYQgNRPoicvHE.js"></script>
+<script>(function(i,s,o,g,r,a,m){i["GoogleAnalyticsObject"]=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,"script","https://web.archive.org/web/20211030111302/https://www.google-analytics.com/analytics.js","ga");ga("create", "UA-3573389-24", {"cookieDomain":".www.health.govt.nz","siteSpeedSampleRate":15});ga("send", "pageview");</script>
+<script src="https://web.archive.org/web/20211030111302js_/https://www.health.govt.nz/sites/default/files/js/js_QAXZNPwLISRLHqyNpT4Vvr_iqD9foD6GTbEjlhIIjeo.js"></script>
+<script src="https://web.archive.org/web/20211030111302js_/https://www.health.govt.nz/sites/default/files/js/js_4VW9edmu3V8VjGJxFfXGAwkXeW2cJIa5h-6y7SgwVrk.js"></script>
+<script>    (function(h,o,t,j,a,r){
+        h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
+        h._hjSettings={hjid:930919,hjsv:6};
+        a=o.getElementsByTagName('head')[0];
+        r=o.createElement('script');r.async=1;
+        r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+        a.appendChild(r);
+    })(window,document,'https://web.archive.org/web/20211030111302/https://static.hotjar.com/c/hotjar-','.js?sv=');
+</script>
+<script>jQuery.extend(Drupal.settings, {"basePath":"\/","pathPrefix":"","ajaxPageState":{"theme":"mohpub_bootstrap","theme_token":"zPqDGczuEaC2SZ7lyymBEnBododd_i9k5t1l6IHLRBU","js":{"sites\/all\/modules\/custom\/table_d3chart\/js\/table_d3chart.js":1,"sites\/all\/modules\/custom\/moh_d3\/moh_d3.js":1,"sites\/all\/modules\/contrib\/jquery_update\/replace\/jquery\/1.7\/jquery.min.js":1,"misc\/jquery-extend-3.4.0.js":1,"misc\/jquery-html-prefilter-3.5.0-backport.js":1,"misc\/jquery.once.js":1,"misc\/drupal.js":1,"sites\/all\/modules\/contrib\/ckeditor_accordion\/js\/ckeditor-accordion.js":1,"sites\/all\/modules\/contrib\/extlink\/extlink.js":1,"modules\/field\/modules\/text\/text.js":1,"sites\/all\/modules\/contrib\/field_group\/field_group.js":1,"sites\/all\/modules\/contrib\/google_analytics\/googleanalytics.js":1,"0":1,"sites\/all\/libraries\/c3\/c3.js":1,"sites\/all\/libraries\/d3\/d3.min.js":1,"sites\/all\/modules\/contrib\/d3\/js\/d3.js":1,"sites\/all\/libraries\/d3.helpers\/d3.helpers.js":1,"sites\/all\/libraries\/d3.c3\/d3-c3.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/assets\/ios-fix.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/affix.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/alert.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/button.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/carousel.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/collapse.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/dropdown.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/modal.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/tooltip.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/popover.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/scrollspy.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/tab.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/transition.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/jquery.cookie.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/jquery.moh.announcement.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/svgeezy.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/fitvids.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/bootstrap-tabcollapse.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/jquery.scrollTo.min.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/script.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/jquery.google_analytics.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/bootstrap-accessibility.min.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/style-switcher.js":1,"1":1},"css":{"modules\/system\/system.base.css":1,"sites\/all\/modules\/contrib\/calendar\/css\/calendar_multiday.css":1,"sites\/all\/modules\/contrib\/ckeditor_accordion\/css\/ckeditor-accordion.css":1,"modules\/field\/theme\/field.css":1,"modules\/node\/node.css":1,"sites\/all\/modules\/contrib\/extlink\/extlink.css":1,"sites\/all\/modules\/contrib\/views\/css\/views.css":1,"sites\/all\/modules\/contrib\/ckeditor\/css\/ckeditor.css":1,"sites\/all\/modules\/contrib\/ctools\/css\/ctools.css":1,"sites\/all\/modules\/contrib\/panels\/css\/panels.css":1,"sites\/all\/libraries\/c3\/c3.css":1,"sites\/all\/libraries\/d3.c3\/d3-c3.css":1,"sites\/all\/themes\/mohpub_bootstrap\/fontawesome\/css\/fontawesome.min.css":1,"sites\/all\/themes\/mohpub_bootstrap\/fontawesome\/css\/solid.min.css":1,"sites\/all\/themes\/mohpub_bootstrap\/fontawesome\/css\/brands.min.css":1,"sites\/all\/modules\/features\/site_profile\/css\/fix-rubik-multiselect-height.css":1,"sites\/all\/themes\/mohpub_bootstrap\/css\/style.css":1,"sites\/all\/themes\/mohpub_bootstrap\/css\/responsive-tables.css":1,"sites\/all\/themes\/mohpub_bootstrap\/css\/print.css":1}},"field_group":{"div":"full"},"ckeditor_accordion":{"collapseAll":1},"extlink":{"extTarget":0,"extClass":"ext","extLabel":"(link is external)","extImgClass":0,"extIconPlacement":"append","extSubdomains":0,"extExclude":"","extInclude":"","extCssExclude":"","extCssExplicit":"","extAlert":0,"extAlertText":"This link will take you to an external web site. We are not responsible for their content.","mailtoClass":"mailto","mailtoLabel":"(link sends e-mail)"},"googleanalytics":{"trackOutbound":1,"trackMailto":1,"trackDownload":1,"trackDownloadExtensions":"7z|aac|arc|arj|asf|asx|avi|bin|csv|doc|exe|flv|gif|gz|gzip|hqx|jar|jpe?g|js|mp(2|3|4|e?g)|mov(ie)?|msi|msp|pdf|phps|png|ppt|qtm?|ra(m|r)?|sea|sit|tar|tgz|torrent|txt|wav|wma|wmv|wpd|xls|xml|z|zip|docx|xlsx|pptx|pptm|ppsx|ppsm|epub"},"mohD3":{"C3Types":["line","spline","step","area","area-spline","area-step","bar","scatter","pie","donut","gauge"],"graphRender":"line","graphLegend":true,"graphDefaultColors":"#2b8cbe, #abdda4, #7f7f7f, #92cddc, #dc8b0c","graphDefaultGroupedTooltip":0,"graphDefaultGridX":0,"graphDefaultGridY":0,"graphDefaultLegendPosition":"top-right","graphDefaultTooltip":1,"graphDefaultDataLabel":0,"graphLegendStep":"5","graphInteraction":true,"graphTypes":"","graphXaxisShow":true,"graphXaxisLabel":"","graphYaxisLabel":"","graphXaxisType":"category","graphXaxisCentered":false,"graphXaxisRotation":"","graphXaxisHeight":"","graphYaxisShow":true,"graphYaxisMax":"","graphYaxisMin":"","graphYaxisInverted":false,"graphYaxisCenter":"","graphYaxisPrefix":"","graphYaxisSuffix":"","graphYaxisPosition":"","graphY2axisShow":false,"graphY2axisSource":"","graphY2axisMax":"","graphY2axisMin":"","graphGroups":"","graphRotated":false,"graphIgnoreEmpty":false,"graphLineDot":true,"graphBarRatio":"0.9","graphDot":true,"graphDotR":"2.5","graphFocus":false},"tableD3":{"show":"View table data source","hide":"Hide table data source"},"urlIsAjaxTrusted":{"\/our-work\/diseases-and-conditions\/covid-19-novel-coronavirus\/covid-19-data-and-statistics\/covid-19-vaccine-data":true},"bootstrap":{"anchorsFix":1,"anchorsSmoothScrolling":1,"formHasError":1,"popoverEnabled":1,"popoverOptions":{"animation":1,"html":0,"placement":"right","selector":"","trigger":"click","triggerAutoclose":1,"title":"","content":"","delay":0,"container":"body"},"tooltipEnabled":1,"tooltipOptions":{"animation":1,"html":0,"placement":"auto left","selector":"","trigger":"hover focus","delay":0,"container":"body"}}});</script>
+  <!-- HTML5 element support for IE6-8 -->
+  <!--[if lt IE 9]>
+    <script src="/sites/all/themes/mohpub_bootstrap/js/assets/html5shiv.js"></script>
+    <script src="/sites/all/themes/mohpub_bootstrap/js/assets/respond.min.js"></script>
+  <![endif]-->
+</head>
+<body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-12052 node-type-page node-has-intro"><!-- BEGIN WAYBACK TOOLBAR INSERT -->
+<style type="text/css">
+body {
+  margin-top:0 !important;
+  padding-top:0 !important;
+  /*min-width:800px !important;*/
+}
+</style>
+<script>__wm.rw(0);</script>
+<div id="wm-ipp-base" lang="en" style="display:none;direction:ltr;">
+<div id="wm-ipp" style="position:fixed;left:0;top:0;right:0;">
+<div id="wm-ipp-inside">
+  <div style="position:relative;">
+    <div id="wm-logo" style="float:left;width:110px;padding-top:12px;">
+      <a href="/web/" title="Wayback Machine home page"><img src="/_static/images/toolbar/wayback-toolbar-logo-200.png" srcset="/_static/images/toolbar/wayback-toolbar-logo-100.png, /_static/images/toolbar/wayback-toolbar-logo-150.png 1.5x, /_static/images/toolbar/wayback-toolbar-logo-200.png 2x" alt="Wayback Machine" style="width:100px" border="0" /></a>
+    </div>
+    <div class="r" style="float:right;">
+      <div id="wm-btns" style="text-align:right;height:25px;">
+                  <div id="wm-save-snapshot-success">success</div>
+          <div id="wm-save-snapshot-fail">fail</div>
+          <a id="wm-save-snapshot-open" href="#"
+	     title="Share via My Web Archive" >
+            <span class="iconochive-web"></span>
+          </a>
+          <a href="https://archive.org/account/login.php"
+             title="Sign In"
+             id="wm-sign-in"
+          >
+            <span class="iconochive-person"></span>
+          </a>
+          <span id="wm-save-snapshot-in-progress" class="iconochive-web"></span>
+        	<a href="http://faq.web.archive.org/" title="Get some help using the Wayback Machine" style="top:-6px;"><span class="iconochive-question" style="color:rgb(87,186,244);font-size:160%;"></span></a>
+	<a id="wm-tb-close" href="#close" onclick="__wm.h(event);return false;" style="top:-2px;" title="Close the toolbar"><span class="iconochive-remove-circle" style="color:#888888;font-size:240%;"></span></a>
+      </div>
+      <div id="wm-share">
+          <a href="/web/20211030111302/http://web.archive.org/screenshot/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data"
+             id="wm-screenshot"
+             title="screenshot">
+            <span class="wm-icon-screen-shot"></span>
+          </a>
+          <a href="#"
+            id="wm-video"
+            title="video">
+            <span class="iconochive-movies"></span>
+          </a>
+	<a id="wm-share-facebook" href="#" data-url="https://web.archive.org/web/20211030111302/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="Share on Facebook" style="margin-right:5px;" target="_blank"><span class="iconochive-facebook" style="color:#3b5998;font-size:160%;"></span></a>
+	<a id="wm-share-twitter" href="#" data-url="https://web.archive.org/web/20211030111302/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="Share on Twitter" style="margin-right:5px;" target="_blank"><span class="iconochive-twitter" style="color:#1dcaff;font-size:160%;"></span></a>
+      </div>
+    </div>
+    <table class="c" style="">
+      <tbody>
+	<tr>
+	  <td class="u" colspan="2">
+	    <form target="_top" method="get" action="/web/submit" name="wmtb" id="wmtb"><input type="text" name="url" id="wmtbURL" value="https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" onfocus="this.focus();this.select();" /><input type="hidden" name="type" value="replay" /><input type="hidden" name="date" value="20211030111302" /><input type="submit" value="Go" /></form>
+	  </td>
+	  <td class="n" rowspan="2" style="width:110px;">
+	    <table>
+	      <tbody>
+		<!-- NEXT/PREV MONTH NAV AND MONTH INDICATOR -->
+		<tr class="m">
+		  <td class="b" nowrap="nowrap"><a href="https://web.archive.org/web/20210929203937/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="29 Sep 2021"><strong>Sep</strong></a></td>
+		  <td class="c" id="displayMonthEl" title="You are here: 11:13:02 Oct 30, 2021">OCT</td>
+		  <td class="f" nowrap="nowrap">Nov</td>
+		</tr>
+		<!-- NEXT/PREV CAPTURE NAV AND DAY OF MONTH INDICATOR -->
+		<tr class="d">
+		  <td class="b" nowrap="nowrap"><a href="https://web.archive.org/web/20211028192036/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="19:20:36 Oct 28, 2021"><img src="/_static/images/toolbar/wm_tb_prv_on.png" alt="Previous capture" width="14" height="16" border="0" /></a></td>
+		  <td class="c" id="displayDayEl" style="width:34px;font-size:24px;white-space:nowrap;" title="You are here: 11:13:02 Oct 30, 2021">30</td>
+		  <td class="f" nowrap="nowrap"><a href="https://web.archive.org/web/20211031120029/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="12:00:29 Oct 31, 2021"><img src="/_static/images/toolbar/wm_tb_nxt_on.png" alt="Next capture" width="14" height="16" border="0" /></a></td>
+		</tr>
+		<!-- NEXT/PREV YEAR NAV AND YEAR INDICATOR -->
+		<tr class="y">
+		  <td class="b" nowrap="nowrap">2020</td>
+		  <td class="c" id="displayYearEl" title="You are here: 11:13:02 Oct 30, 2021">2021</td>
+		  <td class="f" nowrap="nowrap">2022</td>
+		</tr>
+	      </tbody>
+	    </table>
+	  </td>
+	</tr>
+	<tr>
+	  <td class="s">
+	    	    <div id="wm-nav-captures">
+	      	      <a class="t" href="/web/20211030111302*/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="See a list of every capture for this URL">682 captures</a>
+	      <div class="r" title="Timespan for captures of this URL">07 Apr 2021 - 06 Nov 2021</div>
+	      </div>
+	  </td>
+	  <td class="k">
+	    <a href="" id="wm-graph-anchor">
+	      <div id="wm-ipp-sparkline" title="Explore captures for this URL" style="position: relative">
+		<canvas id="wm-sparkline-canvas" width="650" height="27" border="0"></canvas>
+	      </div>
+	    </a>
+	  </td>
+	</tr>
+      </tbody>
+    </table>
+    <div style="position:absolute;bottom:0;right:2px;text-align:right;">
+      <a id="wm-expand" class="wm-btn wm-closed" href="#expand" onclick="__wm.ex(event);return false;"><span id="wm-expand-icon" class="iconochive-down-solid"></span> <span style="font-size:80%">About this capture</span></a>
+    </div>
+  </div>
+    <div id="wm-capinfo" style="border-top:1px solid #777;display:none; overflow: hidden">
+                    <div id="wm-capinfo-collected-by">
+    <div style="background-color:#666;color:#fff;font-weight:bold;text-align:center">COLLECTED BY</div>
+    <div style="padding:3px;position:relative" id="wm-collected-by-content">
+            <div style="display:inline-block;vertical-align:top;width:50%;">
+			<span class="c-logo" style="background-image:url(https://archive.org/services/img/focused_crawls);"></span>
+		Organization: <a style="color:#33f;" href="https://archive.org/details/focused_crawls" target="_new"><span class="wm-title">Internet Archive</span></a>
+		<div style="max-height:75px;overflow:hidden;position:relative;">
+	  <div style="position:absolute;top:0;left:0;width:100%;height:75px;background:linear-gradient(to bottom,rgba(255,255,255,0) 0%,rgba(255,255,255,0) 90%,rgba(255,255,255,255) 100%);"></div>
+	  Focused crawls are collections of frequently-updated webcrawl data from narrow (as opposed to broad or wide) web crawls, often focused on a single domain or subdomain.<br />
+	</div>
+	      </div>
+      <div style="display:inline-block;vertical-align:top;width:49%;">
+			<span class="c-logo" style="background-image:url(https://archive.org/services/img/abc.net.au-news)"></span>
+		<div>Collection: <a style="color:#33f;" href="https://archive.org/details/abc.net.au-news" target="_new"><span class="wm-title">abc.net.au-news</span></a></div>
+	      </div>
+    </div>
+    </div>
+    <div id="wm-capinfo-timestamps">
+    <div style="background-color:#666;color:#fff;font-weight:bold;text-align:center" title="Timestamps for the elements of this page">TIMESTAMPS</div>
+    <div>
+      <div id="wm-capresources" style="margin:0 5px 5px 5px;max-height:250px;overflow-y:scroll !important"></div>
+      <div id="wm-capresources-loading" style="text-align:left;margin:0 20px 5px 5px;display:none"><img src="/_static/images/loading.gif" alt="loading" /></div>
+    </div>
+    </div>
+  </div></div></div></div><div id="wm-ipp-print">The Wayback Machine - https://web.archive.org/web/20211030111302/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data</div>
+<div id="donato" style="position:relative;width:100%;">
+  <div id="donato-base">
+    <iframe id="donato-if" src="https://archive.org/includes/donate.php?as_page=1&amp;platform=wb&amp;referer=https%3A//web.archive.org/web/20211030111302/https%3A//www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data"
+	    scrolling="no" frameborder="0" style="width:100%; height:100%">
+    </iframe>
+  </div>
+</div><script type="text/javascript">
+__wm.bt(650,27,25,2,"web","https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data","20211030111302",1996,"/_static/",["/_static/css/banner-styles.css?v=omkqRugM","/_static/css/iconochive.css?v=qtvMKcIJ"], "False");
+  __wm.rw(1);
+</script>
+<!-- END WAYBACK TOOLBAR INSERT -->
+<!--googleoff: all-->
+  <div id="skip-link">
+    <a href="#skip-content" id="skipper" class="element-invisible element-focusable">Skip to main content</a>
+  </div>
+    <div id="page">
+  <header id="navbar" role="banner" class="navbar container navbar-default">
+          <ul class="menu nav navbar-nav secondary"><li class="first leaf jobs depth-1"><a href="https://web.archive.org/web/20211030111302/https://careers.health.govt.nz/" title="">Jobs</a></li>
+<li class="leaf news depth-1"><a href="/web/20211030111302/https://www.health.govt.nz/news-media" data-is-top-level="0" title="">News</a></li>
+<li class="leaf contact-us depth-1"><a href="/web/20211030111302/https://www.health.govt.nz/about-ministry/contact-us" title="">Contact us</a></li>
+<li class="leaf facebook depth-1"><a href="https://web.archive.org/web/20211030111302/https://www.facebook.com/minhealthnz/">Facebook</a></li>
+<li class="leaf twitter depth-1"><a href="https://web.archive.org/web/20211030111302/https://twitter.com/minhealthnz" data-is-top-level="0" title="">Twitter</a></li>
+<li class="last leaf youtube depth-1"><a href="https://web.archive.org/web/20211030111302/https://www.youtube.com/user/minhealthnz" data-is-top-level="0" title="">Youtube</a></li>
+</ul>        <div class="container">
+      <div class="navbar-header">
+                <a class="logo navbar-btn pull-left" href="/web/20211030111302/https://www.health.govt.nz/" title="Home">
+          <img src="/web/20211030111302im_/https://www.health.govt.nz/sites/all/themes/mohpub_bootstrap/images/mohlogo.svg" alt="Ministry of Health"/>
+        </a>
+                  <div class="region region-header-top">
+    <section id="block-apachesolr-panels-search-form" class="block block-apachesolr-panels clearfix">
+
+
+  <form action="/web/20211030111302/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" method="post" id="apachesolr-panels-search-block" accept-charset="UTF-8"><div><div class="form-item form-item-apachesolr-panels-search-form form-type-textfield form-group"> <label class="control-label" for="edit-apachesolr-panels-search-form">Search</label>
+<input title="Enter the terms you wish to search for." class="form-control form-text" type="text" id="edit-apachesolr-panels-search-form" name="apachesolr_panels_search_form" value="" size="15" maxlength="128"/></div><input type="hidden" name="form_build_id" value="form-lyfz6VNYSUWF7DHocsFusqe8-1cA6PHx2szx4LOvHyU"/>
+<input type="hidden" name="form_id" value="apachesolr_panels_search_block"/>
+<div class="form-actions form-wrapper form-group" id="edit-actions"><button type="submit" id="edit-submit" name="op" value="Search" class="btn btn-primary form-submit">Search</button>
+</div></div></form>
+</section>
+  </div>
+        <!-- .btn-navbar is used as the toggle for collapsed navbar content -->
+        <button aria-expanded="false" aria-controls="megamenu" type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+                    <span class="menu-text">Menu</span><span class="sr-only">Toggle navigation</span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+
+        </button>
+      </div>
+
+              <div class="navbar-collapse collapse">
+          <nav id="megamenu" role="navigation">
+                          <h2 class="element-invisible">Main menu</h2><ul id="main-menu" class="menu nav navbar-nav yamm navbar"><li class="first dropdown"><a href="/web/20211030111302/https://www.health.govt.nz/your-health" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="megamenu-dropdown-780">Your health <b class="caret"></b></a>
+    <div id="megamenu-dropdown-780" class="dropdown-menu">
+    <div class="yamm-content">
+      <div class="row">
+                            <div class="col">
+            <h3><a href="/web/20211030111302/https://www.health.govt.nz/your-health/conditions-and-treatments?mega=Your%20health&amp;title=Conditions%20%26%20treatments" class="menu-header">Conditions &amp; treatments</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211030111302/https://www.health.govt.nz/your-health/conditions-and-treatments/mental-health/depression?mega=Your%20health&amp;title=Depression">Depression</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/diabetes?mega=Your%20health&amp;title=Diabetes">Diabetes</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/influenza?mega=Your%20health&amp;title=Influenza">Influenza</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/measles?mega=Your%20health&amp;title=Measles">Measles</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/meningococcal-disease-including-meningitis?mega=Your%20health&amp;title=Meningococcal%20disease">Meningococcal disease</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/mumps?mega=Your%20health&amp;title=Mumps">Mumps</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/respiratory-syncytial-virus-rsv?mega=Your%20health&amp;title=RSV">RSV</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/sore-throat?mega=Your%20health&amp;title=Sore%20throat">Sore throat</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/your-health/conditions-and-treatments?mega=Your%20health&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211030111302/https://www.health.govt.nz/your-health/healthy-living?mega=Your%20health&amp;title=Healthy%20living" class="menu-header">Healthy living</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211030111302/https://www.health.govt.nz/your-health/healthy-living/drinking-water?mega=Your%20health&amp;title=Drinking-water">Drinking-water</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/your-health/healthy-living/food-activity-and-sleep/green-prescriptions?mega=Your%20health&amp;title=Green%20Prescriptions">Green Prescriptions</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/your-health/healthy-living/food-activity-and-sleep/healthy-eating?mega=Your%20health&amp;title=Healthy%20eating">Healthy eating</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/your-health/healthy-living/immunisation?mega=Your%20health&amp;title=Immunisation">Immunisation</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/your-health/healthy-living/food-activity-and-sleep/physical-activity?mega=Your%20health&amp;title=Physical%20activity">Physical activity</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/your-health/healthy-living/addictions/quitting-smoking?mega=Your%20health&amp;title=Smoking">Smoking</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/your-health/healthy-living/teeth-and-gums?mega=Your%20health&amp;title=Teeth%20and%20gums">Teeth and gums</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/your-health/healthy-living?mega=Your%20health&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211030111302/https://www.health.govt.nz/your-health/pregnancy-and-kids?mega=Your%20health&amp;title=Pregnancy%20and%20kids" class="menu-header">Pregnancy and kids</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211030111302/https://www.health.govt.nz/your-health/pregnancy-and-kids/birth-and-afterwards?mega=Your%20health&amp;title=Birth%20and%20afterwards">Birth and afterwards</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/your-health/pregnancy-and-kids/first-year/helpful-advice-during-first-year/breastfeeding-perfect-you-and-your-baby?mega=Your%20health&amp;title=Breastfeeding">Breastfeeding</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/your-health/pregnancy-and-kids/pregnancy?mega=Your%20health&amp;title=Pregnancy">Pregnancy</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/your-health/pregnancy-and-kids/services-and-support-during-pregnancy?mega=Your%20health&amp;title=Services%20and%20support%20during%20pregnancy">Services and support during pregnancy</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/your-health/pregnancy-and-kids/services-and-support-you-and-your-child?mega=Your%20health&amp;title=Services%20and%20support%20for%20you%20and%20your%20child">Services and support for you and your child</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/your-health/pregnancy-and-kids/first-year?mega=Your%20health&amp;title=The%20first%20year">The first year</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/your-health/pregnancy-and-kids/under-fives?mega=Your%20health&amp;title=Under%20fives">Under fives</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/your-health/pregnancy-and-kids?mega=Your%20health&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211030111302/https://www.health.govt.nz/your-health/services-and-support?mega=Your%20health&amp;title=Services%20and%20support" class="menu-header">Services &amp; support</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211030111302/https://www.health.govt.nz/your-health/services-and-support/health-care-services/help-alcohol-and-drug-problems?mega=Your%20health&amp;title=Alcohol%20and%20drugs">Alcohol and drugs</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/your-health/services-and-support/disability-services?mega=Your%20health&amp;title=Disability%20services">Disability services</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/your-health/services-and-support/health-care-services/earthquake-support-line?mega=Your%20health&amp;title=Earthquake%20Support%20Line">Earthquake Support Line</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/your-health/services-and-support/health-care-services/healthline?mega=Your%20health&amp;title=Healthline">Healthline</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/your-health/services-and-support/health-care-services/mental-health-services?mega=Your%20health&amp;title=Mental%20health%20services">Mental health services</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/your-health/services-and-support/health-care-services/maori-health-provider-directory?mega=Your%20health&amp;title=M%C4%81ori%20health%20providers">Māori health providers</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/your-health/services-and-support/health-care-services/services-older-people/rest-home-certification-and-audits?mega=Your%20health&amp;title=Rest%20home%20certification">Rest home certification</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/your-health/services-and-support/health-care-services/hospitals-and-specialist-services/travel-assistance?mega=Your%20health&amp;title=Travel%20assistance">Travel assistance</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/your-health/services-and-support?mega=Your%20health&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                        </div>
+    </div>
+    <div class="feature-links">
+      <h3 class="sr-only">Other related resources</h3>
+      <a href="/web/20211030111302/https://www.health.govt.nz/your-health/full-a-z?mega=Your%20health&amp;title=A-Z">View the full A-Z</a>    </div>
+  </div>
+</li>
+<li class="dropdown"><a href="/web/20211030111302/https://www.health.govt.nz/new-zealand-health-system" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="megamenu-dropdown-6076">NZ health system <b class="caret"></b></a>
+    <div id="megamenu-dropdown-6076" class="dropdown-menu">
+    <div class="yamm-content">
+      <div class="row">
+                            <div class="col">
+            <h3><a href="/web/20211030111302/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people?mega=NZ%20health%20system&amp;title=Key%20organisations" class="menu-header">Key organisations</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211030111302/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/crown-entities-and-statutory-boards?mega=NZ%20health%20system&amp;title=Crown%20entities%20%26%20agencies">Crown entities &amp; agencies</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/district-health-boards?mega=NZ%20health%20system&amp;title=District%20health%20boards">District health boards</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/non-governmental-organisations?mega=NZ%20health%20system&amp;title=Non-governmental%20organisations">Non-governmental organisations</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/primary-health-organisations?mega=NZ%20health%20system&amp;title=Primary%20health%20organisations">Primary health organisations</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/public-health-units?mega=NZ%20health%20system&amp;title=Public%20health%20units">Public health units</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people?mega=NZ%20health%20system&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211030111302/https://www.health.govt.nz/new-zealand-health-system/health-system-indicators-framework?mega=NZ%20health%20system&amp;title=Health%20System%20Indicators%20framework" class="menu-header">Health System Indicators framework</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211030111302/https://www.health.govt.nz/new-zealand-health-system/health-system-indicators-framework?mega=NZ%20health%20system&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211030111302/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services?mega=NZ%20health%20system&amp;title=Eligibility%20for%20public%20health%20services" class="menu-header">Eligibility for public health services</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211030111302/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services/guide-eligibility-publicly-funded-health-services?mega=NZ%20health%20system&amp;title=Guide%20to%20eligibility">Guide to eligibility</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services/eligibility-questions-and-answers-consumers?mega=NZ%20health%20system&amp;title=Q%26A%20for%20consumers">Q&amp;A for consumers</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services/eligibility-questions-and-answers-service-providers?mega=NZ%20health%20system&amp;title=Q%26A%20for%20service%20providers">Q&amp;A for service providers</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services/reciprocal-health-agreements?mega=NZ%20health%20system&amp;title=Reciprocal%20health%20agreements">Reciprocal health agreements</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services?mega=NZ%20health%20system&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211030111302/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements?mega=NZ%20health%20system&amp;title=Claims%2C%20provider%20payments%20and%20entitlements" class="menu-header">Claims &amp; provider payments</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211030111302/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/carer-support-claims?mega=NZ%20health%20system&amp;title=Carer%20Support">Carer Support</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/high-use-health-card-payments?mega=NZ%20health%20system&amp;title=High%20Use%20Health%20Card%20payments">High Use Health Card payments</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/between-travel-settlement?mega=NZ%20health%20system&amp;title=In-Between%20Travel%20Settlement">In-Between Travel Settlement</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/maternity-claim-forms?mega=NZ%20health%20system&amp;title=Maternity%20claim%20forms">Maternity claim forms</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/national-travel-assistance?mega=NZ%20health%20system&amp;title=National%20travel%20assistance%20claims">National travel assistance claims</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements?mega=NZ%20health%20system&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                        </div>
+    </div>
+    <div class="feature-links">
+      <h3 class="sr-only">Other related resources</h3>
+      <a href="/web/20211030111302/https://www.health.govt.nz/new-zealand-health-system/overview-health-system?mega=NZ%20health%20system&amp;title=Overview">Overview of the health system</a>  <a href="/web/20211030111302/https://www.health.govt.nz/new-zealand-health-system/my-dhb?mega=NZ%20health%20system&amp;title=Mydhb">My DHB</a> <a href="/web/20211030111302/https://www.health.govt.nz/new-zealand-health-system/system-level-measures-framework?mega=NZ%20health%20system&amp;title=SLM">System level measures</a>  <a href="/web/20211030111302/https://www.health.govt.nz/publication/new-zealand-health-strategy-2016?mega=NZ%20health%20system&amp;title=HealthStrategy">NZ Health Strategy</a>    </div>
+  </div>
+</li>
+<li class="dropdown"><a href="/web/20211030111302/https://www.health.govt.nz/our-work" class="dropdown-toggle active-trail" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="megamenu-dropdown-776">Our work <b class="caret"></b></a>
+  <div id="megamenu-dropdown-776" class="dropdown-menu">
+    <div class="yamm-content">
+      <div class="row">
+                            <ul class="col list-unstyled no-menu-header">
+                                                                                <li>
+                <a href="/web/20211030111302/https://www.health.govt.nz/our-work/hospitals-and-specialist-care/acute-care?mega=Our%20work&amp;title=Acute%20care" class="menu-header">Acute care</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211030111302/https://www.health.govt.nz/our-work/diseases-and-conditions/antimicrobial-resistance?mega=Our%20work&amp;title=Antimicrobial%20resistance" class="menu-header">Antimicrobial resistance</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211030111302/https://www.health.govt.nz/our-work/populations/asian-and-migrant-health?mega=Our%20work&amp;title=Asian%20and%20migrant%20health" class="menu-header">Asian and migrant health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211030111302/https://www.health.govt.nz/our-work/border-health?mega=Our%20work&amp;title=Border%20health" class="menu-header">Border health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211030111302/https://www.health.govt.nz/our-work/life-stages/breastfeeding?mega=Our%20work&amp;title=Breastfeeding" class="menu-header">Breastfeeding</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211030111302/https://www.health.govt.nz/our-work/diseases-and-conditions/cancer?mega=Our%20work&amp;title=Cancer" class="menu-header">Cancer</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211030111302/https://www.health.govt.nz/our-work/regulation-health-and-disability-system/certification-health-care-services?mega=Our%20work&amp;title=Certification%20of%20health%20care%20services" class="menu-header">Certification of health care services</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211030111302/https://www.health.govt.nz/our-work/life-stages/child-health?mega=Our%20work&amp;title=Child%20health" class="menu-header">Child health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211030111302/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus?mega=Our%20work&amp;title=COVID-19" class="menu-header">COVID-19 (novel coronavirus)</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211030111302/https://www.health.govt.nz/our-work/diseases-and-conditions/diabetes?mega=Our%20work&amp;title=Diabetes" class="menu-header">Diabetes</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211030111302/https://www.health.govt.nz/our-work/digital-health?mega=Our%20work&amp;title=Digital%20health" class="menu-header">Digital health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211030111302/https://www.health.govt.nz/our-work/disability-services?mega=Our%20work&amp;title=Disability%20services" class="menu-header">Disability services</a>                              </li>
+                                                                </ul>
+                            <ul class="col list-unstyled no-menu-header">
+                                                                                <li>
+                <a href="/web/20211030111302/https://www.health.govt.nz/our-work/diseases-and-conditions?mega=Our%20work&amp;title=Diseases%20and%20conditions" class="menu-header">Diseases and conditions</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211030111302/https://www.health.govt.nz/our-work/hospitals-and-specialist-care/emergency-departments?mega=Our%20work&amp;title=Emergency%20departments" class="menu-header">Emergency departments</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211030111302/https://www.health.govt.nz/our-work/emergency-management?mega=Our%20work&amp;title=Emergency%20management" class="menu-header">Emergency management</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211030111302/https://www.health.govt.nz/our-work/environmental-health?mega=Our%20work&amp;title=Environmental%20health" class="menu-header">Environmental health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211030111302/https://www.health.govt.nz/our-work/preventative-health-wellness/family-violence?mega=Our%20work&amp;title=Family%20violence" class="menu-header">Family violence</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211030111302/https://www.health.govt.nz/our-work/preventative-health-wellness/fluoride-and-oral-health?mega=Our%20work&amp;title=Fluoride%20and%20oral%20health" class="menu-header">Fluoride and oral health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211030111302/https://www.health.govt.nz/our-work/health-identity?mega=Our%20work&amp;title=Health%20identity" class="menu-header">Health identity</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211030111302/https://www.health.govt.nz/our-work/digital-health/digital-health-sector-architecture-standards-and-governance/health-information-standards-0?mega=Our%20work&amp;title=Health%20information%20standards" class="menu-header">Health information standards</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211030111302/https://www.health.govt.nz/our-work/health-infrastructure-unit-hiu?mega=Our%20work&amp;title=Health%20Infrastructure%20Unit" class="menu-header">Health Infrastructure Unit</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211030111302/https://www.health.govt.nz/our-work/life-stages/health-older-people?mega=Our%20work&amp;title=Health%20of%20older%20people" class="menu-header">Health of older people</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211030111302/https://www.health.govt.nz/our-work/health-workforce?mega=Our%20work&amp;title=Health%20workforce" class="menu-header">Health workforce</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211030111302/https://www.health.govt.nz/our-work/hospitals-and-specialist-care?mega=Our%20work&amp;title=Hospitals%20and%20specialist%20care" class="menu-header">Hospitals and specialist care</a>                              </li>
+                                                                </ul>
+                            <ul class="col list-unstyled no-menu-header">
+                                                                                <li>
+                <a href="/web/20211030111302/https://www.health.govt.nz/our-work/preventative-health-wellness/immunisation?mega=Our%20work&amp;title=Immunisation" class="menu-header">Immunisation</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211030111302/https://www.health.govt.nz/our-work/ionising-radiation-safety?mega=Our%20work&amp;title=Ionising%20radiation%20safety" class="menu-header">Ionising radiation safety</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211030111302/https://www.health.govt.nz/our-work/populations/maori-health?mega=Our%20work&amp;title=M%C4%81ori%20health" class="menu-header">Māori health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211030111302/https://www.health.govt.nz/our-work/life-stages/maternity-services?mega=Our%20work&amp;title=Maternity" class="menu-header">Maternity</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211030111302/https://www.health.govt.nz/our-work/regulation-health-and-disability-system/medicinal-cannabis-agency?mega=Our%20work&amp;title=Medicinal%20Cannabis%20Agency" class="menu-header">Medicinal cannabis</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211030111302/https://www.health.govt.nz/our-work/regulation-health-and-disability-system/medicines-control?mega=Our%20work&amp;title=Medicines%20control" class="menu-header">Medicines control</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211030111302/https://www.health.govt.nz/our-work/mental-health-and-addiction?mega=Our%20work&amp;title=Mental%20health%20and%20addiction" class="menu-header">Mental health and addiction</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211030111302/https://www.health.govt.nz/our-work/nursing?mega=Our%20work&amp;title=Nursing" class="menu-header">Nursing</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211030111302/https://www.health.govt.nz/our-work/preventative-health-wellness/nutrition?mega=Our%20work&amp;title=Nutrition" class="menu-header">Nutrition</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211030111302/https://www.health.govt.nz/our-work/preventative-health-wellness/oral-health?mega=Our%20work&amp;title=Oral%20health" class="menu-header">Oral health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211030111302/https://www.health.govt.nz/our-work/hospitals-and-specialist-care/organ-donation-and-transplantation?mega=Our%20work&amp;title=Organ%20donation%20and%20transplantation" class="menu-header">Organ donation and transplantation</a>                              </li>
+                                                                </ul>
+                            <ul class="col list-unstyled no-menu-header">
+                                                                                <li>
+                <a href="/web/20211030111302/https://www.health.govt.nz/our-work/populations/pacific-health?mega=Our%20work&amp;title=Pacific%20health" class="menu-header">Pacific health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211030111302/https://www.health.govt.nz/new-zealand-health-system/pay-equity-settlements?mega=Our%20work&amp;title=Pay%20equity%20settlements" class="menu-header">Pay equity</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211030111302/https://www.health.govt.nz/our-work/preventative-health-wellness/physical-activity?mega=Our%20work&amp;title=Physical%20activity" class="menu-header">Physical activity</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211030111302/https://www.health.govt.nz/our-work/hospitals-and-specialist-care/planned-care-services?mega=Our%20work&amp;title=Planned%20Care%20services" class="menu-header">Planned Care services</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211030111302/https://www.health.govt.nz/our-work/preventative-health-wellness?mega=Our%20work&amp;title=Preventative%20health/wellness" class="menu-header">Preventative health/wellness</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211030111302/https://www.health.govt.nz/our-work/primary-health-care?mega=Our%20work&amp;title=Primary%20health%20care" class="menu-header">Primary health care</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211030111302/https://www.health.govt.nz/our-work/public-health-workforce-development?mega=Our%20work&amp;title=Public%20health%20workforce%20development" class="menu-header">Public health workforce</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211030111302/https://www.health.govt.nz/our-work/regulation-health-and-disability-system?mega=Our%20work&amp;title=Regulation" class="menu-header">Regulation</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211030111302/https://www.health.govt.nz/our-work/preventative-health-wellness/tobacco-control?mega=Our%20work&amp;title=Tobacco%20control" class="menu-header">Tobacco control</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211030111302/https://www.health.govt.nz/our-work/regulation-health-and-disability-system/regulation-vaping-and-smokeless-tobacco-products?mega=Our%20work&amp;title=Vaping%20and%20smokeless%20tobacco%20products" class="menu-header">Vaping &amp; smokeless tobacco</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211030111302/https://www.health.govt.nz/our-work/who-code-nz?mega=Our%20work&amp;title=WHO%20Code%20in%20NZ" class="menu-header">WHO Code in NZ</a>                              </li>
+                      </ul>
+              </div>
+    </div>
+    <div class="feature-links">
+      <a href="/web/20211030111302/https://www.health.govt.nz/our-work?mega=Our%20work&amp;title=A-Z">View the full A-Z</a>    </div>
+  </div>
+</li>
+<li class="dropdown"><a href="/web/20211030111302/https://www.health.govt.nz/nz-health-statistics" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="megamenu-dropdown-778">Health statistics <b class="caret"></b></a>
+    <div id="megamenu-dropdown-778" class="dropdown-menu">
+    <div class="yamm-content">
+      <div class="row">
+                            <div class="col">
+            <h3><a href="/web/20211030111302/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets?mega=Health%20statistics&amp;title=Health%20statistics%20and%20data%20sets" class="menu-header">Statistics by topic</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211030111302/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/cancer-data-and-stats?mega=Health%20statistics&amp;title=Cancer">Cancer</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/diabetes-data-and-stats?mega=Health%20statistics&amp;title=Diabetes">Diabetes</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/mental-health-data-and-stats?mega=Health%20statistics&amp;title=Mental%20health">Mental health</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/maori-health-data-and-stats?mega=Health%20statistics&amp;title=M%C4%81ori%20health">Māori health</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/obesity-statistics?mega=Health%20statistics&amp;title=Obesity">Obesity</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/suicide-data-and-stats?mega=Health%20statistics&amp;title=Suicide">Suicide</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/tobacco-data-and-stats?mega=Health%20statistics&amp;title=Tobacco">Tobacco</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets?mega=Health%20statistics&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211030111302/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys?mega=Health%20statistics&amp;title=National%20collections%20and%20surveys" class="menu-header">About our surveys &amp; data collections</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211030111302/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/surveys/past-surveys/alcohol-and-drug-use-survey?mega=Health%20statistics&amp;title=Alcohol%20%26%20Drug%20Use%20Survey">Alcohol &amp; Drug Use Survey</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/national-collections-annual-maintenance-project?mega=Health%20statistics&amp;title=NCAMP">NCAMP</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/collections/new-zealand-cancer-registry-nzcr?mega=Health%20statistics&amp;title=NZ%20Cancer%20Registry">NZ Cancer Registry</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/surveys/new-zealand-health-survey?mega=Health%20statistics&amp;title=NZ%20Health%20Survey">NZ Health Survey</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/surveys/past-surveys/nutrition-survey?mega=Health%20statistics&amp;title=Nutrition%20Survey">Nutrition Survey</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/collections/primhd-mental-health-data?mega=Health%20statistics&amp;title=PRIMHD">PRIMHD</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys?mega=Health%20statistics&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211030111302/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology?mega=Health%20statistics&amp;title=Classification%20and%20Terminology" class="menu-header">Classification &amp; terminology</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211030111302/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology/using-icd-10-am-achi-acs/coding-queries/coding-query-database?mega=Health%20statistics&amp;title=Coding%20query%20database">Coding query database</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology/using-icd-10-am-achi-acs/courses-clinical-coding?mega=Health%20statistics&amp;title=Courses%20on%20clinical%20coding">Courses on clinical coding</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology/new-zealand-snomed-ct-national-release-centre?mega=Health%20statistics&amp;title=SNOMED%20CT">SNOMED CT</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology/using-icd-10-am-achi-acs?mega=Health%20statistics&amp;title=Using%20ICD-10-AM/ACHI/ACS">Using ICD-10-AM/ACHI/ACS</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology?mega=Health%20statistics&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211030111302/https://www.health.govt.nz/nz-health-statistics/data-references?mega=Health%20statistics&amp;title=Data%20references" class="menu-header">Data references</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211030111302/https://www.health.govt.nz/nz-health-statistics/data-references/code-tables?mega=Health%20statistics&amp;title=Code%20tables">Code tables</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/nz-health-statistics/data-references/data-dictionaries?mega=Health%20statistics&amp;title=Data%20dictionaries">Data dictionaries</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/nz-health-statistics/data-references/diagnosis-related-groups?mega=Health%20statistics&amp;title=Diagnosis-related%20groups">Diagnosis-related groups</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/nz-health-statistics/data-references/code-tables/common-code-tables/domicile-code-table?mega=Health%20statistics&amp;title=Domicile%20code%20table">Domicile code table</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/nz-health-statistics/data-references/mapping-tools?mega=Health%20statistics&amp;title=ICD%20mapping%20tools">ICD mapping tools</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/nz-health-statistics/data-references/weighted-inlier-equivalent-separations?mega=Health%20statistics&amp;title=Weighted%20Inlier%20Equivalent%20Separations">Weighted Inlier Equivalent Separations</a></li>
+                                  <li><a href="/web/20211030111302/https://www.health.govt.nz/nz-health-statistics/data-references?mega=Health%20statistics&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                        </div>
+    </div>
+    <div class="feature-links">
+      <h3 class="sr-only">Other related resources</h3>
+      <a href="/web/20211030111302/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/tier-1-health-statistics-release-calendar?mega=Health%20statistics&amp;title=Tier%201%20calendar">Release calendar for our Tier 1 statistics</a> <a href="/web/20211030111302/https://www.health.govt.nz/nz-health-statistics/about-data-collection?mega=Health%20statistics&amp;title=Enquiries">Data and survey enquiries</a>    </div>
+  </div>
+</li>
+<li class=""><a href="/web/20211030111302/https://www.health.govt.nz/publications" aria-haspopup="false">Publications</a></li>
+<li class=""><a href="/web/20211030111302/https://www.health.govt.nz/about-ministry" aria-haspopup="false">About us</a></li>
+<li class="visible-xs"><a href="/web/20211030111302/https://www.health.govt.nz/contactus" aria-haspopup="false">Contact us</a></li>
+</ul>
+                                  </nav>
+        </div>
+          </div>
+  </header>
+
+  <div class="main-container container">
+    <!-- announcement -->
+        <!-- /announcement -->
+
+    <header role="banner" id="page-header">
+
+          </header> <!-- /#page-header -->
+
+    <div class="row">
+
+      <section class="col-sm-12">
+                        <a id="main-content"></a>
+                                                                            <div class="breadcrumbs">
+            <ul><li><a href="/web/20211030111302/https://www.health.govt.nz/">Home</a></li><li><a href="/web/20211030111302/https://www.health.govt.nz/our-work">Our work</a></li><li><a href="/web/20211030111302/https://www.health.govt.nz/our-work/diseases-and-conditions">Diseases and conditions</a></li><li><a href="/web/20211030111302/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished" data-is-top-level="1" title="">COVID-19</a></li><li><a href="/web/20211030111302/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics" class="menu-node-unpublished menu-node-unpublished">Data and statistics</a></li><li><span class="current-breadcrumb">Vaccine data</span></li></ul>          </div>
+
+
+
+          <div class="region region-content">
+    <section id="block-system-main" class="block block-system clearfix">
+
+
+  <div class="bootstrap-threecol-stacked">
+
+      <div class="row"> <!-- @TODO: Add extra classes -->
+      <div class="panel-panel left col-xs-12 col-md-3 col-lg-3"><div class="panel-pane pane-block pane-menu-block-1 odd pane-top-link">
+
+        <span class="top-link"><a href="/web/20211030111302/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished active-trail" data-is-top-level="1">COVID-19</a></span>
+
+
+  <div class="pane-content">
+        <div class="menu-block-wrapper menu-block-1 menu-name-main-menu parent-mlid-1445 menu-level-2">
+  <ul class="menu nav"><li class="first collapsed menu-mlid-10163 health-advice depth-4"><a href="/web/20211030111302/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-health-advice-public" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished">Health advice</a></li>
+<li class="collapsed menu-mlid-10630 covid-19-vaccines- depth-4 section-overview hide-children"><a href="/web/20211030111302/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-vaccines" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished" data-is-top-level="1" title="">COVID-19 vaccines </a></li>
+<li class="collapsed menu-mlid-9997 health-professionals depth-4"><a href="/web/20211030111302/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-information-health-professionals" class="menu-node-unpublished menu-node-unpublished">Health professionals</a></li>
+<li class="collapsed menu-mlid-10019 specific-audiences depth-4"><a href="/web/20211030111302/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-information-specific-audiences" class="menu-node-unpublished">Specific audiences</a></li>
+<li class="expanded active-trail menu-mlid-10096 data-and-statistics depth-4"><a href="/web/20211030111302/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics" class="menu-node-unpublished menu-node-unpublished active-trail">Data and statistics</a><ul class="menu nav"><li class="first leaf menu-mlid-10062 current-cases depth-5 same-level-as-node"><a href="/web/20211030111302/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-current-cases" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Current cases</a></li>
+<li class="leaf menu-mlid-10146 case-demographics depth-5 same-level-as-node"><a href="/web/20211030111302/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-case-demographics">Case demographics</a></li>
+<li class="leaf menu-mlid-10097 source-of-cases depth-5 same-level-as-node"><a href="/web/20211030111302/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-source-cases" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Source of cases</a></li>
+<li class="leaf menu-mlid-10119 testing-for-covid-19 depth-5 same-level-as-node"><a href="/web/20211030111302/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/testing-covid-19" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Testing for COVID-19</a></li>
+<li class="leaf menu-mlid-10371 nz-covid-tracer-app-data depth-5 same-level-as-node"><a href="/web/20211030111302/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-nz-covid-tracer-app-data" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">NZ COVID Tracer app data</a></li>
+<li class="expanded active-trail active menu-mlid-10584 active vaccine-data depth-5 same-level-as-node"><a href="/web/20211030111302/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished active-trail active">Vaccine data</a><ul class="menu nav"><li class="first leaf menu-mlid-10867 covid-19-vaccination-uptake-rates-across-nz depth-6"><a href="/web/20211030111302/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-across-nz" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">COVID-19 Vaccination uptake rates across NZ</a></li>
+<li class="leaf menu-mlid-10868 covid-19-vaccination-uptake-rates---māori depth-6"><a href="/web/20211030111302/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-maori-communities-across-nz" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">COVID-19 Vaccination uptake rates - Māori</a></li>
+<li class="last leaf menu-mlid-10869 covid-19-vaccination-uptake-rates---pacific depth-6"><a href="/web/20211030111302/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-pacific-communities-across-nz" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">COVID-19 Vaccination uptake rates - Pacific</a></li>
+</ul></li>
+<li class="last leaf menu-mlid-10404 data-resources depth-5 same-level-as-node"><a href="/web/20211030111302/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-data-resources" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Data resources</a></li>
+</ul></li>
+<li class="collapsed menu-mlid-10369 response-planning depth-4"><a href="/web/20211030111302/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-response-planning" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Response planning</a></li>
+<li class="collapsed menu-mlid-10015 resources-and-tools depth-4"><a href="/web/20211030111302/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-resources-and-tools" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Resources and tools</a></li>
+<li class="last leaf menu-mlid-10004 news-and-media depth-4 section-overview hide-children"><a href="/web/20211030111302/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-news-and-media-updates" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">News and media</a></li>
+</ul></div>
+  </div>
+
+
+  </div>
+</div>      <div class="panel-panel middle col-xs-12 col-md-9 col-lg-9"><div class="panel-pane pane-page-title even">
+
+
+
+  <div class="pane-content">
+    <span id="skip-content" tabindex="-1"></span>    <h1>COVID-19: Vaccine data</h1>
+  </div>
+
+
+  </div>
+<div class="panel-pane pane-node-content odd">
+
+
+
+  <div class="pane-content">
+        <article id="node-12052" class="node node-page node-sticky view-mode-full clearfix" about="/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" typeof="sioc:Item foaf:Document">
+    <header>
+            <span property="dc:title" content="COVID-19: Vaccine data" class="rdf-meta element-hidden"></span>      </header>
+    <div class="field field-name-field-intro-text field-type-text-long field-label-hidden"><div class="field-items"><div class="field-item even"><p class="intro-text">Data and statistics about the rollout of COVID-19 vaccines in New Zealand.</p></div></div></div><div class="field field-name-body field-type-text-with-summary field-label-hidden"><div class="field-items"><div class="field-item even" property="content:encoded"><p>On this page:</p>
+
+<ul>
+	<li><a href="#daily">Daily updates</a>
+
+	<ul>
+		<li><a href="#total-vaccinations">Total vaccinations</a></li>
+		<li><a href="#ethnicity">Vaccinations by ethnicity</a></li>
+		<li><a href="#90pct">Vaccinations to 90% by DHB</a></li>
+	</ul>
+	</li>
+	<li><a href="#weekly-updates">Weekly updates</a>
+	<ul>
+		<li><a href="#model">Vaccinations against plan</a></li>
+		<li><a href="#uptake">Vaccinations uptake</a></li>
+		<li><a href="#by-day">Vaccinations by day</a></li>
+		<li><a href="#location">Vaccinations by DHB</a></li>
+		<li><a href="#group">Vaccinations by group</a></li>
+		<li><a href="#by_soh">Stock on hand</a></li>
+		<li><a href="#age">Vaccinations by age</a></li>
+		<li><a href="#workforce">Trained vaccinator and active vaccinator</a></li>
+		<li><a href="#group">Vaccinations by group</a></li>
+		<li><a href="#download">Details of vaccination&nbsp;data</a></li>
+	</ul>
+	</li>
+	<li><a href="#adverse-events">Adverse events from immunisations</a></li>
+</ul>
+
+<hr/><!--daily-->
+<h2><a id="daily" name="daily"></a>COVID-19 vaccinations: daily updates</h2>
+
+<div class="well well-sm">
+<p style="margin-top: 0"><strong>Data in this section is as at 11:59pm 29 October 2021 and is updated daily.</strong></p>
+</div>
+
+<h3><a id="total-vaccinations" name="total-vaccinations"></a>Total Vaccinations</h3>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">&nbsp;</th>
+			<th scope="col" style="text-align:right">Vaccinations yesterday</th>
+			<th scope="col" style="text-align:right">Cumulative total</th>
+			<th scope="col" style="text-align:right">Eligible population vaccinated %</th>
+			<th scope="col" style="text-align:right">Total population vaccinated %</th>
+			<th scope="col" style="text-align:right">Vaccinated or booked</th>
+			<th scope="col" style="text-align:right">Eligible vaccinated or booked %</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">First dose</th>
+			<td style="text-align:right">10,995</td>
+			<td style="text-align:right">3,693,489</td>
+			<td style="text-align:right">88%</td>
+			<td style="text-align:right">74%</td>
+			<td style="text-align:right">3,708,113</td>
+			<td style="text-align:right">88%</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Second dose</th>
+			<td style="text-align:right">31,760</td>
+			<td style="text-align:right">3,111,805</td>
+			<td style="text-align:right">74%</td>
+			<td style="text-align:right">62%</td>
+			<td style="text-align:right">3,364,938</td>
+			<td style="text-align:right">80%</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total doses</strong></th>
+			<td style="text-align:right"><strong>42,755</strong></td>
+			<td style="text-align:right"><strong>6,805,294</strong></td>
+		</tr>
+	</tbody>
+</table>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Total vaccinations" class="img-responsive" height="900" src="/web/20211030111302im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_summary_14_0.png" width="5340"/></figure>
+
+<h5>Definitions</h5>
+
+<ul>
+	<li><strong>Cumulative total:</strong>&nbsp;All vaccinations that have been administered and entered into the COVID-19 Immunisation Register up until midnight of the night before the data is published.</li>
+	<li><strong>Eligible population vaccinated %:</strong>&nbsp;Vaccinations administered divided by HSU population estimates for the eligible population (12+).</li>
+	<li><strong>Total population vaccinated %:</strong>&nbsp;Vaccinations administered divided by HSU population estimates for the total population (0+).</li>
+	<li><strong>Vaccinated or booked:</strong>&nbsp;Count of individuals who have either received their vaccination or have booked via Book My Vaccine to receive a vaccination.</li>
+	<li><strong>Eligible vaccinated or booked %:</strong>&nbsp;Count of individuals who have either received their vaccination or have booked via Book My Vaccine to receive a vaccination divided by HSU population estimates for the eligible population (12+).</li>
+</ul>
+
+<p>HSU population estimates are available in the downloadable spreadsheet at the bottom of the page. Throughout the rest of this sheet doses per 1,000 are based on eligible (12+) population.</p>
+
+<p>Bookings are only counted if the site is using Book My Vaccine. Bookings made through other Patient Management Systems are not counted.</p>
+
+<hr/>
+<h3><a id="by_eth" name="ethnicity"></a>Cumulative vaccinations by ethnicity</h3>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">Ethnicity *</th>
+			<th scope="col" style="text-align:right">First dose administered</th>
+			<th scope="col" style="text-align:right">First doses per 1,000 people</th>
+			<th scope="col" style="text-align:right">Second dose administered</th>
+			<th scope="col" style="text-align:right">Second doses per 1,000 people</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">Māori</th>
+			<td style="text-align:right">406,537</td>
+			<td style="text-align:right">712</td>
+			<td style="text-align:right">294,268</td>
+			<td style="text-align:right">515</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Pacific Peoples</th>
+			<td style="text-align:right">241,973</td>
+			<td style="text-align:right">844</td>
+			<td style="text-align:right">192,419</td>
+			<td style="text-align:right">671</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Asian</th>
+			<td style="text-align:right">606,241</td>
+			<td style="text-align:right">&gt;950</td>
+			<td style="text-align:right">534,368</td>
+			<td style="text-align:right">893</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">European / Other</th>
+			<td style="text-align:right">2,404,882</td>
+			<td style="text-align:right">881</td>
+			<td style="text-align:right">2,062,736</td>
+			<td style="text-align:right">755</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Unknown</th>
+			<td style="text-align:right">33,856</td>
+			<td style="text-align:right">-</td>
+			<td style="text-align:right">28,014</td>
+			<td style="text-align:right">-</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total</strong></th>
+			<td style="text-align:right"><strong>3,693,489</strong></td>
+			<td style="text-align:right"><strong>878</strong></td>
+			<td style="text-align:right"><strong>3,111,805</strong></td>
+			<td style="text-align:right"><strong>739</strong></td>
+		</tr>
+	</tbody>
+</table>
+
+<p><strong>*</strong> The prioritised ethnicity classification system allocates each person to a single ethnic group, based on the ethnic groups they identify with. Where people identify with more than one group, they are assigned in this order of priority: Māori, Pacific Peoples, Asian, and European/Other. So, if a person identifies as being Māori and New Zealand European, the person is counted as Māori. See <a href="/web/20211030111302/https://www.health.govt.nz/publication/hiso-100012017-ethnicity-data-protocols">Ethnicity Data Protocols</a> for further information.</p>
+
+<p>Ethnicity breakdown by DHB of residence is available in the downloadable spreadsheet at the bottom of the page.</p>
+
+<hr/>
+<h3><a id="90pct" name="90pct"></a>Vaccinations to 90% by DHB</h3>
+
+<h4><a id="90pct all ethnicities" name="90pct all ethnicities"></a>All Ethnicities</h4>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">&nbsp;</th>
+			<th scope="col" style="text-align:right">First doses</th>
+			<th scope="col" style="text-align:right">First doses %</th>
+			<th scope="col" style="text-align:right">First doses to 90%</th>
+			<th scope="col" style="text-align:right">Second doses</th>
+			<th scope="col" style="text-align:right">Second doses %</th>
+			<th scope="col" style="text-align:right">Second doses to 90%</th>
+			<th scope="col" style="text-align:right">Population</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">Northland</th>
+			<td style="text-align:right">127,447</td>
+			<td style="text-align:right">79%</td>
+			<td style="text-align:right">17,741</td>
+			<td style="text-align:right">103,000</td>
+			<td style="text-align:right">64%</td>
+			<td style="text-align:right">42,188</td>
+			<td style="text-align:right">161,320</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waitemata</th>
+			<td style="text-align:right">478,860</td>
+			<td style="text-align:right">91%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">417,802</td>
+			<td style="text-align:right">79%</td>
+			<td style="text-align:right">55,676</td>
+			<td style="text-align:right">526,087</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Auckland</th>
+			<td style="text-align:right">397,623</td>
+			<td style="text-align:right">94%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">354,251</td>
+			<td style="text-align:right">84%</td>
+			<td style="text-align:right">27,311</td>
+			<td style="text-align:right">423,958</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Counties Manukau</th>
+			<td style="text-align:right">427,835</td>
+			<td style="text-align:right">89%</td>
+			<td style="text-align:right">6,661</td>
+			<td style="text-align:right">366,733</td>
+			<td style="text-align:right">76%</td>
+			<td style="text-align:right">67,763</td>
+			<td style="text-align:right">482,773</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waikato</th>
+			<td style="text-align:right">308,535</td>
+			<td style="text-align:right">86%</td>
+			<td style="text-align:right">12,923</td>
+			<td style="text-align:right">254,507</td>
+			<td style="text-align:right">71%</td>
+			<td style="text-align:right">66,951</td>
+			<td style="text-align:right">357,176</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Lakes</th>
+			<td style="text-align:right">75,641</td>
+			<td style="text-align:right">80%</td>
+			<td style="text-align:right">9,336</td>
+			<td style="text-align:right">61,016</td>
+			<td style="text-align:right">65%</td>
+			<td style="text-align:right">23,961</td>
+			<td style="text-align:right">94,419</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Bay of Plenty</th>
+			<td style="text-align:right">179,551</td>
+			<td style="text-align:right">83%</td>
+			<td style="text-align:right">15,696</td>
+			<td style="text-align:right">143,827</td>
+			<td style="text-align:right">66%</td>
+			<td style="text-align:right">51,420</td>
+			<td style="text-align:right">216,941</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Tairawhiti</th>
+			<td style="text-align:right">32,626</td>
+			<td style="text-align:right">78%</td>
+			<td style="text-align:right">5,142</td>
+			<td style="text-align:right">26,373</td>
+			<td style="text-align:right">63%</td>
+			<td style="text-align:right">11,396</td>
+			<td style="text-align:right">41,965</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Taranaki</th>
+			<td style="text-align:right">85,658</td>
+			<td style="text-align:right">84%</td>
+			<td style="text-align:right">6,274</td>
+			<td style="text-align:right">66,348</td>
+			<td style="text-align:right">65%</td>
+			<td style="text-align:right">25,584</td>
+			<td style="text-align:right">102,147</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hawkes Bay</th>
+			<td style="text-align:right">122,399</td>
+			<td style="text-align:right">84%</td>
+			<td style="text-align:right">8,615</td>
+			<td style="text-align:right">102,181</td>
+			<td style="text-align:right">70%</td>
+			<td style="text-align:right">28,833</td>
+			<td style="text-align:right">145,571</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">MidCentral</th>
+			<td style="text-align:right">130,862</td>
+			<td style="text-align:right">86%</td>
+			<td style="text-align:right">6,210</td>
+			<td style="text-align:right">108,830</td>
+			<td style="text-align:right">71%</td>
+			<td style="text-align:right">28,242</td>
+			<td style="text-align:right">152,302</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Whanganui</th>
+			<td style="text-align:right">45,939</td>
+			<td style="text-align:right">80%</td>
+			<td style="text-align:right">5,583</td>
+			<td style="text-align:right">38,606</td>
+			<td style="text-align:right">67%</td>
+			<td style="text-align:right">12,916</td>
+			<td style="text-align:right">57,247</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Capital and Coast</th>
+			<td style="text-align:right">249,430</td>
+			<td style="text-align:right">92%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">214,922</td>
+			<td style="text-align:right">79%</td>
+			<td style="text-align:right">29,135</td>
+			<td style="text-align:right">271,174</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hutt Valley</th>
+			<td style="text-align:right">114,179</td>
+			<td style="text-align:right">88%</td>
+			<td style="text-align:right">3,036</td>
+			<td style="text-align:right">95,258</td>
+			<td style="text-align:right">73%</td>
+			<td style="text-align:right">21,957</td>
+			<td style="text-align:right">130,239</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Wairarapa</th>
+			<td style="text-align:right">35,304</td>
+			<td style="text-align:right">85%</td>
+			<td style="text-align:right">1,980</td>
+			<td style="text-align:right">29,722</td>
+			<td style="text-align:right">72%</td>
+			<td style="text-align:right">7,562</td>
+			<td style="text-align:right">41,427</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Nelson Marlborough</th>
+			<td style="text-align:right">117,338</td>
+			<td style="text-align:right">86%</td>
+			<td style="text-align:right">4,831</td>
+			<td style="text-align:right">102,101</td>
+			<td style="text-align:right">75%</td>
+			<td style="text-align:right">20,068</td>
+			<td style="text-align:right">135,743</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">West Coast</th>
+			<td style="text-align:right">22,584</td>
+			<td style="text-align:right">81%</td>
+			<td style="text-align:right">2,531</td>
+			<td style="text-align:right">18,378</td>
+			<td style="text-align:right">66%</td>
+			<td style="text-align:right">6,737</td>
+			<td style="text-align:right">27,906</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Canterbury</th>
+			<td style="text-align:right">436,822</td>
+			<td style="text-align:right">90%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">346,684</td>
+			<td style="text-align:right">72%</td>
+			<td style="text-align:right">87,917</td>
+			<td style="text-align:right">482,890</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">South Canterbury</th>
+			<td style="text-align:right">45,162</td>
+			<td style="text-align:right">86%</td>
+			<td style="text-align:right">2,164</td>
+			<td style="text-align:right">38,658</td>
+			<td style="text-align:right">74%</td>
+			<td style="text-align:right">8,668</td>
+			<td style="text-align:right">52,584</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Southern</th>
+			<td style="text-align:right">257,654</td>
+			<td style="text-align:right">89%</td>
+			<td style="text-align:right">1,560</td>
+			<td style="text-align:right">220,955</td>
+			<td style="text-align:right">77%</td>
+			<td style="text-align:right">38,258</td>
+			<td style="text-align:right">288,015</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Overseas / Unknown</th>
+			<td style="text-align:right">2,040</td>
+			<td style="text-align:right">12%</td>
+			<td style="text-align:right">13,416</td>
+			<td style="text-align:right">1,653</td>
+			<td style="text-align:right">10%</td>
+			<td style="text-align:right">13,803</td>
+			<td style="text-align:right">17,173</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total</strong></th>
+			<td style="text-align:right"><strong>3,693,489</strong></td>
+			<td style="text-align:right"><strong>88%</strong></td>
+			<td style="text-align:right"><strong>94,662</strong></td>
+			<td style="text-align:right"><strong>3,111,805</strong></td>
+			<td style="text-align:right"><strong>74%</strong></td>
+			<td style="text-align:right"><strong>676,346</strong></td>
+			<td style="text-align:right"><strong>4,209,057</strong></td>
+		</tr>
+	</tbody>
+</table>
+
+<p>First/second doses % are the number of first/second doses administered divided by the eligible population. First/second doses to 90% are the number of doses required to reach 90% of the eligible population. For these two measures, the national total may not be the sum of DHB measures.</p>
+
+<h4><a id="90pct Māori" name="90pct Māori">Māori</a></h4>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">&nbsp;</th>
+			<th scope="col" style="text-align:right">First doses</th>
+			<th scope="col" style="text-align:right">First doses %</th>
+			<th scope="col" style="text-align:right">First doses to 90%</th>
+			<th scope="col" style="text-align:right">Second doses</th>
+			<th scope="col" style="text-align:right">Second doses %</th>
+			<th scope="col" style="text-align:right">Second doses to 90%</th>
+			<th scope="col" style="text-align:right">Population</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">Northland</th>
+			<td style="text-align:right">33,775</td>
+			<td style="text-align:right">67%</td>
+			<td style="text-align:right">11,664</td>
+			<td style="text-align:right">23,463</td>
+			<td style="text-align:right">46%</td>
+			<td style="text-align:right">21,976</td>
+			<td style="text-align:right">50,488</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waitemata</th>
+			<td style="text-align:right">32,680</td>
+			<td style="text-align:right">79%</td>
+			<td style="text-align:right">4,322</td>
+			<td style="text-align:right">25,014</td>
+			<td style="text-align:right">61%</td>
+			<td style="text-align:right">11,988</td>
+			<td style="text-align:right">41,113</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Auckland</th>
+			<td style="text-align:right">22,832</td>
+			<td style="text-align:right">82%</td>
+			<td style="text-align:right">2,181</td>
+			<td style="text-align:right">17,908</td>
+			<td style="text-align:right">64%</td>
+			<td style="text-align:right">7,105</td>
+			<td style="text-align:right">27,792</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Counties Manukau</th>
+			<td style="text-align:right">46,225</td>
+			<td style="text-align:right">73%</td>
+			<td style="text-align:right">10,919</td>
+			<td style="text-align:right">33,223</td>
+			<td style="text-align:right">52%</td>
+			<td style="text-align:right">23,921</td>
+			<td style="text-align:right">63,493</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waikato</th>
+			<td style="text-align:right">50,331</td>
+			<td style="text-align:right">72%</td>
+			<td style="text-align:right">12,405</td>
+			<td style="text-align:right">35,010</td>
+			<td style="text-align:right">50%</td>
+			<td style="text-align:right">27,726</td>
+			<td style="text-align:right">69,707</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Lakes</th>
+			<td style="text-align:right">19,426</td>
+			<td style="text-align:right">65%</td>
+			<td style="text-align:right">7,650</td>
+			<td style="text-align:right">13,709</td>
+			<td style="text-align:right">46%</td>
+			<td style="text-align:right">13,368</td>
+			<td style="text-align:right">30,085</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Bay of Plenty</th>
+			<td style="text-align:right">30,459</td>
+			<td style="text-align:right">64%</td>
+			<td style="text-align:right">12,502</td>
+			<td style="text-align:right">21,225</td>
+			<td style="text-align:right">44%</td>
+			<td style="text-align:right">21,736</td>
+			<td style="text-align:right">47,734</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Tairawhiti</th>
+			<td style="text-align:right">13,349</td>
+			<td style="text-align:right">67%</td>
+			<td style="text-align:right">4,506</td>
+			<td style="text-align:right">9,786</td>
+			<td style="text-align:right">49%</td>
+			<td style="text-align:right">8,069</td>
+			<td style="text-align:right">19,839</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Taranaki</th>
+			<td style="text-align:right">10,802</td>
+			<td style="text-align:right">68%</td>
+			<td style="text-align:right">3,512</td>
+			<td style="text-align:right">7,126</td>
+			<td style="text-align:right">45%</td>
+			<td style="text-align:right">7,188</td>
+			<td style="text-align:right">15,904</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hawkes Bay</th>
+			<td style="text-align:right">22,691</td>
+			<td style="text-align:right">67%</td>
+			<td style="text-align:right">7,962</td>
+			<td style="text-align:right">16,274</td>
+			<td style="text-align:right">48%</td>
+			<td style="text-align:right">14,379</td>
+			<td style="text-align:right">34,059</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">MidCentral</th>
+			<td style="text-align:right">17,187</td>
+			<td style="text-align:right">71%</td>
+			<td style="text-align:right">4,616</td>
+			<td style="text-align:right">12,404</td>
+			<td style="text-align:right">51%</td>
+			<td style="text-align:right">9,398</td>
+			<td style="text-align:right">24,225</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Whanganui</th>
+			<td style="text-align:right">8,764</td>
+			<td style="text-align:right">65%</td>
+			<td style="text-align:right">3,397</td>
+			<td style="text-align:right">6,557</td>
+			<td style="text-align:right">49%</td>
+			<td style="text-align:right">5,604</td>
+			<td style="text-align:right">13,512</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Capital and Coast</th>
+			<td style="text-align:right">21,470</td>
+			<td style="text-align:right">80%</td>
+			<td style="text-align:right">2,800</td>
+			<td style="text-align:right">16,630</td>
+			<td style="text-align:right">62%</td>
+			<td style="text-align:right">7,640</td>
+			<td style="text-align:right">26,967</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hutt Valley</th>
+			<td style="text-align:right">13,871</td>
+			<td style="text-align:right">73%</td>
+			<td style="text-align:right">3,340</td>
+			<td style="text-align:right">10,234</td>
+			<td style="text-align:right">54%</td>
+			<td style="text-align:right">6,977</td>
+			<td style="text-align:right">19,123</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Wairarapa</th>
+			<td style="text-align:right">4,394</td>
+			<td style="text-align:right">70%</td>
+			<td style="text-align:right">1,278</td>
+			<td style="text-align:right">3,123</td>
+			<td style="text-align:right">50%</td>
+			<td style="text-align:right">2,549</td>
+			<td style="text-align:right">6,302</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Nelson Marlborough</th>
+			<td style="text-align:right">7,876</td>
+			<td style="text-align:right">70%</td>
+			<td style="text-align:right">2,247</td>
+			<td style="text-align:right">5,946</td>
+			<td style="text-align:right">53%</td>
+			<td style="text-align:right">4,177</td>
+			<td style="text-align:right">11,248</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">West Coast</th>
+			<td style="text-align:right">1,977</td>
+			<td style="text-align:right">72%</td>
+			<td style="text-align:right">512</td>
+			<td style="text-align:right">1,428</td>
+			<td style="text-align:right">52%</td>
+			<td style="text-align:right">1,060</td>
+			<td style="text-align:right">2,765</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Canterbury</th>
+			<td style="text-align:right">28,054</td>
+			<td style="text-align:right">76%</td>
+			<td style="text-align:right">5,218</td>
+			<td style="text-align:right">19,563</td>
+			<td style="text-align:right">53%</td>
+			<td style="text-align:right">13,709</td>
+			<td style="text-align:right">36,969</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">South Canterbury</th>
+			<td style="text-align:right">2,424</td>
+			<td style="text-align:right">71%</td>
+			<td style="text-align:right">661</td>
+			<td style="text-align:right">1,802</td>
+			<td style="text-align:right">53%</td>
+			<td style="text-align:right">1,283</td>
+			<td style="text-align:right">3,428</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Southern</th>
+			<td style="text-align:right">17,763</td>
+			<td style="text-align:right">75%</td>
+			<td style="text-align:right">3,518</td>
+			<td style="text-align:right">13,706</td>
+			<td style="text-align:right">58%</td>
+			<td style="text-align:right">7,575</td>
+			<td style="text-align:right">23,646</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Overseas / Unknown</th>
+			<td style="text-align:right">187</td>
+			<td style="text-align:right">7%</td>
+			<td style="text-align:right">2,201</td>
+			<td style="text-align:right">137</td>
+			<td style="text-align:right">5%</td>
+			<td style="text-align:right">2,251</td>
+			<td style="text-align:right">2,653</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total</strong></th>
+			<td style="text-align:right"><strong>406,537</strong></td>
+			<td style="text-align:right"><strong>71%</strong></td>
+			<td style="text-align:right"><strong>107,410</strong></td>
+			<td style="text-align:right"><strong>294,268</strong></td>
+			<td style="text-align:right"><strong>52%</strong></td>
+			<td style="text-align:right"><strong>219,679</strong></td>
+			<td style="text-align:right"><strong>571,052</strong></td>
+		</tr>
+	</tbody>
+</table>
+
+<h4><a id="90pct Pacific Peoples" name="90pct Pacific Peoples"></a>Pacific Peoples</h4>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">&nbsp;</th>
+			<th scope="col" style="text-align:right">First doses</th>
+			<th scope="col" style="text-align:right">First doses %</th>
+			<th scope="col" style="text-align:right">First doses to 90%</th>
+			<th scope="col" style="text-align:right">Second doses</th>
+			<th scope="col" style="text-align:right">Second doses %</th>
+			<th scope="col" style="text-align:right">Second doses to 90%</th>
+			<th scope="col" style="text-align:right">Population</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">Northland</th>
+			<td style="text-align:right">2,359</td>
+			<td style="text-align:right">80%</td>
+			<td style="text-align:right">282</td>
+			<td style="text-align:right">1,716</td>
+			<td style="text-align:right">58%</td>
+			<td style="text-align:right">925</td>
+			<td style="text-align:right">2,934</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waitemata</th>
+			<td style="text-align:right">31,964</td>
+			<td style="text-align:right">85%</td>
+			<td style="text-align:right">1,852</td>
+			<td style="text-align:right">25,490</td>
+			<td style="text-align:right">68%</td>
+			<td style="text-align:right">8,326</td>
+			<td style="text-align:right">37,573</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Auckland</th>
+			<td style="text-align:right">39,316</td>
+			<td style="text-align:right">84%</td>
+			<td style="text-align:right">2,863</td>
+			<td style="text-align:right">31,604</td>
+			<td style="text-align:right">67%</td>
+			<td style="text-align:right">10,575</td>
+			<td style="text-align:right">46,866</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Counties Manukau</th>
+			<td style="text-align:right">96,341</td>
+			<td style="text-align:right">83%</td>
+			<td style="text-align:right">8,507</td>
+			<td style="text-align:right">76,831</td>
+			<td style="text-align:right">66%</td>
+			<td style="text-align:right">28,017</td>
+			<td style="text-align:right">116,498</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waikato</th>
+			<td style="text-align:right">9,126</td>
+			<td style="text-align:right">85%</td>
+			<td style="text-align:right">488</td>
+			<td style="text-align:right">7,173</td>
+			<td style="text-align:right">67%</td>
+			<td style="text-align:right">2,441</td>
+			<td style="text-align:right">10,682</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Lakes</th>
+			<td style="text-align:right">1,811</td>
+			<td style="text-align:right">79%</td>
+			<td style="text-align:right">246</td>
+			<td style="text-align:right">1,409</td>
+			<td style="text-align:right">62%</td>
+			<td style="text-align:right">648</td>
+			<td style="text-align:right">2,286</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Bay of Plenty</th>
+			<td style="text-align:right">3,999</td>
+			<td style="text-align:right">&gt;95%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">3,083</td>
+			<td style="text-align:right">84%</td>
+			<td style="text-align:right">228</td>
+			<td style="text-align:right">3,679</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Tairawhiti</th>
+			<td style="text-align:right">862</td>
+			<td style="text-align:right">89%</td>
+			<td style="text-align:right">6</td>
+			<td style="text-align:right">668</td>
+			<td style="text-align:right">69%</td>
+			<td style="text-align:right">200</td>
+			<td style="text-align:right">965</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Taranaki</th>
+			<td style="text-align:right">1,048</td>
+			<td style="text-align:right">83%</td>
+			<td style="text-align:right">95</td>
+			<td style="text-align:right">785</td>
+			<td style="text-align:right">62%</td>
+			<td style="text-align:right">358</td>
+			<td style="text-align:right">1,270</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hawkes Bay</th>
+			<td style="text-align:right">5,085</td>
+			<td style="text-align:right">&gt;95%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">4,149</td>
+			<td style="text-align:right">83%</td>
+			<td style="text-align:right">369</td>
+			<td style="text-align:right">5,020</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">MidCentral</th>
+			<td style="text-align:right">3,764</td>
+			<td style="text-align:right">84%</td>
+			<td style="text-align:right">257</td>
+			<td style="text-align:right">2,900</td>
+			<td style="text-align:right">65%</td>
+			<td style="text-align:right">1,121</td>
+			<td style="text-align:right">4,468</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Whanganui</th>
+			<td style="text-align:right">1,041</td>
+			<td style="text-align:right">75%</td>
+			<td style="text-align:right">202</td>
+			<td style="text-align:right">826</td>
+			<td style="text-align:right">60%</td>
+			<td style="text-align:right">417</td>
+			<td style="text-align:right">1,381</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Capital and Coast</th>
+			<td style="text-align:right">15,610</td>
+			<td style="text-align:right">81%</td>
+			<td style="text-align:right">1,649</td>
+			<td style="text-align:right">12,525</td>
+			<td style="text-align:right">65%</td>
+			<td style="text-align:right">4,734</td>
+			<td style="text-align:right">19,177</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hutt Valley</th>
+			<td style="text-align:right">7,919</td>
+			<td style="text-align:right">80%</td>
+			<td style="text-align:right">986</td>
+			<td style="text-align:right">6,238</td>
+			<td style="text-align:right">63%</td>
+			<td style="text-align:right">2,667</td>
+			<td style="text-align:right">9,894</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Wairarapa</th>
+			<td style="text-align:right">687</td>
+			<td style="text-align:right">82%</td>
+			<td style="text-align:right">66</td>
+			<td style="text-align:right">551</td>
+			<td style="text-align:right">66%</td>
+			<td style="text-align:right">202</td>
+			<td style="text-align:right">837</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Nelson Marlborough</th>
+			<td style="text-align:right">3,595</td>
+			<td style="text-align:right">&gt;95%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">3,135</td>
+			<td style="text-align:right">&gt;95%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">2,115</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">West Coast</th>
+			<td style="text-align:right">231</td>
+			<td style="text-align:right">82%</td>
+			<td style="text-align:right">23</td>
+			<td style="text-align:right">172</td>
+			<td style="text-align:right">61%</td>
+			<td style="text-align:right">82</td>
+			<td style="text-align:right">282</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Canterbury</th>
+			<td style="text-align:right">10,545</td>
+			<td style="text-align:right">83%</td>
+			<td style="text-align:right">918</td>
+			<td style="text-align:right">7,856</td>
+			<td style="text-align:right">62%</td>
+			<td style="text-align:right">3,607</td>
+			<td style="text-align:right">12,737</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">South Canterbury</th>
+			<td style="text-align:right">778</td>
+			<td style="text-align:right">93%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">572</td>
+			<td style="text-align:right">68%</td>
+			<td style="text-align:right">181</td>
+			<td style="text-align:right">837</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Southern</th>
+			<td style="text-align:right">5,557</td>
+			<td style="text-align:right">92%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">4,443</td>
+			<td style="text-align:right">74%</td>
+			<td style="text-align:right">985</td>
+			<td style="text-align:right">6,031</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Overseas / Unknown</th>
+			<td style="text-align:right">335</td>
+			<td style="text-align:right">29%</td>
+			<td style="text-align:right">699</td>
+			<td style="text-align:right">293</td>
+			<td style="text-align:right">26%</td>
+			<td style="text-align:right">741</td>
+			<td style="text-align:right">1,149</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total</strong></th>
+			<td style="text-align:right"><strong>241,973</strong></td>
+			<td style="text-align:right"><strong>84%</strong></td>
+			<td style="text-align:right"><strong>16,040</strong></td>
+			<td style="text-align:right"><strong>192,419</strong></td>
+			<td style="text-align:right"><strong>67%</strong></td>
+			<td style="text-align:right"><strong>65,594</strong></td>
+			<td style="text-align:right"><strong>286,681</strong></td>
+		</tr>
+	</tbody>
+</table>
+<!--daily_end-->
+
+<hr/>
+<h2><a id="weekly-updates" name="weekly-updates"></a>COVID-19 vaccinations: weekly updates</h2>
+
+<div class="well well-sm">
+<p style="margin-top: 0"><strong>Data in this section is as at 11:59pm 26 October 2021 and is updated weekly on Wednesdays.</strong></p>
+</div>
+
+<h3><a id="model" model="" name="id="></a>Cumulative vaccinations</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccination doses administered compared to plan doses" class="img-responsive" height="830" src="/web/20211030111302im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/vaccineplanmodel_13.png" width="1780"/></figure>
+
+<p>Production plan figures are the volumes agreed with DHBs and national providers for expected vaccinations. These figures have been matched with expected supply. Detailed plans are available in the Excel file at the bottom of this page.</p>
+
+<p>The Stock received figures are the cumulative supply of doses to date.</p>
+
+<p>DHB capacity plans for the remainder of the year are undergoing review.</p>
+
+<hr/><!--
+<h3><a id="model" model="" name="id="></a>Cumulative vaccinations for last 6 weeks</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccination doses administered compared to plan doses - 6wks" class="img-responsive" height="830" src="/vaccineplanmodel_wks.png" width="1780" /></figure>
+
+<hr />
+-->
+<h3><a id="uptake" name="uptake"></a>Vaccine uptake</h3>
+
+<p>Maps and data related to uptake rates of the COVID-19 vaccine across the country are available on the pages linked below. These show&nbsp;vaccination records aggregated by area of residence for all New Zealand residents, Māori communities, and Pacific communities.</p>
+
+<ul>
+	<li><a href="/web/20211030111302/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-across-nz">COVID-19 Vaccination uptake rates across NZ</a></li>
+	<li><a href="/web/20211030111302/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-maori-communities-across-nz">COVID-19 Vaccination uptake rates within Māori communities across NZ</a></li>
+	<li><a href="/web/20211030111302/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-pacific-communities-across-nz">COVID-19 Vaccination uptake rates within Pacific communities across NZ</a></li>
+</ul>
+
+<h4><a id="uptake" name="uptake"></a>Vaccine uptake per rate ratio (unadjusted) Māori and Pacific compared with Non-Māori non-Pacific</h4>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine Uptake per 1,000 (HSU) Rate Ratio, Showing Prioritised Ethnicity, vs Non-Māori Non-Pacific, By Age Band" class="img-responsive" height="830" src="/web/20211030111302im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_mix_8.png" width="1780"/></figure>
+
+<p>In the Chart above, rate ratios tell us the rate Māori or Pacific People per population are being vaccinated compared with non-Māori non-Pacific. This comparison can be split by age group.</p>
+
+<ul>
+	<li>A rate of one means the groups being compared are being vaccinated at the same rate.</li>
+	<li>A rate over one means Māori (or Pacific) are being vaccinated at a higher rate than non-Māori non-Pacific.</li>
+	<li>A rate under one means Māori (or Pacific) are being vaccinated at a lower rate than non-Māori non-Pacific.</li>
+</ul>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<td colspan="2" style="border-top: 0 !important; border-bottom-color: #FDD6AF !important; border-right: 0 !important;">&nbsp;</td>
+			<th colspan="6" id="ac1">Māori</th>
+			<th colspan="6" id="ac8">Pacific Peoples</th>
+		</tr>
+		<tr>
+			<th id="ar1">DHB</th>
+			<th>Dose number</th>
+			<th headers="ac1" id="ac2">65+</th>
+			<th headers="ac1" id="ac3">50-64</th>
+			<th headers="ac1" id="ac4">35-49</th>
+			<th headers="ac1" id="ac5">20-34</th>
+			<th headers="ac1" id="ac6">12-19</th>
+			<th headers="ac1" id="ac7">All ages</th>
+			<th headers="ac8" id="ac9">65+</th>
+			<th headers="ac8" id="ac10">50-64</th>
+			<th headers="ac8" id="ac11">35-49</th>
+			<th headers="ac8" id="ac12">20-34</th>
+			<th headers="ac8" id="ac13">12-19</th>
+			<th headers="ac8" id="ac14">All ages</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th headers="ar1" id="ar2" rowspan="2">National</th>
+			<th headers="ar1 ar2" id="ar3">Dose 1</th>
+			<td headers="ar1 ar2 ar3 ac1 ac2" style="background-color:green; color: #FFF;"><strong>0.99</strong></td>
+			<td headers="ar1 ar2 ar3 ac1 ac3" style="background-color:mediumseagreen"><strong>0.93</strong></td>
+			<td headers="ar1 ar2 ar3 ac1 ac4" style="background-color:yellow"><strong>0.79</strong></td>
+			<td headers="ar1 ar2 ar3 ac1 ac5" style="background-color:coral"><strong>0.67</strong></td>
+			<td headers="ar1 ar2 ar3 ac1 ac6" style="background-color:orange"><strong>0.71</strong></td>
+			<td headers="ar1 ar2 ar3 ac1 ac7" style="background-color:yellow"><strong>0.77</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac9" style="background-color:mediumseagreen"><strong>0.94</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac10" style="background-color:green; color: #FFF;"><strong>0.99</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac11" style="background-color:green; color: #FFF;"><strong>0.98</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac12" style="background-color:lightgreen"><strong>0.89</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac13" style="background-color:mediumseagreen"><strong>0.90</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac14" style="background-color:mediumseagreen"><strong>0.93</strong></td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar2" id="ar4">Dose 2</th>
+			<td headers="ar1 ar2 ar4 ac1 ac2" style="background-color:green; color: #FFF;"><strong>0.96</strong></td>
+			<td headers="ar1 ar2 ar4 ac1 ac3" style="background-color:lightgreen"><strong>0.87</strong></td>
+			<td headers="ar1 ar2 ar4 ac1 ac4" style="background-color:coral"><strong>0.68</strong></td>
+			<td headers="ar1 ar2 ar4 ac1 ac5" style="background-color:crimson; color: #FFF;"><strong>0.51</strong></td>
+			<td headers="ar1 ar2 ar4 ac1 ac6" style="background-color:crimson; color: #FFF;"><strong>0.57</strong></td>
+			<td headers="ar1 ar2 ar4 ac1 ac7" style="background-color:coral"><strong>0.65</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac9" style="background-color:mediumseagreen"><strong>0.92</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac10" style="background-color:green; color: #FFF;"><strong>0.99</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac11" style="background-color:green; color: #FFF;"><strong>0.97</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac12" style="background-color:palegreen"><strong>0.82</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac13" style="background-color:lightgreen"><strong>0.86</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac14" style="background-color:lightgreen"><strong>0.86</strong></td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar5" rowspan="2">Northland</th>
+			<th headers="ar1 ar5" id="ar6">Dose 1</th>
+			<td headers="ar1 ar5 ar6 ac1 ac2" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar5 ar6 ac1 ac3" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar5 ar6 ac1 ac4" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar5 ar6 ac1 ac5" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar5 ar6 ac1 ac6" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar5 ar6 ac1 ac7" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar5 ar6 ac8 ac9" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar5 ar6 ac8 ac10" style="background-color:green; color: #FFF;">1.06</td>
+			<td headers="ar1 ar5 ar6 ac8 ac11" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar5 ar6 ac8 ac12" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar5 ar6 ac8 ac13" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar5 ar6 ac8 ac14" style="background-color:mediumseagreen">0.94</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar5" id="ar7">Dose 2</th>
+			<td headers="ar1 ar5 ar7 ac1 ac2" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar5 ar7 ac1 ac3" style="background-color:lightgreen">0.87</td>
+			<td headers="ar1 ar5 ar7 ac1 ac4" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar5 ar7 ac1 ac5" style="background-color:crimson; color: #FFF;">0.49</td>
+			<td headers="ar1 ar5 ar7 ac1 ac6" style="background-color:crimson; color: #FFF;">0.59</td>
+			<td headers="ar1 ar5 ar7 ac1 ac7" style="background-color:tomato">0.63</td>
+			<td headers="ar1 ar5 ar7 ac8 ac9" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar5 ar7 ac8 ac10" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar5 ar7 ac8 ac11" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar5 ar7 ac8 ac12" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar5 ar7 ac8 ac13" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar5 ar7 ac8 ac14" style="background-color:palegreen">0.80</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar8" rowspan="2">Auckland Metro</th>
+			<th headers="ar1 ar8" id="ar9">Dose 1</th>
+			<td headers="ar1 ar8 ar9 ac1 ac2" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar8 ar9 ac1 ac3" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar8 ar9 ac1 ac4" style="background-color:palegreen">0.81</td>
+			<td headers="ar1 ar8 ar9 ac1 ac5" style="background-color:orange">0.72</td>
+			<td headers="ar1 ar8 ar9 ac1 ac6" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar8 ar9 ac1 ac7" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar8 ar9 ac8 ac9" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar8 ar9 ac8 ac10" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar8 ar9 ac8 ac11" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar8 ar9 ac8 ac12" style="background-color:palegreen">0.81</td>
+			<td headers="ar1 ar8 ar9 ac8 ac13" style="background-color:palegreen">0.84</td>
+			<td headers="ar1 ar8 ar9 ac8 ac14" style="background-color:lightgreen">0.88</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar8" id="ar10">Dose 2</th>
+			<td headers="ar1 ar8 ar10 ac1 ac2" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar8 ar10 ac1 ac3" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar8 ar10 ac1 ac4" style="background-color:coral">0.69</td>
+			<td headers="ar1 ar8 ar10 ac1 ac5" style="background-color:crimson; color: #FFF;">0.54</td>
+			<td headers="ar1 ar8 ar10 ac1 ac6" style="background-color:crimson; color: #FFF;">0.59</td>
+			<td headers="ar1 ar8 ar10 ac1 ac7" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar8 ar10 ac8 ac9" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar8 ar10 ac8 ac10" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar8 ar10 ac8 ac11" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar8 ar10 ac8 ac12" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar8 ar10 ac8 ac13" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar8 ar10 ac8 ac14" style="background-color:yellow">0.78</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar11" rowspan="2">Waikato</th>
+			<th headers="ar1 ar11" id="ar12">Dose 1</th>
+			<td headers="ar1 ar11 ar12 ac1 ac2" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar11 ar12 ac1 ac3" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar11 ar12 ac1 ac4" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar11 ar12 ac1 ac5" style="background-color:coral">0.69</td>
+			<td headers="ar1 ar11 ar12 ac1 ac6" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar11 ar12 ac1 ac7" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar11 ar12 ac8 ac9" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar11 ar12 ac8 ac10" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar11 ar12 ac8 ac11" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar11 ar12 ac8 ac12" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar11 ar12 ac8 ac13" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar11 ar12 ac8 ac14" style="background-color:mediumseagreen">0.94</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar11" id="ar13">Dose 2</th>
+			<td headers="ar1 ar11 ar13 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar11 ar13 ac1 ac3" style="background-color:lightgreen">0.87</td>
+			<td headers="ar1 ar11 ar13 ac1 ac4" style="background-color:coral">0.68</td>
+			<td headers="ar1 ar11 ar13 ac1 ac5" style="background-color:crimson; color: #FFF;">0.50</td>
+			<td headers="ar1 ar11 ar13 ac1 ac6" style="background-color:crimson; color: #FFF;">0.57</td>
+			<td headers="ar1 ar11 ar13 ac1 ac7" style="background-color:tomato">0.64</td>
+			<td headers="ar1 ar11 ar13 ac8 ac9" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar11 ar13 ac8 ac10" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar11 ar13 ac8 ac11" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar11 ar13 ac8 ac12" style="background-color:palegreen">0.84</td>
+			<td headers="ar1 ar11 ar13 ac8 ac13" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar11 ar13 ac8 ac14" style="background-color:lightgreen">0.87</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar14" rowspan="2">Bay of Plenty</th>
+			<th headers="ar1 ar14" id="ar15">Dose 1</th>
+			<td headers="ar1 ar14 ar15 ac1 ac2" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar14 ar15 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar14 ar15 ac1 ac4" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar14 ar15 ac1 ac5" style="background-color:crimson; color: #FFF;">0.57</td>
+			<td headers="ar1 ar14 ar15 ac1 ac6" style="background-color:tomato">0.64</td>
+			<td headers="ar1 ar14 ar15 ac1 ac7" style="background-color:orange">0.72</td>
+			<td headers="ar1 ar14 ar15 ac8 ac9" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar14 ar15 ac8 ac10" style="background-color:green; color: #FFF;">1.09</td>
+			<td headers="ar1 ar14 ar15 ac8 ac11" style="background-color:green; color: #FFF;">1.47</td>
+			<td headers="ar1 ar14 ar15 ac8 ac12" style="background-color:green; color: #FFF;">1.52</td>
+			<td headers="ar1 ar14 ar15 ac8 ac13" style="background-color:lightgreen">0.87</td>
+			<td headers="ar1 ar14 ar15 ac8 ac14" style="background-color:green; color: #FFF;">1.23</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar14" id="ar16">Dose 2</th>
+			<td headers="ar1 ar14 ar16 ac1 ac2" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar14 ar16 ac1 ac3" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar14 ar16 ac1 ac4" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar14 ar16 ac1 ac5" style="background-color:crimson; color: #FFF;">0.46</td>
+			<td headers="ar1 ar14 ar16 ac1 ac6" style="background-color:crimson; color: #FFF;">0.54</td>
+			<td headers="ar1 ar14 ar16 ac1 ac7" style="background-color:tomato">0.60</td>
+			<td headers="ar1 ar14 ar16 ac8 ac9" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar14 ar16 ac8 ac10" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar14 ar16 ac8 ac11" style="background-color:green; color: #FFF;">1.60</td>
+			<td headers="ar1 ar14 ar16 ac8 ac12" style="background-color:green; color: #FFF;">1.78</td>
+			<td headers="ar1 ar14 ar16 ac8 ac13" style="background-color:yellow">0.77</td>
+			<td headers="ar1 ar14 ar16 ac8 ac14" style="background-color:green; color: #FFF;">1.15</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar17" rowspan="2">Tairawhiti</th>
+			<th headers="ar1 ar17" id="ar18">Dose 1</th>
+			<td headers="ar1 ar17 ar18 ac1 ac2" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar17 ar18 ac1 ac3" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar17 ar18 ac1 ac4" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar17 ar18 ac1 ac5" style="background-color:tomato">0.62</td>
+			<td headers="ar1 ar17 ar18 ac1 ac6" style="background-color:coral">0.69</td>
+			<td headers="ar1 ar17 ar18 ac1 ac7" style="background-color:yellow">0.76</td>
+			<td headers="ar1 ar17 ar18 ac8 ac9" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar17 ar18 ac8 ac10" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar17 ar18 ac8 ac11" style="background-color:green; color: #FFF;">1.10</td>
+			<td headers="ar1 ar17 ar18 ac8 ac12" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar17 ar18 ac8 ac13" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar17 ar18 ac8 ac14" style="background-color:green; color: #FFF;">1.01</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar17" id="ar19">Dose 2</th>
+			<td headers="ar1 ar17 ar19 ac1 ac2" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar17 ar19 ac1 ac3" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar17 ar19 ac1 ac4" style="background-color:coral">0.68</td>
+			<td headers="ar1 ar17 ar19 ac1 ac5" style="background-color:crimson; color: #FFF;">0.49</td>
+			<td headers="ar1 ar17 ar19 ac1 ac6" style="background-color:crimson; color: #FFF;">0.55</td>
+			<td headers="ar1 ar17 ar19 ac1 ac7" style="background-color:tomato">0.64</td>
+			<td headers="ar1 ar17 ar19 ac8 ac9" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar17 ar19 ac8 ac10" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar17 ar19 ac8 ac11" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar17 ar19 ac8 ac12" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar17 ar19 ac8 ac13" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar17 ar19 ac8 ac14" style="background-color:mediumseagreen">0.90</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar20" rowspan="2">Lakes</th>
+			<th headers="ar1 ar20" id="ar21">Dose 1</th>
+			<td headers="ar1 ar20 ar21 ac1 ac2" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar20 ar21 ac1 ac3" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar20 ar21 ac1 ac4" style="background-color:yellow">0.76</td>
+			<td headers="ar1 ar20 ar21 ac1 ac5" style="background-color:crimson; color: #FFF;">0.58</td>
+			<td headers="ar1 ar20 ar21 ac1 ac6" style="background-color:coral">0.65</td>
+			<td headers="ar1 ar20 ar21 ac1 ac7" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar20 ar21 ac8 ac9" style="background-color:green; color: #FFF;">1.06</td>
+			<td headers="ar1 ar20 ar21 ac8 ac10" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar20 ar21 ac8 ac11" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar20 ar21 ac8 ac12" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar20 ar21 ac8 ac13" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar20 ar21 ac8 ac14" style="background-color:mediumseagreen">0.90</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar20" id="ar22">Dose 2</th>
+			<td headers="ar1 ar20 ar22 ac1 ac2" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar20 ar22 ac1 ac3" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar20 ar22 ac1 ac4" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar20 ar22 ac1 ac5" style="background-color:crimson; color: #FFF;">0.44</td>
+			<td headers="ar1 ar20 ar22 ac1 ac6" style="background-color:crimson; color: #FFF;">0.53</td>
+			<td headers="ar1 ar20 ar22 ac1 ac7" style="background-color:tomato">0.61</td>
+			<td headers="ar1 ar20 ar22 ac8 ac9" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar20 ar22 ac8 ac10" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar20 ar22 ac8 ac11" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar20 ar22 ac8 ac12" style="background-color:palegreen">0.83</td>
+			<td headers="ar1 ar20 ar22 ac8 ac13" style="background-color:lightgreen">0.86</td>
+			<td headers="ar1 ar20 ar22 ac8 ac14" style="background-color:palegreen">0.83</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar23" rowspan="2">Taranaki</th>
+			<th headers="ar1 ar23" id="ar24">Dose 1</th>
+			<td headers="ar1 ar23 ar24 ac1 ac2" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar23 ar24 ac1 ac3" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar23 ar24 ac1 ac4" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar23 ar24 ac1 ac5" style="background-color:coral">0.68</td>
+			<td headers="ar1 ar23 ar24 ac1 ac6" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar23 ar24 ac1 ac7" style="background-color:yellow">0.77</td>
+			<td headers="ar1 ar23 ar24 ac8 ac9" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar23 ar24 ac8 ac10" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar23 ar24 ac8 ac11" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar23 ar24 ac8 ac12" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar23 ar24 ac8 ac13" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar23 ar24 ac8 ac14" style="background-color:mediumseagreen">0.94</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar23" id="ar25">Dose 2</th>
+			<td headers="ar1 ar23 ar25 ac1 ac2" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar23 ar25 ac1 ac3" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar23 ar25 ac1 ac4" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar23 ar25 ac1 ac5" style="background-color:crimson; color: #FFF;">0.52</td>
+			<td headers="ar1 ar23 ar25 ac1 ac6" style="background-color:crimson; color: #FFF;">0.56</td>
+			<td headers="ar1 ar23 ar25 ac1 ac7" style="background-color:tomato">0.64</td>
+			<td headers="ar1 ar23 ar25 ac8 ac9" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar23 ar25 ac8 ac10" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar23 ar25 ac8 ac11" style="background-color:green; color: #FFF;">1.21</td>
+			<td headers="ar1 ar23 ar25 ac8 ac12" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar23 ar25 ac8 ac13" style="background-color:lightgreen">0.87</td>
+			<td headers="ar1 ar23 ar25 ac8 ac14" style="background-color:lightgreen">0.89</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar26" rowspan="2">Whanganui</th>
+			<th headers="ar1 ar26" id="ar27">Dose 1</th>
+			<td headers="ar1 ar26 ar27 ac1 ac2" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar26 ar27 ac1 ac3" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar26 ar27 ac1 ac4" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar26 ar27 ac1 ac5" style="background-color:coral">0.65</td>
+			<td headers="ar1 ar26 ar27 ac1 ac6" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar26 ar27 ac1 ac7" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar26 ar27 ac8 ac9" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar26 ar27 ac8 ac10" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar26 ar27 ac8 ac11" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar26 ar27 ac8 ac12" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar26 ar27 ac8 ac13" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar26 ar27 ac8 ac14" style="background-color:lightgreen">0.87</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar26" id="ar28">Dose 2</th>
+			<td headers="ar1 ar26 ar28 ac1 ac2" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar26 ar28 ac1 ac3" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar26 ar28 ac1 ac4" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar26 ar28 ac1 ac5" style="background-color:crimson; color: #FFF;">0.51</td>
+			<td headers="ar1 ar26 ar28 ac1 ac6" style="background-color:tomato">0.60</td>
+			<td headers="ar1 ar26 ar28 ac1 ac7" style="background-color:coral">0.65</td>
+			<td headers="ar1 ar26 ar28 ac8 ac9" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar26 ar28 ac8 ac10" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar26 ar28 ac8 ac11" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar26 ar28 ac8 ac12" style="background-color:palegreen">0.83</td>
+			<td headers="ar1 ar26 ar28 ac8 ac13" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar26 ar28 ac8 ac14" style="background-color:palegreen">0.80</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar29" rowspan="2">Hawke&#39;s Bay</th>
+			<th headers="ar1 ar29" id="ar30">Dose 1</th>
+			<td headers="ar1 ar29 ar30 ac1 ac2" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar29 ar30 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar29 ar30 ac1 ac4" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar29 ar30 ac1 ac5" style="background-color:crimson; color: #FFF;">0.59</td>
+			<td headers="ar1 ar29 ar30 ac1 ac6" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar29 ar30 ac1 ac7" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar29 ar30 ac8 ac9" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar29 ar30 ac8 ac10" style="background-color:green; color: #FFF;">1.05</td>
+			<td headers="ar1 ar29 ar30 ac8 ac11" style="background-color:green; color: #FFF;">1.42</td>
+			<td headers="ar1 ar29 ar30 ac8 ac12" style="background-color:green; color: #FFF;">1.32</td>
+			<td headers="ar1 ar29 ar30 ac8 ac13" style="background-color:lightgreen">0.88</td>
+			<td headers="ar1 ar29 ar30 ac8 ac14" style="background-color:green; color: #FFF;">1.16</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar29" id="ar31">Dose 2</th>
+			<td headers="ar1 ar29 ar31 ac1 ac2" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar29 ar31 ac1 ac3" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar29 ar31 ac1 ac4" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar29 ar31 ac1 ac5" style="background-color:crimson; color: #FFF;">0.47</td>
+			<td headers="ar1 ar29 ar31 ac1 ac6" style="background-color:crimson; color: #FFF;">0.57</td>
+			<td headers="ar1 ar29 ar31 ac1 ac7" style="background-color:tomato">0.61</td>
+			<td headers="ar1 ar29 ar31 ac8 ac9" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar29 ar31 ac8 ac10" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar29 ar31 ac8 ac11" style="background-color:green; color: #FFF;">1.48</td>
+			<td headers="ar1 ar29 ar31 ac8 ac12" style="background-color:green; color: #FFF;">1.48</td>
+			<td headers="ar1 ar29 ar31 ac8 ac13" style="background-color:lightgreen">0.86</td>
+			<td headers="ar1 ar29 ar31 ac8 ac14" style="background-color:green; color: #FFF;">1.10</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar32" rowspan="2">MidCentral</th>
+			<th headers="ar1 ar32" id="ar33">Dose 1</th>
+			<td headers="ar1 ar32 ar33 ac1 ac2" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar32 ar33 ac1 ac3" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar32 ar33 ac1 ac4" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar32 ar33 ac1 ac5" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar32 ar33 ac1 ac6" style="background-color:orange">0.72</td>
+			<td headers="ar1 ar32 ar33 ac1 ac7" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar32 ar33 ac8 ac9" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar32 ar33 ac8 ac10" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar32 ar33 ac8 ac11" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar32 ar33 ac8 ac12" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar32 ar33 ac8 ac13" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar32 ar33 ac8 ac14" style="background-color:mediumseagreen">0.94</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar32" id="ar34">Dose 2</th>
+			<td headers="ar1 ar32 ar34 ac1 ac2" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar32 ar34 ac1 ac3" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar32 ar34 ac1 ac4" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar32 ar34 ac1 ac5" style="background-color:crimson; color: #FFF;">0.58</td>
+			<td headers="ar1 ar32 ar34 ac1 ac6" style="background-color:tomato">0.60</td>
+			<td headers="ar1 ar32 ar34 ac1 ac7" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar32 ar34 ac8 ac9" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar32 ar34 ac8 ac10" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar32 ar34 ac8 ac11" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar32 ar34 ac8 ac12" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar32 ar34 ac8 ac13" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar32 ar34 ac8 ac14" style="background-color:lightgreen">0.85</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar35" rowspan="2">Wairarapa</th>
+			<th headers="ar1 ar35" id="ar36">Dose 1</th>
+			<td headers="ar1 ar35 ar36 ac1 ac2" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar35 ar36 ac1 ac3" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar35 ar36 ac1 ac4" style="background-color:palegreen">0.84</td>
+			<td headers="ar1 ar35 ar36 ac1 ac5" style="background-color:orange">0.72</td>
+			<td headers="ar1 ar35 ar36 ac1 ac6" style="background-color:yellow">0.77</td>
+			<td headers="ar1 ar35 ar36 ac1 ac7" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar35 ar36 ac8 ac9" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar35 ar36 ac8 ac10" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar35 ar36 ac8 ac11" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar35 ar36 ac8 ac12" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar35 ar36 ac8 ac13" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar35 ar36 ac8 ac14" style="background-color:mediumseagreen">0.92</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar35" id="ar37">Dose 2</th>
+			<td headers="ar1 ar35 ar37 ac1 ac2" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar35 ar37 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar35 ar37 ac1 ac4" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar35 ar37 ac1 ac5" style="background-color:crimson; color: #FFF;">0.55</td>
+			<td headers="ar1 ar35 ar37 ac1 ac6" style="background-color:tomato">0.63</td>
+			<td headers="ar1 ar35 ar37 ac1 ac7" style="background-color:tomato">0.64</td>
+			<td headers="ar1 ar35 ar37 ac8 ac9" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar35 ar37 ac8 ac10" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar35 ar37 ac8 ac11" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar35 ar37 ac8 ac12" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar35 ar37 ac8 ac13" style="background-color:palegreen">0.84</td>
+			<td headers="ar1 ar35 ar37 ac8 ac14" style="background-color:lightgreen">0.86</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar38" rowspan="2">Capital &amp; Coast and Hutt Valley</th>
+			<th headers="ar1 ar38" id="ar39">Dose 1</th>
+			<td headers="ar1 ar38 ar39 ac1 ac2" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar38 ar39 ac1 ac3" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar38 ar39 ac1 ac4" style="background-color:palegreen">0.83</td>
+			<td headers="ar1 ar38 ar39 ac1 ac5" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar38 ar39 ac1 ac6" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar38 ar39 ac1 ac7" style="background-color:palegreen">0.81</td>
+			<td headers="ar1 ar38 ar39 ac8 ac9" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar38 ar39 ac8 ac10" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar38 ar39 ac8 ac11" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar38 ar39 ac8 ac12" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar38 ar39 ac8 ac13" style="background-color:palegreen">0.84</td>
+			<td headers="ar1 ar38 ar39 ac8 ac14" style="background-color:lightgreen">0.86</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar38" id="ar40">Dose 2</th>
+			<td headers="ar1 ar38 ar40 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar38 ar40 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar38 ar40 ac1 ac4" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar38 ar40 ac1 ac5" style="background-color:tomato">0.63</td>
+			<td headers="ar1 ar38 ar40 ac1 ac6" style="background-color:tomato">0.62</td>
+			<td headers="ar1 ar38 ar40 ac1 ac7" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar38 ar40 ac8 ac9" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar38 ar40 ac8 ac10" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar38 ar40 ac8 ac11" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar38 ar40 ac8 ac12" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar38 ar40 ac8 ac13" style="background-color:yellow">0.76</td>
+			<td headers="ar1 ar38 ar40 ac8 ac14" style="background-color:palegreen">0.80</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar41" rowspan="2">Nelson Marlborough</th>
+			<th headers="ar1 ar41" id="ar42">Dose 1</th>
+			<td headers="ar1 ar41 ar42 ac1 ac2" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar41 ar42 ac1 ac3" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar41 ar42 ac1 ac4" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar41 ar42 ac1 ac5" style="background-color:coral">0.69</td>
+			<td headers="ar1 ar41 ar42 ac1 ac6" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar41 ar42 ac1 ac7" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar41 ar42 ac8 ac9" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar41 ar42 ac8 ac10" style="background-color:green; color: #FFF;">1.28</td>
+			<td headers="ar1 ar41 ar42 ac8 ac11" style="background-color:green; color: #FFF;">2.45</td>
+			<td headers="ar1 ar41 ar42 ac8 ac12" style="background-color:green; color: #FFF;">2.89</td>
+			<td headers="ar1 ar41 ar42 ac8 ac13" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar41 ar42 ac8 ac14" style="background-color:green; color: #FFF;">1.97</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar41" id="ar43">Dose 2</th>
+			<td headers="ar1 ar41 ar43 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar41 ar43 ac1 ac3" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar41 ar43 ac1 ac4" style="background-color:orange">0.72</td>
+			<td headers="ar1 ar41 ar43 ac1 ac5" style="background-color:crimson; color: #FFF;">0.57</td>
+			<td headers="ar1 ar41 ar43 ac1 ac6" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar41 ar43 ac1 ac7" style="background-color:coral">0.69</td>
+			<td headers="ar1 ar41 ar43 ac8 ac9" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar41 ar43 ac8 ac10" style="background-color:green; color: #FFF;">1.26</td>
+			<td headers="ar1 ar41 ar43 ac8 ac11" style="background-color:green; color: #FFF;">2.57</td>
+			<td headers="ar1 ar41 ar43 ac8 ac12" style="background-color:green; color: #FFF;">3.47</td>
+			<td headers="ar1 ar41 ar43 ac8 ac13" style="background-color:green; color: #FFF;">1.05</td>
+			<td headers="ar1 ar41 ar43 ac8 ac14" style="background-color:green; color: #FFF;">1.95</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar44" rowspan="2">West Coast</th>
+			<th headers="ar1 ar44" id="ar45">Dose 1</th>
+			<td headers="ar1 ar44 ar45 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar44 ar45 ac1 ac3" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar44 ar45 ac1 ac4" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar44 ar45 ac1 ac5" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar44 ar45 ac1 ac6" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar44 ar45 ac1 ac7" style="background-color:lightgreen">0.86</td>
+			<td headers="ar1 ar44 ar45 ac8 ac9" style="background-color:green; color: #FFF;">1.33</td>
+			<td headers="ar1 ar44 ar45 ac8 ac10" style="background-color:green; color: #FFF;">1.06</td>
+			<td headers="ar1 ar44 ar45 ac8 ac11" style="background-color:green; color: #FFF;">1.07</td>
+			<td headers="ar1 ar44 ar45 ac8 ac12" style="background-color:green; color: #FFF;">1.24</td>
+			<td headers="ar1 ar44 ar45 ac8 ac13" style="background-color:palegreen">0.83</td>
+			<td headers="ar1 ar44 ar45 ac8 ac14" style="background-color:green; color: #FFF;">0.99</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar44" id="ar46">Dose 2</th>
+			<td headers="ar1 ar44 ar46 ac1 ac2" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar44 ar46 ac1 ac3" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar44 ar46 ac1 ac4" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar44 ar46 ac1 ac5" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar44 ar46 ac1 ac6" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar44 ar46 ac1 ac7" style="background-color:yellow">0.76</td>
+			<td headers="ar1 ar44 ar46 ac8 ac9" style="background-color:green; color: #FFF;">1.33</td>
+			<td headers="ar1 ar44 ar46 ac8 ac10" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar44 ar46 ac8 ac11" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar44 ar46 ac8 ac12" style="background-color:green; color: #FFF;">1.57</td>
+			<td headers="ar1 ar44 ar46 ac8 ac13" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar44 ar46 ac8 ac14" style="background-color:mediumseagreen">0.91</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar47" rowspan="2">Canterbury</th>
+			<th headers="ar1 ar47" id="ar48">Dose 1</th>
+			<td headers="ar1 ar47 ar48 ac1 ac2" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar47 ar48 ac1 ac3" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar47 ar48 ac1 ac4" style="background-color:palegreen">0.83</td>
+			<td headers="ar1 ar47 ar48 ac1 ac5" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar47 ar48 ac1 ac6" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar47 ar48 ac1 ac7" style="background-color:palegreen">0.81</td>
+			<td headers="ar1 ar47 ar48 ac8 ac9" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar47 ar48 ac8 ac10" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar47 ar48 ac8 ac11" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar47 ar48 ac8 ac12" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar47 ar48 ac8 ac13" style="background-color:lightgreen">0.88</td>
+			<td headers="ar1 ar47 ar48 ac8 ac14" style="background-color:lightgreen">0.89</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar47" id="ar49">Dose 2</th>
+			<td headers="ar1 ar47 ar49 ac1 ac2" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar47 ar49 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar47 ar49 ac1 ac4" style="background-color:yellow">0.77</td>
+			<td headers="ar1 ar47 ar49 ac1 ac5" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar47 ar49 ac1 ac6" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar47 ar49 ac1 ac7" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar47 ar49 ac8 ac9" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar47 ar49 ac8 ac10" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar47 ar49 ac8 ac11" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar47 ar49 ac8 ac12" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar47 ar49 ac8 ac13" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar47 ar49 ac8 ac14" style="background-color:lightgreen">0.85</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar50" rowspan="2">South Canterbury</th>
+			<th headers="ar1 ar50" id="ar51">Dose 1</th>
+			<td headers="ar1 ar50 ar51 ac1 ac2" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar50 ar51 ac1 ac3" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar50 ar51 ac1 ac4" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar50 ar51 ac1 ac5" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar50 ar51 ac1 ac6" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar50 ar51 ac1 ac7" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar50 ar51 ac8 ac9" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar50 ar51 ac8 ac10" style="background-color:green; color: #FFF;">1.09</td>
+			<td headers="ar1 ar50 ar51 ac8 ac11" style="background-color:green; color: #FFF;">1.18</td>
+			<td headers="ar1 ar50 ar51 ac8 ac12" style="background-color:green; color: #FFF;">1.23</td>
+			<td headers="ar1 ar50 ar51 ac8 ac13" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar50 ar51 ac8 ac14" style="background-color:green; color: #FFF;">1.06</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar50" id="ar52">Dose 2</th>
+			<td headers="ar1 ar50 ar52 ac1 ac2" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar50 ar52 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar50 ar52 ac1 ac4" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar50 ar52 ac1 ac5" style="background-color:tomato">0.63</td>
+			<td headers="ar1 ar50 ar52 ac1 ac6" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar50 ar52 ac1 ac7" style="background-color:coral">0.69</td>
+			<td headers="ar1 ar50 ar52 ac8 ac9" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar50 ar52 ac8 ac10" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar50 ar52 ac8 ac11" style="background-color:green; color: #FFF;">1.09</td>
+			<td headers="ar1 ar50 ar52 ac8 ac12" style="background-color:green; color: #FFF;">1.15</td>
+			<td headers="ar1 ar50 ar52 ac8 ac13" style="background-color:green; color: #FFF;">1.05</td>
+			<td headers="ar1 ar50 ar52 ac8 ac14" style="background-color:lightgreen">0.89</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar53" rowspan="2">Southern</th>
+			<th headers="ar1 ar53" id="ar54">Dose 1</th>
+			<td headers="ar1 ar53 ar54 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar53 ar54 ac1 ac3" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar53 ar54 ac1 ac4" style="background-color:palegreen">0.83</td>
+			<td headers="ar1 ar53 ar54 ac1 ac5" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar53 ar54 ac1 ac6" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar53 ar54 ac1 ac7" style="background-color:palegreen">0.81</td>
+			<td headers="ar1 ar53 ar54 ac8 ac9" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar53 ar54 ac8 ac10" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar53 ar54 ac8 ac11" style="background-color:green; color: #FFF;">1.07</td>
+			<td headers="ar1 ar53 ar54 ac8 ac12" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar53 ar54 ac8 ac13" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar53 ar54 ac8 ac14" style="background-color:green; color: #FFF;">1.01</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar53" id="ar55">Dose 2</th>
+			<td headers="ar1 ar53 ar55 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar53 ar55 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar53 ar55 ac1 ac4" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar53 ar55 ac1 ac5" style="background-color:coral">0.66</td>
+			<td headers="ar1 ar53 ar55 ac1 ac6" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar53 ar55 ac1 ac7" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar53 ar55 ac8 ac9" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar53 ar55 ac8 ac10" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar53 ar55 ac8 ac11" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar53 ar55 ac8 ac12" style="background-color:green; color: #FFF;">1.05</td>
+			<td headers="ar1 ar53 ar55 ac8 ac13" style="background-color:lightgreen">0.87</td>
+			<td headers="ar1 ar53 ar55 ac8 ac14" style="background-color:mediumseagreen">0.93</td>
+		</tr>
+	</tbody>
+</table>
+
+<p>This table shows the rate of doses administered (per 1,000 population) to Māori or Pacific Peoples, relative to the rate of doses for Non-Māori and Non-Pacific groups. Less than one means the group is receiving a lower proportion of doses than would be expected if equity is being achieved. More than one means they are receiving a higher proportion of doses than would be expected if equity is being achieved. Exactly one means doses administered are in line with their proportion of population.</p>
+
+<ul>
+	<li><a download="" href="/web/20211030111302/https://www.health.govt.nz/system/files/documents/pages/rateratioexplainer_2.docx">Rate Ratio Explainer (Word, 434 KB)</a></li>
+</ul>
+
+<p>At all ages the size (weightings) of the age groups becomes a major contributing factor to comparative ratios, which is why the all ages (12+) figure may not appear to be in line with the age splits.</p>
+
+<h4><a id="uptake" name="uptake"></a>Vaccine uptake per 1,000 people by ethnicity</h4>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine uptake per 1,000 people by ethnicity" class="img-responsive" height="830" src="/web/20211030111302im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_eth_8.png" width="1780"/></figure>
+
+<h4><a id="uptake" name="uptake"></a>Vaccine uptake per 1,000 people by age band</h4>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine uptake per 1,000 people by age band" class="img-responsive" height="1030" src="/web/20211030111302im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_age_9.png" width="1780"/></figure>
+
+<h4><a id="uptake" name="location"></a>Vaccine uptake per 1,000 people by DHB of residence</h4>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine uptake per 1,000 people by DHB of residence" class="img-responsive" height="1030" src="/web/20211030111302im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_dhb_4.png" width="1780"/></figure>
+<!--
+<hr />
+<h3><a id="by_dhb_plan" name="dhb_plan"></a>Cumulative vaccination plan for DHBs</h3>
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">DHB of service</th>
+			<th scope="col" style="text-align:right">Actuals to Sunday 24 October</th>
+			<th scope="col" style="text-align:right">DHB Plan to Sunday 24 October</th>
+			<th scope="col" style="text-align:right">Variance</th>
+			<th scope="col" style="text-align:right">% of Plan</th>
+			<th scope="col" style="text-align:right">Week to date</th>
+		</tr>
+	</thead>
+	<tbody> --><!--plan--><!--
+<tr><td nowrap="nowrap">Auckland Metro</td><td>190621</td><td>205515</td><td>-14894</td><td>93%</td><td>9913</td></tr>
+<tr><td nowrap="nowrap">Bay of Plenty</td><td>22841</td><td>14255</td><td>8586</td><td>160%</td><td>1843</td></tr>
+<tr><td nowrap="nowrap">Canterbury</td><td>50558</td><td>39266</td><td>11292</td><td>129%</td><td>2769</td></tr>
+<tr><td nowrap="nowrap">Capital & Coast and Hutt Valley</td><td>48758</td><td>39742</td><td>9016</td><td>123%</td><td>1796</td></tr>
+<tr><td nowrap="nowrap">Hawke's Bay</td><td>15319</td><td>18205</td><td>-2886</td><td>84%</td><td>1351</td></tr>
+<tr><td nowrap="nowrap">Lakes</td><td>13437</td><td>12810</td><td>627</td><td>105%</td><td>731</td></tr>
+<tr><td nowrap="nowrap">MidCentral</td><td>10708</td><td>7237</td><td>3471</td><td>148%</td><td>1191</td></tr>
+<tr><td nowrap="nowrap">Nelson Marlborough</td><td>30198</td><td>18574</td><td>11624</td><td>163%</td><td>1285</td></tr>
+<tr><td nowrap="nowrap">Northland</td><td>21469</td><td>24762</td><td>-3293</td><td>87%</td><td>1257</td></tr>
+<tr><td nowrap="nowrap">South Canterbury</td><td>8106</td><td>8033</td><td>73</td><td>101%</td><td>389</td></tr>
+<tr><td nowrap="nowrap">Southern</td><td>35234</td><td>34594</td><td>640</td><td>102%</td><td>1794</td></tr>
+<tr><td nowrap="nowrap">Tairāwhiti</td><td>4579</td><td>4928</td><td>-349</td><td>93%</td><td>290</td></tr>
+<tr><td nowrap="nowrap">Taranaki</td><td>5619</td><td>5297</td><td>322</td><td>106%</td><td>168</td></tr>
+<tr><td nowrap="nowrap">Waikato</td><td>36070</td><td>32842</td><td>3228</td><td>110%</td><td>1905</td></tr>
+<tr><td nowrap="nowrap">Wairarapa</td><td>4516</td><td>4960</td><td>-444</td><td>91%</td><td>468</td></tr>
+<tr><td nowrap="nowrap">West Coast</td><td>3533</td><td>3300</td><td>233</td><td>107%</td><td>336</td></tr>
+<tr><td nowrap="nowrap">Whanganui</td><td>6982</td><td>4711</td><td>2271</td><td>148%</td><td>612</td></tr>
+<tr><td nowrap="nowrap">Other Sites</td><td>24890</td><td>14575</td><td>10315</td><td>171%</td><td>613</td></tr>
+<tr><td nowrap="nowrap">Total</td><td>533438</td><td>493606</td><td>39832</td><td>108%</td><td>28711</td></tr>
+!--plan_end--><!--	</tbody>
+</table>
+
+
+<p>The information provided in this table is based on cumulative DHB plans to the last week ending on Sunday. The final column shows vaccinations administered since Sunday by DHB of service to reconcile total actuals in this table to other total numbers shown.   On-going, and as we roll-out the vaccination programme, we anticipate that there could be a potential variance of up to ten percent (plus or minus) between DHB Plans and actual vaccination numbers. This is on the basis that, for example, an unplanned significant event could affect roll-out implementation or some DHBs might exceed their planned vaccination numbers.
+</p>
+-->
+
+<hr/>
+<h3><a id="by_dhb" name="location"></a>Cumulative vaccinations by DHB</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Cumulative vaccinations for DHBs" class="img-responsive" height="830" src="/web/20211030111302im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/dhbstacked_12.png" width="1780"/></figure>
+
+<hr/>
+<h3><a id="by-day" name="by-day"></a>Vaccinations by day</h3>
+
+<figure class="image-captioned img-responsive"><img alt="Vaccination doses administered per day" class="img-responsive" height="830" src="/web/20211030111302im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/vaccinebyday_12.png" width="1780"/></figure>
+
+<p>This chart shows the count of vaccinations administered on a given day from the COVID-19 Immunisation Register. Note some records are entered in the register at a later date than the immunisation was received. This means that the figures for a given date may move for some time after that date.</p>
+
+<hr/>
+<h3><a id="group" name="group"></a>Vaccinations by group by week</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccinations by group" class="img-responsive" height="830" src="/web/20211030111302im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/vaccinebygroupwk_12.png" width="1780"/></figure>
+
+<hr/>
+<h3><a id="group_d" name="group_d"></a>Cumulative vaccinations by group</h3>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">Priority Group</th>
+			<th scope="col" style="text-align:right">First dose administered</th>
+			<th scope="col" style="text-align:right">Second dose administered</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">Group 1</th>
+			<td style="text-align:right">66,767</td>
+			<td style="text-align:right">65,205</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Group 2</th>
+			<td style="text-align:right">661,231</td>
+			<td style="text-align:right">621,689</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Group 3</th>
+			<td style="text-align:right">793,481</td>
+			<td style="text-align:right">746,741</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Group 4</th>
+			<td style="text-align:right">2,136,491</td>
+			<td style="text-align:right">1,585,195</td>
+		</tr>
+	</tbody>
+</table>
+
+<p>For definitions of the groups and further detail see the downloadable spreadsheet at the bottom of the page.</p>
+
+<hr/>
+<h3><a id="by_soh" name="stockonhand"></a>Vaccine available for distribution at week end</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine available for distribution at week end" class="img-responsive" height="830" src="/web/20211030111302im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/stockonhand_13.png" width="1780"/></figure>
+
+<p>Vaccine available for distribution is stock (in doses) held at central warehouses. It does not include stock in transit or available at sites ready for use.</p>
+
+<hr/>
+<h3><a id="by_eth" name="ethnicity"></a>Total cumulative doses per 1,000 people by ethnicity</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Total cumulative doses per 1,000 people by ethnicity" class="img-responsive" height="830" src="/web/20211030111302im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/ethnicity_12.png" width="1780"/></figure>
+
+<p>This chart shows both first and second doses. As a result this chart may exceed 1,000 doses per 1,000 people.</p>
+
+<p><strong>*</strong> The prioritised ethnicity classification system allocates each person to a single ethnic group, based on the ethnic groups they identify with. Where people identify with more than one group, they are assigned in this order of priority: Māori, Pacific Peoples, Asian, and European/Other. So, if a person identifies as being Māori and New Zealand European, the person is counted as Māori. See <a href="/web/20211030111302/https://www.health.govt.nz/publication/hiso-100012017-ethnicity-data-protocols">Ethnicity Data Protocols</a> for further information.</p>
+
+<p>Ethnicity breakdown by DHB of residence is available in the downloadable spreadsheet at the bottom of the page.</p>
+
+<hr/>
+<h3><a id="by_age" name="age"></a>Cumulative vaccinations by age</h3>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">Age</th>
+			<th scope="col" style="text-align:right">First dose administered</th>
+			<th scope="col" style="text-align:right">First doses per 1,000 people</th>
+			<th scope="col" style="text-align:right">Fully vaccinated</th>
+			<th scope="col" style="text-align:right">Fully vaccinated per 1,000 people</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">12 - 19 years</th>
+			<td style="text-align:right">403,029</td>
+			<td style="text-align:right">802</td>
+			<td style="text-align:right">279,575</td>
+			<td style="text-align:right">557</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">20 - 34 years</th>
+			<td style="text-align:right">845,409</td>
+			<td style="text-align:right">817</td>
+			<td style="text-align:right">604,676</td>
+			<td style="text-align:right">585</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">35 - 49 years</th>
+			<td style="text-align:right">824,175</td>
+			<td style="text-align:right">862</td>
+			<td style="text-align:right">670,851</td>
+			<td style="text-align:right">701</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">50 - 64 years</th>
+			<td style="text-align:right">836,170</td>
+			<td style="text-align:right">901</td>
+			<td style="text-align:right">749,933</td>
+			<td style="text-align:right">809</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">65 and over</th>
+			<td style="text-align:right">749,187</td>
+			<td style="text-align:right">950</td>
+			<td style="text-align:right">713,795</td>
+			<td style="text-align:right">905</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total</strong></th>
+			<td style="text-align:right"><strong>3,657,970</strong></td>
+			<td style="text-align:right"><strong>869</strong></td>
+			<td style="text-align:right"><strong>3,018,830</strong></td>
+			<td style="text-align:right"><strong>717</strong></td>
+		</tr>
+	</tbody>
+</table>
+
+<p>Age breakdown by ethnicity and gender is available in the downloadable spreadsheet at the bottom of the page.</p>
+
+<hr/>
+<h3><a id="workforce" name="workforce"></a>Trained vaccinators and active vaccinators</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Trained vaccinators and active vaccinators" class="img-responsive" height="830" src="/web/20211030111302im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/workforce_12.png" width="1780"/></figure>
+
+<p><strong>Trained vaccinators</strong> are individuals who have completed the COVID-19 training. Many trained people are only able to offer a small number of hours to the COVID-19 vaccination programme.</p>
+
+<p><strong>Active vaccinators</strong> are trained individuals who are actively vaccinating. The number of active vaccinators does not reflect the hours worked vaccinating. For example, one vaccinator may work 40 hours in a week at one DHB and will show as 1 vaccinator in the headcount. In another DHB, 4 vaccinators may work 10 hours each (total 40 hours), but will show as 4 vaccinators in the headcount for that week.</p>
+
+<p>Both counts of trained and active vaccinators are cumulative. The difference between the two is due to a number of factors. This includes: individuals being trained in anticipation of future sites being opened (the largest factor); rostering; leave or non-availability; local health priorities; sites opening and closing.</p>
+
+<hr/>
+<h3><a id="usage" name="usage"></a>Wastage of vaccine stock</h3>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">&nbsp;</th>
+			<th scope="col">Wastage</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">New Zealand</th>
+			<td>0.29%</td>
+		</tr>
+	</tbody>
+</table>
+
+<p>Wastage is vials that have been reported as wasted since 13 July in the Inventory portal by DHBs or central warehouses divided by vials used over the same time frame.</p>
+
+<h3><a id="download" name="download"></a>Details of vaccination data</h3>
+
+<p>Download a spreadsheet containing key vaccination data. This includes HSU based population estimates for calculating vaccine uptake rates.</p>
+
+<p><a download="" href="/web/20211030111302/https://www.health.govt.nz/system/files/documents/pages/covid_vaccinations_26_10_2021.xlsx">COVID-19 vaccination data through 26 Oct 2021 (Excel, 363 KB)</a></p>
+
+<p>This spreadsheet is based on the information made available at the time of publishing and may be subject to changes. Please take note of any notes and caveats on each sheet.</p>
+
+<p>The below attachments provide some analysis on our progress on equity. The two PDF files are high level summaries of overall progress. The Excel documents are interactive and provides the ability to delve further into those overall numbers. NB: These Excel workbooks use features that are non-compatible with versions of MS Office 2016 and earlier.</p>
+
+<ul>
+	<li><a download="" href="/web/20211030111302/https://www.health.govt.nz/system/files/documents/pages/211024_-_cvip_equity_-_rate_ratios_by_ethnicity_ageband_and_dhb.pdf">Covid-19 Vaccine Rate Ratios by Ethnicity, Ageband and DHB (PDF, 642 KB)</a></li>
+	<li><a download="" href="/web/20211030111302/https://www.health.govt.nz/system/files/documents/pages/211024_-_cvip_equity_-_uptake_by_ethnicity_ageband_and_dhb.pdf">Covid-19 Vaccine Uptake by Ethnicity, Ageband and DHB (PDF, 550 KB)</a></li>
+	<li><a download="" href="/web/20211030111302/https://www.health.govt.nz/system/files/documents/pages/211024_-_cvip_equity_-_level_1_ethnicity_uptake_and_rate_ratios.xlsx">Covid-19 Vaccine Equity - Level 1 Ethnicity Uptake and Rate Ratios (Excel, 152 KB)</a></li>
+	<li><a download="" href="/web/20211030111302/https://www.health.govt.nz/system/files/documents/pages/211024_-_cvip_equity_-_level_2_ethnicity_uptake_and_rate_ratios.xlsx">Covid-19 Vaccine Equity - Level 2 Ethnicity Uptake and Rate Ratios (Excel, 378 KB)</a></li>
+	<li><a download="" href="/web/20211030111302/https://www.health.govt.nz/system/files/documents/pages/211024_-_cvip_equity_-_rate_ratios_and_uptake_over_time.xlsx">Rate Ratios and Uptake Over Time (Excel, 996 KB)</a></li>
+</ul>
+
+<hr/>
+<h3><a id="adverse-events" name="adverse-events"></a>Adverse events following&nbsp;immunisations (AEFI)</h3>
+
+<p>Like all medicines, the COVID-19 vaccine may cause side effects in some people. These are common, are usually mild, don&rsquo;t last long and won&rsquo;t stop people from having the second dose or going about daily life. Serious allergic reactions do occur but are extremely rare.</p>
+
+<p>Suspected AEFI to COVID-19 vaccines are reported to the <a href="https://web.archive.org/web/20211030111302/https://nzphvc.otago.ac.nz/">Centre for Adverse Reactions Monitoring</a> (CARM).&nbsp;<a href="https://web.archive.org/web/20211030111302/https://www.medsafe.govt.nz/">Medsafe</a> is closely monitoring the AEFI reported from the use of the COVID-19 vaccine and will report regularly on their findings.&nbsp;</p>
+
+<p><a href="https://web.archive.org/web/20211030111302/https://www.medsafe.govt.nz/COVID-19/vaccine-report-overview.asp">View Medsafe data on COVID-19 vaccine adverse effects following immunisation</a></p>
+</div></div></div>    </article>
+  </div>
+
+
+  </div>
+<div class="panel-pane pane-node-links even">
+
+
+
+  <div class="pane-content">
+          </div>
+
+
+  </div>
+
+<div class="panel-pane pane-views pane-sub-pages even">
+
+        <h2 class="pane-title h3">In this section</h2>
+
+
+  <div class="pane-content">
+        <div class="view view-sub-pages view-id-sub_pages view-display-id-block view-dom-id-bd31809127d923acac2e34f7d5c186bb">
+
+
+
+      <div class="view-content">
+      <div class="item-list">    <ul>          <li class="views-row views-row-1 views-row-odd views-row-first">
+  <div class="views-field views-field-title">        <div class="field-content">
+<div class="views-field views-field-title">
+  <h3 class="field-content">
+    <a href="/web/20211030111302/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-across-nz">COVID-19 Vaccination uptake rates across NZ</a>  </h3>
+</div></div>  </div>
+  <span class="views-field views-field-body">        <span class="field-content">This page provides information related to uptake rates of the COVID-19 vaccine across the country.
+</span>  </span>
+  <span class="views-field views-field-view-node">        <span class="field-content"><a href="/web/20211030111302/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-across-nz">Read more</a></span>  </span></li>
+          <li class="views-row views-row-2 views-row-even">
+  <div class="views-field views-field-title">        <div class="field-content">
+<div class="views-field views-field-title">
+  <h3 class="field-content">
+    <a href="/web/20211030111302/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-maori-communities-across-nz">COVID-19 Vaccination uptake rates within Māori communities across NZ</a>  </h3>
+</div></div>  </div>
+  <span class="views-field views-field-body">        <span class="field-content">This page provides information related to uptake rates of the COVID-19 vaccine within Māori communities across New Zealand.
+</span>  </span>
+  <span class="views-field views-field-view-node">        <span class="field-content"><a href="/web/20211030111302/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-maori-communities-across-nz">Read more</a></span>  </span></li>
+          <li class="views-row views-row-3 views-row-odd views-row-last">
+  <div class="views-field views-field-title">        <div class="field-content">
+<div class="views-field views-field-title">
+  <h3 class="field-content">
+    <a href="/web/20211030111302/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-pacific-communities-across-nz">COVID-19 Vaccination uptake rates within Pacific communities across NZ</a>  </h3>
+</div></div>  </div>
+  <span class="views-field views-field-body">        <span class="field-content">This page provides information related to uptake rates of the COVID-19 vaccine within Pacific communities across New Zealand.
+</span>  </span>
+  <span class="views-field views-field-view-node">        <span class="field-content"><a href="/web/20211030111302/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-pacific-communities-across-nz">Read more</a></span>  </span></li>
+      </ul></div>    </div>
+
+
+
+
+
+
+</div>  </div>
+
+
+  </div>
+</div>          </div>
+
+  </div>
+
+</section>
+  </div>
+      </section>
+
+
+    </div>
+    <div id="content-footer-wrapper" class="clearfix">
+      <div id="content-footer" class="clearfix">
+                  <p class="page_updated">Page last updated: <span class="date">30 October 2021</span></p>                  <div class="region region-content-footer">
+    <section id="block-moh-tools-page-tools" class="block block-moh-tools clearfix">
+  <a href="#" data-placement="top" data-title="Share this content." data-html="true" data-content="<p>Share this page on some of the most popular social networking and content sites on the internet.</p><div class='service-links'><ul><li><a href='https://twitter.com/share?url=https%3A//www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data&amp;text=COVID-19%3A%20Vaccine%20data' title='Share this on Twitter' class='service-links-twitter' rel='nofollow'><img typeof='foaf:Image' class='img-responsive' src='https://www.health.govt.nz/sites/all/modules/contrib/service_links/images/twitter.png' alt='Twitter' /> Twitter</a></li>
+<li><a href='https://www.facebook.com/sharer.php?u=https%3A//www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data&amp;t=COVID-19%3A%20Vaccine%20data' title='Share on Facebook' class='service-links-facebook' rel='nofollow'><img typeof='foaf:Image' class='img-responsive' src='https://www.health.govt.nz/sites/all/modules/contrib/service_links/images/facebook.png' alt='Facebook' /> Facebook</a></li>
+</ul></div>" class="share-this-content"><i class="fa fa-share"></i> Share</a><a href="#" title="print this page" class="print"><i class="fa fa-print"></i> Print</a><a href="https://web.archive.org/web/20211030111302/https://www.health.govt.nz/forward?path=node/12052" title="Email this page" class="email"><i class="fa fa-envelope"></i> Email</a><a href="/web/20211030111302/https://www.health.govt.nz/feedback?ref=https%3A//www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="Feedback" class="rss"><i class="fa fa-comment"></i> Feedback</a></section>
+
+  </div>
+      </div>
+    </div>
+
+  </div>
+  <footer class="footer container">
+    <h2 class="hidden">Site Footer</h2>
+    <div class="footer-default">
+      <div class="row">
+        <div class="col-sm-6 col-md-6">
+          <div class="field field-name-field-tax-first-column-links">
+            <ul class="field-items"><li class="field-item"><a href="https://web.archive.org/web/20211030111302/https://www.health.govt.nz/node/492" class="">About this site</a></li><li class="field-item"><a href="https://web.archive.org/web/20211030111302/https://www.health.govt.nz/node/524" class="">Contact us</a></li><li class="field-item"><a href="https://web.archive.org/web/20211030111302/https://www.health.govt.nz/node/488" class="">Other Ministry of Health websites</a></li><li class="field-item"><a href="https://web.archive.org/web/20211030111302/https://www.health.govt.nz/node/7497" class="">Official Information Act requests</a></li><li class="field-item"><a href="https://web.archive.org/web/20211030111302/https://www.health.govt.nz/about-ministry/information-releases" class="">Information releases</a></li><li class="field-item"><a href="https://web.archive.org/web/20211030111302/https://consult.health.govt.nz/" class="">Consultations</a></li></ul>
+          </div>
+        </div>
+        <div class="col-sm-6 col-md-6">
+          <div class="field field-name-field-tax-footer-body field-type-text-long field-label-hidden"><div class="field-items"><div class="field-item even"><h3>Where to go for help</h3>
+
+<table>
+	<tbody>
+		<tr>
+			<th scope="row">Emergencies</th>
+			<td><strong>Dial <a href="tel:111">111</a></strong> (for ambulance, fire or police)</td>
+		</tr>
+		<tr>
+			<th scope="row">Healthline</th>
+			<td><strong>Dial <a href="tel:0800611116">0800 611 116</a></strong></td>
+		</tr>
+		<tr>
+			<th scope="row">Poisons</th>
+			<td><strong>Dial <a href="tel:0800764766">0800 POISON</a> </strong>(<a href="tel:0800764766">0800 764 766</a>)</td>
+		</tr>
+		<tr>
+			<th scope="row">Mental health crisis</th>
+			<td><strong><a href="/web/20211030111302/https://www.health.govt.nz/your-health/services-and-support/health-care-services/mental-health-services/crisis-assessment-teams">Emergency contact numbers</a></strong></td>
+		</tr>
+	</tbody>
+</table>
+</div></div></div>        </div>
+      </div>
+      <div class="row">
+        <div class="sub-footer">
+          <div class="column col-sm-12 col-md-3">
+            <a href="https://web.archive.org/web/20211030111302/https://www.govt.nz/">
+              <img src="/web/20211030111302im_/https://www.health.govt.nz/sites/all/themes/mohpub_bootstrap/images/nzgovtlogo_white.png" width="152" height="16" alt="govt.nz - connecting you to New Zealand central &amp; local government services" title="govt.nz - connecting you to New Zealand central &amp; local government services"/>
+            </a>
+          </div>
+          <div class="column col-sm-12 col-md-9">
+          <span class="bottom-menu-moh with-v-divider">&copy; Ministry of Health – Manatū Hauora</span><ul class="bottom-menu-list"><li class="bottom-menu-list-item with-v-divider"><a href="https://web.archive.org/web/20211030111302/https://www.health.govt.nz/sitemap" class="">Site map</a></li><li class="bottom-menu-list-item with-v-divider"><a href="https://web.archive.org/web/20211030111302/https://www.health.govt.nz/about-site/privacy-and-security" class="">Privacy &amp; security</a></li><li class="bottom-menu-list-item with-v-divider"><a href="https://web.archive.org/web/20211030111302/https://www.health.govt.nz/about-site/copyright" class="">Copyright</a></li></ul>          </div>
+        </div>
+      </div>
+    </div>
+    <div class="footer-print">&copy; Ministry of Health – Manatū Hauora</div>
+  </footer>
+  <a class="scrollToTop">Back to top <i class="fas fa-arrow-up"></i></a>
+</div>
+  <script src="https://web.archive.org/web/20211030111302js_/https://www.health.govt.nz/sites/default/files/js/js_akZOsKtodu3PdnQzY3_ElOfujkLxJcowmaWgHTBBLOE.js"></script>
+</body>
+</html>
+<!--
+     FILE ARCHIVED ON 11:13:02 Oct 30, 2021 AND RETRIEVED FROM THE
+     INTERNET ARCHIVE ON 03:16:31 Nov 07, 2021.
+     JAVASCRIPT APPENDED BY WAYBACK MACHINE, COPYRIGHT INTERNET ARCHIVE.
+
+     ALL OTHER CONTENT MAY ALSO BE PROTECTED BY COPYRIGHT (17 U.S.C.
+     SECTION 108(a)(3)).
+-->
+<!--
+playback timings (ms):
+  captures_list: 117.013
+  exclusion.robots: 0.232
+  exclusion.robots.policy: 0.223
+  RedisCDXSource: 0.48
+  esindex: 0.008
+  LoadShardBlock: 76.683 (3)
+  PetaboxLoader3.datanode: 65.751 (4)
+  CDXLines.iter: 28.518 (3)
+  load_resource: 274.521
+  PetaboxLoader3.resolve: 40.477
+-->

--- a/data/rawSite/2021-10-30.html
+++ b/data/rawSite/2021-10-30.html
@@ -1,0 +1,2523 @@
+
+<!DOCTYPE html>
+<html lang="en" dir="ltr" prefix="" class="no-js">
+<head><script src="//archive.org/includes/analytics.js?v=cf34f82" type="text/javascript"></script>
+<script type="text/javascript">window.addEventListener('DOMContentLoaded',function(){var v=archive_analytics.values;v.service='wb';v.server_name='wwwb-app202.us.archive.org';v.server_ms=376;archive_analytics.send_pageview({});});</script>
+<script type="text/javascript" src="/_static/js/bundle-playback.js?v=UfTkgsKx" charset="utf-8"></script>
+<script type="text/javascript" src="/_static/js/wombat.js?v=UHAOicsW" charset="utf-8"></script>
+<script type="text/javascript">
+  __wm.init("https://web.archive.org/web");
+  __wm.wombat("https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data","20211031120029","https://web.archive.org/","web","/_static/",
+	      "1635681629");
+</script>
+<link rel="stylesheet" type="text/css" href="/_static/css/banner-styles.css?v=omkqRugM" />
+<link rel="stylesheet" type="text/css" href="/_static/css/iconochive.css?v=qtvMKcIJ" />
+<!-- End Wayback Rewrite JS Include -->
+
+  <!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta name="format-detection" content="telephone=no"/>
+  <link rel="profile" href="http://www.w3.org/1999/xhtml/vocab"/>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+<link rel="shortcut icon" href="https://web.archive.org/web/20211031120029im_/https://www.health.govt.nz/sites/all/themes/mohpub_bootstrap/favicon.ico" type="image/vnd.microsoft.icon"/>
+<meta name="description" content="Dashboard of data and statistics about the rollout of COVID-19 vaccines in New Zealand"/>
+<meta name="generator" content="Drupal 7 (https://www.drupal.org)"/>
+<link rel="canonical" href="https://web.archive.org/web/20211031120029/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data"/>
+<link rel="shortlink" href="https://web.archive.org/web/20211031120029/https://www.health.govt.nz/node/12052"/>
+<meta property="og:site_name" content="Ministry of Health NZ"/>
+<meta property="og:type" content="article"/>
+<meta property="og:url" content="https://web.archive.org/web/20211031120029/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data"/>
+<meta property="og:title" content="COVID-19: Vaccine data"/>
+<meta property="og:description" content="Dashboard of data and statistics about the rollout of COVID-19 vaccines in New Zealand"/>
+  <title>COVID-19: Vaccine data | Ministry of Health NZ</title>
+  <link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211031120029cs_/https://www.health.govt.nz/sites/default/files/css/css_lQaZfjVpwP_oGNqdtWCSpJT1EMqXdMiU84ekLLxQnc4.css" media="all"/>
+<link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211031120029cs_/https://www.health.govt.nz/sites/default/files/css/css_jqUBpWfMaxMiP7LismdZVlyVv8azUJSE2yaH58nj0cE.css" media="all"/>
+<link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211031120029cs_/https://www.health.govt.nz/sites/default/files/css/css_Rb1wqFBC8VXCJC-BuNY53cvjjlj6UADGvqzo_f-1yN0.css" media="all"/>
+<link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211031120029cs_/https://www.health.govt.nz/sites/default/files/css/css_38_K1lHKg-98m4KKRfv57JBK0gvlKscexGt9MKoi0DE.css" media="all"/>
+<link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211031120029cs_/https://www.health.govt.nz/sites/default/files/css/css_r7NPyvpdYfAyZmk9zkK8OaFKEFj6er5ZJnam2H644DM.css" media="print"/>
+  <link rel="alternate stylesheet" type="text/css" href="/web/20211031120029cs_/https://www.health.govt.nz/sites/all/themes/mohpub_bootstrap/css/high-contrast.css" media="screen" title="High Contrast"/>
+  <script src="https://web.archive.org/web/20211031120029js_/https://www.health.govt.nz/sites/default/files/js/js_zS-CmNFGyegtLYJmqFRpxQvvQrfPIFrOMq_3T3C8sZE.js"></script>
+<script src="https://web.archive.org/web/20211031120029js_/https://www.health.govt.nz/sites/default/files/js/js_fNgZ4Okisfr70Q0yvAYsATgB0o_jD3-srhQQ-VHmlXE.js"></script>
+<script src="https://web.archive.org/web/20211031120029js_/https://www.health.govt.nz/sites/default/files/js/js_YAdPZfg12M1m7ROp3_gVJPS5sArqL0kYQgNRPoicvHE.js"></script>
+<script>(function(i,s,o,g,r,a,m){i["GoogleAnalyticsObject"]=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,"script","https://web.archive.org/web/20211031120029/https://www.google-analytics.com/analytics.js","ga");ga("create", "UA-3573389-24", {"cookieDomain":".www.health.govt.nz","siteSpeedSampleRate":15});ga("send", "pageview");</script>
+<script src="https://web.archive.org/web/20211031120029js_/https://www.health.govt.nz/sites/default/files/js/js_QAXZNPwLISRLHqyNpT4Vvr_iqD9foD6GTbEjlhIIjeo.js"></script>
+<script src="https://web.archive.org/web/20211031120029js_/https://www.health.govt.nz/sites/default/files/js/js_4VW9edmu3V8VjGJxFfXGAwkXeW2cJIa5h-6y7SgwVrk.js"></script>
+<script>    (function(h,o,t,j,a,r){
+        h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
+        h._hjSettings={hjid:930919,hjsv:6};
+        a=o.getElementsByTagName('head')[0];
+        r=o.createElement('script');r.async=1;
+        r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+        a.appendChild(r);
+    })(window,document,'https://web.archive.org/web/20211031120029/https://static.hotjar.com/c/hotjar-','.js?sv=');
+</script>
+<script>jQuery.extend(Drupal.settings, {"basePath":"\/","pathPrefix":"","ajaxPageState":{"theme":"mohpub_bootstrap","theme_token":"d6qKM1xPFkK0hcClr9N7L8ljYbRTeDoVq7EmEZE7MmI","js":{"sites\/all\/modules\/custom\/table_d3chart\/js\/table_d3chart.js":1,"sites\/all\/modules\/custom\/moh_d3\/moh_d3.js":1,"sites\/all\/modules\/contrib\/jquery_update\/replace\/jquery\/1.7\/jquery.min.js":1,"misc\/jquery-extend-3.4.0.js":1,"misc\/jquery-html-prefilter-3.5.0-backport.js":1,"misc\/jquery.once.js":1,"misc\/drupal.js":1,"sites\/all\/modules\/contrib\/ckeditor_accordion\/js\/ckeditor-accordion.js":1,"sites\/all\/modules\/contrib\/extlink\/extlink.js":1,"modules\/field\/modules\/text\/text.js":1,"sites\/all\/modules\/contrib\/field_group\/field_group.js":1,"sites\/all\/modules\/contrib\/google_analytics\/googleanalytics.js":1,"0":1,"sites\/all\/libraries\/c3\/c3.js":1,"sites\/all\/libraries\/d3\/d3.min.js":1,"sites\/all\/modules\/contrib\/d3\/js\/d3.js":1,"sites\/all\/libraries\/d3.helpers\/d3.helpers.js":1,"sites\/all\/libraries\/d3.c3\/d3-c3.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/assets\/ios-fix.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/affix.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/alert.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/button.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/carousel.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/collapse.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/dropdown.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/modal.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/tooltip.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/popover.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/scrollspy.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/tab.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/transition.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/jquery.cookie.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/jquery.moh.announcement.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/svgeezy.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/fitvids.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/bootstrap-tabcollapse.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/jquery.scrollTo.min.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/script.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/jquery.google_analytics.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/bootstrap-accessibility.min.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/style-switcher.js":1,"1":1},"css":{"modules\/system\/system.base.css":1,"sites\/all\/modules\/contrib\/calendar\/css\/calendar_multiday.css":1,"sites\/all\/modules\/contrib\/ckeditor_accordion\/css\/ckeditor-accordion.css":1,"modules\/field\/theme\/field.css":1,"modules\/node\/node.css":1,"sites\/all\/modules\/contrib\/extlink\/extlink.css":1,"sites\/all\/modules\/contrib\/views\/css\/views.css":1,"sites\/all\/modules\/contrib\/ckeditor\/css\/ckeditor.css":1,"sites\/all\/modules\/contrib\/ctools\/css\/ctools.css":1,"sites\/all\/modules\/contrib\/panels\/css\/panels.css":1,"sites\/all\/libraries\/c3\/c3.css":1,"sites\/all\/libraries\/d3.c3\/d3-c3.css":1,"sites\/all\/themes\/mohpub_bootstrap\/fontawesome\/css\/fontawesome.min.css":1,"sites\/all\/themes\/mohpub_bootstrap\/fontawesome\/css\/solid.min.css":1,"sites\/all\/themes\/mohpub_bootstrap\/fontawesome\/css\/brands.min.css":1,"sites\/all\/modules\/features\/site_profile\/css\/fix-rubik-multiselect-height.css":1,"sites\/all\/themes\/mohpub_bootstrap\/css\/style.css":1,"sites\/all\/themes\/mohpub_bootstrap\/css\/responsive-tables.css":1,"sites\/all\/themes\/mohpub_bootstrap\/css\/print.css":1}},"field_group":{"div":"full"},"ckeditor_accordion":{"collapseAll":1},"extlink":{"extTarget":0,"extClass":"ext","extLabel":"(link is external)","extImgClass":0,"extIconPlacement":"append","extSubdomains":0,"extExclude":"","extInclude":"","extCssExclude":"","extCssExplicit":"","extAlert":0,"extAlertText":"This link will take you to an external web site. We are not responsible for their content.","mailtoClass":"mailto","mailtoLabel":"(link sends e-mail)"},"googleanalytics":{"trackOutbound":1,"trackMailto":1,"trackDownload":1,"trackDownloadExtensions":"7z|aac|arc|arj|asf|asx|avi|bin|csv|doc|exe|flv|gif|gz|gzip|hqx|jar|jpe?g|js|mp(2|3|4|e?g)|mov(ie)?|msi|msp|pdf|phps|png|ppt|qtm?|ra(m|r)?|sea|sit|tar|tgz|torrent|txt|wav|wma|wmv|wpd|xls|xml|z|zip|docx|xlsx|pptx|pptm|ppsx|ppsm|epub"},"mohD3":{"C3Types":["line","spline","step","area","area-spline","area-step","bar","scatter","pie","donut","gauge"],"graphRender":"line","graphLegend":true,"graphDefaultColors":"#2b8cbe, #abdda4, #7f7f7f, #92cddc, #dc8b0c","graphDefaultGroupedTooltip":0,"graphDefaultGridX":0,"graphDefaultGridY":0,"graphDefaultLegendPosition":"top-right","graphDefaultTooltip":1,"graphDefaultDataLabel":0,"graphLegendStep":"5","graphInteraction":true,"graphTypes":"","graphXaxisShow":true,"graphXaxisLabel":"","graphYaxisLabel":"","graphXaxisType":"category","graphXaxisCentered":false,"graphXaxisRotation":"","graphXaxisHeight":"","graphYaxisShow":true,"graphYaxisMax":"","graphYaxisMin":"","graphYaxisInverted":false,"graphYaxisCenter":"","graphYaxisPrefix":"","graphYaxisSuffix":"","graphYaxisPosition":"","graphY2axisShow":false,"graphY2axisSource":"","graphY2axisMax":"","graphY2axisMin":"","graphGroups":"","graphRotated":false,"graphIgnoreEmpty":false,"graphLineDot":true,"graphBarRatio":"0.9","graphDot":true,"graphDotR":"2.5","graphFocus":false},"tableD3":{"show":"View table data source","hide":"Hide table data source"},"urlIsAjaxTrusted":{"\/our-work\/diseases-and-conditions\/covid-19-novel-coronavirus\/covid-19-data-and-statistics\/covid-19-vaccine-data":true},"bootstrap":{"anchorsFix":1,"anchorsSmoothScrolling":1,"formHasError":1,"popoverEnabled":1,"popoverOptions":{"animation":1,"html":0,"placement":"right","selector":"","trigger":"click","triggerAutoclose":1,"title":"","content":"","delay":0,"container":"body"},"tooltipEnabled":1,"tooltipOptions":{"animation":1,"html":0,"placement":"auto left","selector":"","trigger":"hover focus","delay":0,"container":"body"}}});</script>
+  <!-- HTML5 element support for IE6-8 -->
+  <!--[if lt IE 9]>
+    <script src="/sites/all/themes/mohpub_bootstrap/js/assets/html5shiv.js"></script>
+    <script src="/sites/all/themes/mohpub_bootstrap/js/assets/respond.min.js"></script>
+  <![endif]-->
+</head>
+<body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-12052 node-type-page node-has-intro"><!-- BEGIN WAYBACK TOOLBAR INSERT -->
+<style type="text/css">
+body {
+  margin-top:0 !important;
+  padding-top:0 !important;
+  /*min-width:800px !important;*/
+}
+</style>
+<script>__wm.rw(0);</script>
+<div id="wm-ipp-base" lang="en" style="display:none;direction:ltr;">
+<div id="wm-ipp" style="position:fixed;left:0;top:0;right:0;">
+<div id="wm-ipp-inside">
+  <div style="position:relative;">
+    <div id="wm-logo" style="float:left;width:110px;padding-top:12px;">
+      <a href="/web/" title="Wayback Machine home page"><img src="/_static/images/toolbar/wayback-toolbar-logo-200.png" srcset="/_static/images/toolbar/wayback-toolbar-logo-100.png, /_static/images/toolbar/wayback-toolbar-logo-150.png 1.5x, /_static/images/toolbar/wayback-toolbar-logo-200.png 2x" alt="Wayback Machine" style="width:100px" border="0" /></a>
+    </div>
+    <div class="r" style="float:right;">
+      <div id="wm-btns" style="text-align:right;height:25px;">
+                  <div id="wm-save-snapshot-success">success</div>
+          <div id="wm-save-snapshot-fail">fail</div>
+          <a id="wm-save-snapshot-open" href="#"
+	     title="Share via My Web Archive" >
+            <span class="iconochive-web"></span>
+          </a>
+          <a href="https://archive.org/account/login.php"
+             title="Sign In"
+             id="wm-sign-in"
+          >
+            <span class="iconochive-person"></span>
+          </a>
+          <span id="wm-save-snapshot-in-progress" class="iconochive-web"></span>
+        	<a href="http://faq.web.archive.org/" title="Get some help using the Wayback Machine" style="top:-6px;"><span class="iconochive-question" style="color:rgb(87,186,244);font-size:160%;"></span></a>
+	<a id="wm-tb-close" href="#close" onclick="__wm.h(event);return false;" style="top:-2px;" title="Close the toolbar"><span class="iconochive-remove-circle" style="color:#888888;font-size:240%;"></span></a>
+      </div>
+      <div id="wm-share">
+          <a href="/web/20211031120029/http://web.archive.org/screenshot/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data"
+             id="wm-screenshot"
+             title="screenshot">
+            <span class="wm-icon-screen-shot"></span>
+          </a>
+          <a href="#"
+            id="wm-video"
+            title="video">
+            <span class="iconochive-movies"></span>
+          </a>
+	<a id="wm-share-facebook" href="#" data-url="https://web.archive.org/web/20211031120029/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="Share on Facebook" style="margin-right:5px;" target="_blank"><span class="iconochive-facebook" style="color:#3b5998;font-size:160%;"></span></a>
+	<a id="wm-share-twitter" href="#" data-url="https://web.archive.org/web/20211031120029/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="Share on Twitter" style="margin-right:5px;" target="_blank"><span class="iconochive-twitter" style="color:#1dcaff;font-size:160%;"></span></a>
+      </div>
+    </div>
+    <table class="c" style="">
+      <tbody>
+	<tr>
+	  <td class="u" colspan="2">
+	    <form target="_top" method="get" action="/web/submit" name="wmtb" id="wmtb"><input type="text" name="url" id="wmtbURL" value="https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" onfocus="this.focus();this.select();" /><input type="hidden" name="type" value="replay" /><input type="hidden" name="date" value="20211031120029" /><input type="submit" value="Go" /></form>
+	  </td>
+	  <td class="n" rowspan="2" style="width:110px;">
+	    <table>
+	      <tbody>
+		<!-- NEXT/PREV MONTH NAV AND MONTH INDICATOR -->
+		<tr class="m">
+		  <td class="b" nowrap="nowrap"><a href="https://web.archive.org/web/20210929203937/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="29 Sep 2021"><strong>Sep</strong></a></td>
+		  <td class="c" id="displayMonthEl" title="You are here: 12:00:29 Oct 31, 2021">OCT</td>
+		  <td class="f" nowrap="nowrap">Nov</td>
+		</tr>
+		<!-- NEXT/PREV CAPTURE NAV AND DAY OF MONTH INDICATOR -->
+		<tr class="d">
+		  <td class="b" nowrap="nowrap"><a href="https://web.archive.org/web/20211030111302/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="11:13:02 Oct 30, 2021"><img src="/_static/images/toolbar/wm_tb_prv_on.png" alt="Previous capture" width="14" height="16" border="0" /></a></td>
+		  <td class="c" id="displayDayEl" style="width:34px;font-size:24px;white-space:nowrap;" title="You are here: 12:00:29 Oct 31, 2021">31</td>
+		  <td class="f" nowrap="nowrap"><a href="https://web.archive.org/web/20211101145759/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="14:57:59 Nov 01, 2021"><img src="/_static/images/toolbar/wm_tb_nxt_on.png" alt="Next capture" width="14" height="16" border="0" /></a></td>
+		</tr>
+		<!-- NEXT/PREV YEAR NAV AND YEAR INDICATOR -->
+		<tr class="y">
+		  <td class="b" nowrap="nowrap">2020</td>
+		  <td class="c" id="displayYearEl" title="You are here: 12:00:29 Oct 31, 2021">2021</td>
+		  <td class="f" nowrap="nowrap">2022</td>
+		</tr>
+	      </tbody>
+	    </table>
+	  </td>
+	</tr>
+	<tr>
+	  <td class="s">
+	    	    <div id="wm-nav-captures">
+	      	      <a class="t" href="/web/20211031120029*/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="See a list of every capture for this URL">682 captures</a>
+	      <div class="r" title="Timespan for captures of this URL">07 Apr 2021 - 06 Nov 2021</div>
+	      </div>
+	  </td>
+	  <td class="k">
+	    <a href="" id="wm-graph-anchor">
+	      <div id="wm-ipp-sparkline" title="Explore captures for this URL" style="position: relative">
+		<canvas id="wm-sparkline-canvas" width="650" height="27" border="0"></canvas>
+	      </div>
+	    </a>
+	  </td>
+	</tr>
+      </tbody>
+    </table>
+    <div style="position:absolute;bottom:0;right:2px;text-align:right;">
+      <a id="wm-expand" class="wm-btn wm-closed" href="#expand" onclick="__wm.ex(event);return false;"><span id="wm-expand-icon" class="iconochive-down-solid"></span> <span style="font-size:80%">About this capture</span></a>
+    </div>
+  </div>
+    <div id="wm-capinfo" style="border-top:1px solid #777;display:none; overflow: hidden">
+                    <div id="wm-capinfo-collected-by">
+    <div style="background-color:#666;color:#fff;font-weight:bold;text-align:center">COLLECTED BY</div>
+    <div style="padding:3px;position:relative" id="wm-collected-by-content">
+            <div style="display:inline-block;vertical-align:top;width:50%;">
+			<span class="c-logo" style="background-image:url(https://archive.org/services/img/focused_crawls);"></span>
+		Organization: <a style="color:#33f;" href="https://archive.org/details/focused_crawls" target="_new"><span class="wm-title">Internet Archive</span></a>
+		<div style="max-height:75px;overflow:hidden;position:relative;">
+	  <div style="position:absolute;top:0;left:0;width:100%;height:75px;background:linear-gradient(to bottom,rgba(255,255,255,0) 0%,rgba(255,255,255,0) 90%,rgba(255,255,255,255) 100%);"></div>
+	  Focused crawls are collections of frequently-updated webcrawl data from narrow (as opposed to broad or wide) web crawls, often focused on a single domain or subdomain.<br />
+	</div>
+	      </div>
+      <div style="display:inline-block;vertical-align:top;width:49%;">
+			<span class="c-logo" style="background-image:url(https://archive.org/services/img/abc.net.au-news)"></span>
+		<div>Collection: <a style="color:#33f;" href="https://archive.org/details/abc.net.au-news" target="_new"><span class="wm-title">abc.net.au-news</span></a></div>
+	      </div>
+    </div>
+    </div>
+    <div id="wm-capinfo-timestamps">
+    <div style="background-color:#666;color:#fff;font-weight:bold;text-align:center" title="Timestamps for the elements of this page">TIMESTAMPS</div>
+    <div>
+      <div id="wm-capresources" style="margin:0 5px 5px 5px;max-height:250px;overflow-y:scroll !important"></div>
+      <div id="wm-capresources-loading" style="text-align:left;margin:0 20px 5px 5px;display:none"><img src="/_static/images/loading.gif" alt="loading" /></div>
+    </div>
+    </div>
+  </div></div></div></div><div id="wm-ipp-print">The Wayback Machine - https://web.archive.org/web/20211031120029/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data</div>
+<div id="donato" style="position:relative;width:100%;">
+  <div id="donato-base">
+    <iframe id="donato-if" src="https://archive.org/includes/donate.php?as_page=1&amp;platform=wb&amp;referer=https%3A//web.archive.org/web/20211031120029/https%3A//www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data"
+	    scrolling="no" frameborder="0" style="width:100%; height:100%">
+    </iframe>
+  </div>
+</div><script type="text/javascript">
+__wm.bt(650,27,25,2,"web","https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data","20211031120029",1996,"/_static/",["/_static/css/banner-styles.css?v=omkqRugM","/_static/css/iconochive.css?v=qtvMKcIJ"], "False");
+  __wm.rw(1);
+</script>
+<!-- END WAYBACK TOOLBAR INSERT -->
+<!--googleoff: all-->
+  <div id="skip-link">
+    <a href="#skip-content" id="skipper" class="element-invisible element-focusable">Skip to main content</a>
+  </div>
+    <div id="page">
+  <header id="navbar" role="banner" class="navbar container navbar-default">
+          <ul class="menu nav navbar-nav secondary"><li class="first leaf jobs depth-1"><a href="https://web.archive.org/web/20211031120029/https://careers.health.govt.nz/" title="">Jobs</a></li>
+<li class="leaf news depth-1"><a href="/web/20211031120029/https://www.health.govt.nz/news-media" data-is-top-level="0" title="">News</a></li>
+<li class="leaf contact-us depth-1"><a href="/web/20211031120029/https://www.health.govt.nz/about-ministry/contact-us" title="">Contact us</a></li>
+<li class="leaf facebook depth-1"><a href="https://web.archive.org/web/20211031120029/https://www.facebook.com/minhealthnz/">Facebook</a></li>
+<li class="leaf twitter depth-1"><a href="https://web.archive.org/web/20211031120029/https://twitter.com/minhealthnz" data-is-top-level="0" title="">Twitter</a></li>
+<li class="last leaf youtube depth-1"><a href="https://web.archive.org/web/20211031120029/https://www.youtube.com/user/minhealthnz" data-is-top-level="0" title="">Youtube</a></li>
+</ul>        <div class="container">
+      <div class="navbar-header">
+                <a class="logo navbar-btn pull-left" href="/web/20211031120029/https://www.health.govt.nz/" title="Home">
+          <img src="/web/20211031120029im_/https://www.health.govt.nz/sites/all/themes/mohpub_bootstrap/images/mohlogo.svg" alt="Ministry of Health"/>
+        </a>
+                  <div class="region region-header-top">
+    <section id="block-apachesolr-panels-search-form" class="block block-apachesolr-panels clearfix">
+
+
+  <form action="/web/20211031120029/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" method="post" id="apachesolr-panels-search-block" accept-charset="UTF-8"><div><div class="form-item form-item-apachesolr-panels-search-form form-type-textfield form-group"> <label class="control-label" for="edit-apachesolr-panels-search-form">Search</label>
+<input title="Enter the terms you wish to search for." class="form-control form-text" type="text" id="edit-apachesolr-panels-search-form" name="apachesolr_panels_search_form" value="" size="15" maxlength="128"/></div><input type="hidden" name="form_build_id" value="form-AogkDflnJfz3MzUR_dHJlXgK1bgo2Rd8KilY2bKojO4"/>
+<input type="hidden" name="form_id" value="apachesolr_panels_search_block"/>
+<div class="form-actions form-wrapper form-group" id="edit-actions"><button type="submit" id="edit-submit" name="op" value="Search" class="btn btn-primary form-submit">Search</button>
+</div></div></form>
+</section>
+  </div>
+        <!-- .btn-navbar is used as the toggle for collapsed navbar content -->
+        <button aria-expanded="false" aria-controls="megamenu" type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+                    <span class="menu-text">Menu</span><span class="sr-only">Toggle navigation</span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+
+        </button>
+      </div>
+
+              <div class="navbar-collapse collapse">
+          <nav id="megamenu" role="navigation">
+                          <h2 class="element-invisible">Main menu</h2><ul id="main-menu" class="menu nav navbar-nav yamm navbar"><li class="first dropdown"><a href="/web/20211031120029/https://www.health.govt.nz/your-health" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="megamenu-dropdown-780">Your health <b class="caret"></b></a>
+    <div id="megamenu-dropdown-780" class="dropdown-menu">
+    <div class="yamm-content">
+      <div class="row">
+                            <div class="col">
+            <h3><a href="/web/20211031120029/https://www.health.govt.nz/your-health/conditions-and-treatments?mega=Your%20health&amp;title=Conditions%20%26%20treatments" class="menu-header">Conditions &amp; treatments</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211031120029/https://www.health.govt.nz/your-health/conditions-and-treatments/mental-health/depression?mega=Your%20health&amp;title=Depression">Depression</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/diabetes?mega=Your%20health&amp;title=Diabetes">Diabetes</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/influenza?mega=Your%20health&amp;title=Influenza">Influenza</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/measles?mega=Your%20health&amp;title=Measles">Measles</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/meningococcal-disease-including-meningitis?mega=Your%20health&amp;title=Meningococcal%20disease">Meningococcal disease</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/mumps?mega=Your%20health&amp;title=Mumps">Mumps</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/respiratory-syncytial-virus-rsv?mega=Your%20health&amp;title=RSV">RSV</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/sore-throat?mega=Your%20health&amp;title=Sore%20throat">Sore throat</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/your-health/conditions-and-treatments?mega=Your%20health&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211031120029/https://www.health.govt.nz/your-health/healthy-living?mega=Your%20health&amp;title=Healthy%20living" class="menu-header">Healthy living</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211031120029/https://www.health.govt.nz/your-health/healthy-living/drinking-water?mega=Your%20health&amp;title=Drinking-water">Drinking-water</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/your-health/healthy-living/food-activity-and-sleep/green-prescriptions?mega=Your%20health&amp;title=Green%20Prescriptions">Green Prescriptions</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/your-health/healthy-living/food-activity-and-sleep/healthy-eating?mega=Your%20health&amp;title=Healthy%20eating">Healthy eating</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/your-health/healthy-living/immunisation?mega=Your%20health&amp;title=Immunisation">Immunisation</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/your-health/healthy-living/food-activity-and-sleep/physical-activity?mega=Your%20health&amp;title=Physical%20activity">Physical activity</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/your-health/healthy-living/addictions/quitting-smoking?mega=Your%20health&amp;title=Smoking">Smoking</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/your-health/healthy-living/teeth-and-gums?mega=Your%20health&amp;title=Teeth%20and%20gums">Teeth and gums</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/your-health/healthy-living?mega=Your%20health&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211031120029/https://www.health.govt.nz/your-health/pregnancy-and-kids?mega=Your%20health&amp;title=Pregnancy%20and%20kids" class="menu-header">Pregnancy and kids</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211031120029/https://www.health.govt.nz/your-health/pregnancy-and-kids/birth-and-afterwards?mega=Your%20health&amp;title=Birth%20and%20afterwards">Birth and afterwards</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/your-health/pregnancy-and-kids/first-year/helpful-advice-during-first-year/breastfeeding-perfect-you-and-your-baby?mega=Your%20health&amp;title=Breastfeeding">Breastfeeding</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/your-health/pregnancy-and-kids/pregnancy?mega=Your%20health&amp;title=Pregnancy">Pregnancy</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/your-health/pregnancy-and-kids/services-and-support-during-pregnancy?mega=Your%20health&amp;title=Services%20and%20support%20during%20pregnancy">Services and support during pregnancy</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/your-health/pregnancy-and-kids/services-and-support-you-and-your-child?mega=Your%20health&amp;title=Services%20and%20support%20for%20you%20and%20your%20child">Services and support for you and your child</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/your-health/pregnancy-and-kids/first-year?mega=Your%20health&amp;title=The%20first%20year">The first year</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/your-health/pregnancy-and-kids/under-fives?mega=Your%20health&amp;title=Under%20fives">Under fives</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/your-health/pregnancy-and-kids?mega=Your%20health&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211031120029/https://www.health.govt.nz/your-health/services-and-support?mega=Your%20health&amp;title=Services%20and%20support" class="menu-header">Services &amp; support</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211031120029/https://www.health.govt.nz/your-health/services-and-support/health-care-services/help-alcohol-and-drug-problems?mega=Your%20health&amp;title=Alcohol%20and%20drugs">Alcohol and drugs</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/your-health/services-and-support/disability-services?mega=Your%20health&amp;title=Disability%20services">Disability services</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/your-health/services-and-support/health-care-services/earthquake-support-line?mega=Your%20health&amp;title=Earthquake%20Support%20Line">Earthquake Support Line</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/your-health/services-and-support/health-care-services/healthline?mega=Your%20health&amp;title=Healthline">Healthline</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/your-health/services-and-support/health-care-services/mental-health-services?mega=Your%20health&amp;title=Mental%20health%20services">Mental health services</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/your-health/services-and-support/health-care-services/maori-health-provider-directory?mega=Your%20health&amp;title=M%C4%81ori%20health%20providers">Māori health providers</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/your-health/services-and-support/health-care-services/services-older-people/rest-home-certification-and-audits?mega=Your%20health&amp;title=Rest%20home%20certification">Rest home certification</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/your-health/services-and-support/health-care-services/hospitals-and-specialist-services/travel-assistance?mega=Your%20health&amp;title=Travel%20assistance">Travel assistance</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/your-health/services-and-support?mega=Your%20health&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                        </div>
+    </div>
+    <div class="feature-links">
+      <h3 class="sr-only">Other related resources</h3>
+      <a href="/web/20211031120029/https://www.health.govt.nz/your-health/full-a-z?mega=Your%20health&amp;title=A-Z">View the full A-Z</a>    </div>
+  </div>
+</li>
+<li class="dropdown"><a href="/web/20211031120029/https://www.health.govt.nz/new-zealand-health-system" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="megamenu-dropdown-6076">NZ health system <b class="caret"></b></a>
+    <div id="megamenu-dropdown-6076" class="dropdown-menu">
+    <div class="yamm-content">
+      <div class="row">
+                            <div class="col">
+            <h3><a href="/web/20211031120029/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people?mega=NZ%20health%20system&amp;title=Key%20organisations" class="menu-header">Key organisations</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211031120029/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/crown-entities-and-statutory-boards?mega=NZ%20health%20system&amp;title=Crown%20entities%20%26%20agencies">Crown entities &amp; agencies</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/district-health-boards?mega=NZ%20health%20system&amp;title=District%20health%20boards">District health boards</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/non-governmental-organisations?mega=NZ%20health%20system&amp;title=Non-governmental%20organisations">Non-governmental organisations</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/primary-health-organisations?mega=NZ%20health%20system&amp;title=Primary%20health%20organisations">Primary health organisations</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/public-health-units?mega=NZ%20health%20system&amp;title=Public%20health%20units">Public health units</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people?mega=NZ%20health%20system&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211031120029/https://www.health.govt.nz/new-zealand-health-system/health-system-indicators-framework?mega=NZ%20health%20system&amp;title=Health%20System%20Indicators%20framework" class="menu-header">Health System Indicators framework</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211031120029/https://www.health.govt.nz/new-zealand-health-system/health-system-indicators-framework?mega=NZ%20health%20system&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211031120029/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services?mega=NZ%20health%20system&amp;title=Eligibility%20for%20public%20health%20services" class="menu-header">Eligibility for public health services</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211031120029/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services/guide-eligibility-publicly-funded-health-services?mega=NZ%20health%20system&amp;title=Guide%20to%20eligibility">Guide to eligibility</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services/eligibility-questions-and-answers-consumers?mega=NZ%20health%20system&amp;title=Q%26A%20for%20consumers">Q&amp;A for consumers</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services/eligibility-questions-and-answers-service-providers?mega=NZ%20health%20system&amp;title=Q%26A%20for%20service%20providers">Q&amp;A for service providers</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services/reciprocal-health-agreements?mega=NZ%20health%20system&amp;title=Reciprocal%20health%20agreements">Reciprocal health agreements</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services?mega=NZ%20health%20system&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211031120029/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements?mega=NZ%20health%20system&amp;title=Claims%2C%20provider%20payments%20and%20entitlements" class="menu-header">Claims &amp; provider payments</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211031120029/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/carer-support-claims?mega=NZ%20health%20system&amp;title=Carer%20Support">Carer Support</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/high-use-health-card-payments?mega=NZ%20health%20system&amp;title=High%20Use%20Health%20Card%20payments">High Use Health Card payments</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/between-travel-settlement?mega=NZ%20health%20system&amp;title=In-Between%20Travel%20Settlement">In-Between Travel Settlement</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/maternity-claim-forms?mega=NZ%20health%20system&amp;title=Maternity%20claim%20forms">Maternity claim forms</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/national-travel-assistance?mega=NZ%20health%20system&amp;title=National%20travel%20assistance%20claims">National travel assistance claims</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements?mega=NZ%20health%20system&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                        </div>
+    </div>
+    <div class="feature-links">
+      <h3 class="sr-only">Other related resources</h3>
+      <a href="/web/20211031120029/https://www.health.govt.nz/new-zealand-health-system/overview-health-system?mega=NZ%20health%20system&amp;title=Overview">Overview of the health system</a>  <a href="/web/20211031120029/https://www.health.govt.nz/new-zealand-health-system/my-dhb?mega=NZ%20health%20system&amp;title=Mydhb">My DHB</a> <a href="/web/20211031120029/https://www.health.govt.nz/new-zealand-health-system/system-level-measures-framework?mega=NZ%20health%20system&amp;title=SLM">System level measures</a>  <a href="/web/20211031120029/https://www.health.govt.nz/publication/new-zealand-health-strategy-2016?mega=NZ%20health%20system&amp;title=HealthStrategy">NZ Health Strategy</a>    </div>
+  </div>
+</li>
+<li class="dropdown"><a href="/web/20211031120029/https://www.health.govt.nz/our-work" class="dropdown-toggle active-trail" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="megamenu-dropdown-776">Our work <b class="caret"></b></a>
+  <div id="megamenu-dropdown-776" class="dropdown-menu">
+    <div class="yamm-content">
+      <div class="row">
+                            <ul class="col list-unstyled no-menu-header">
+                                                                                <li>
+                <a href="/web/20211031120029/https://www.health.govt.nz/our-work/hospitals-and-specialist-care/acute-care?mega=Our%20work&amp;title=Acute%20care" class="menu-header">Acute care</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211031120029/https://www.health.govt.nz/our-work/diseases-and-conditions/antimicrobial-resistance?mega=Our%20work&amp;title=Antimicrobial%20resistance" class="menu-header">Antimicrobial resistance</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211031120029/https://www.health.govt.nz/our-work/populations/asian-and-migrant-health?mega=Our%20work&amp;title=Asian%20and%20migrant%20health" class="menu-header">Asian and migrant health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211031120029/https://www.health.govt.nz/our-work/border-health?mega=Our%20work&amp;title=Border%20health" class="menu-header">Border health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211031120029/https://www.health.govt.nz/our-work/life-stages/breastfeeding?mega=Our%20work&amp;title=Breastfeeding" class="menu-header">Breastfeeding</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211031120029/https://www.health.govt.nz/our-work/diseases-and-conditions/cancer?mega=Our%20work&amp;title=Cancer" class="menu-header">Cancer</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211031120029/https://www.health.govt.nz/our-work/regulation-health-and-disability-system/certification-health-care-services?mega=Our%20work&amp;title=Certification%20of%20health%20care%20services" class="menu-header">Certification of health care services</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211031120029/https://www.health.govt.nz/our-work/life-stages/child-health?mega=Our%20work&amp;title=Child%20health" class="menu-header">Child health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211031120029/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus?mega=Our%20work&amp;title=COVID-19" class="menu-header">COVID-19 (novel coronavirus)</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211031120029/https://www.health.govt.nz/our-work/diseases-and-conditions/diabetes?mega=Our%20work&amp;title=Diabetes" class="menu-header">Diabetes</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211031120029/https://www.health.govt.nz/our-work/digital-health?mega=Our%20work&amp;title=Digital%20health" class="menu-header">Digital health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211031120029/https://www.health.govt.nz/our-work/disability-services?mega=Our%20work&amp;title=Disability%20services" class="menu-header">Disability services</a>                              </li>
+                                                                </ul>
+                            <ul class="col list-unstyled no-menu-header">
+                                                                                <li>
+                <a href="/web/20211031120029/https://www.health.govt.nz/our-work/diseases-and-conditions?mega=Our%20work&amp;title=Diseases%20and%20conditions" class="menu-header">Diseases and conditions</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211031120029/https://www.health.govt.nz/our-work/hospitals-and-specialist-care/emergency-departments?mega=Our%20work&amp;title=Emergency%20departments" class="menu-header">Emergency departments</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211031120029/https://www.health.govt.nz/our-work/emergency-management?mega=Our%20work&amp;title=Emergency%20management" class="menu-header">Emergency management</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211031120029/https://www.health.govt.nz/our-work/environmental-health?mega=Our%20work&amp;title=Environmental%20health" class="menu-header">Environmental health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211031120029/https://www.health.govt.nz/our-work/preventative-health-wellness/family-violence?mega=Our%20work&amp;title=Family%20violence" class="menu-header">Family violence</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211031120029/https://www.health.govt.nz/our-work/preventative-health-wellness/fluoride-and-oral-health?mega=Our%20work&amp;title=Fluoride%20and%20oral%20health" class="menu-header">Fluoride and oral health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211031120029/https://www.health.govt.nz/our-work/health-identity?mega=Our%20work&amp;title=Health%20identity" class="menu-header">Health identity</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211031120029/https://www.health.govt.nz/our-work/digital-health/digital-health-sector-architecture-standards-and-governance/health-information-standards-0?mega=Our%20work&amp;title=Health%20information%20standards" class="menu-header">Health information standards</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211031120029/https://www.health.govt.nz/our-work/health-infrastructure-unit-hiu?mega=Our%20work&amp;title=Health%20Infrastructure%20Unit" class="menu-header">Health Infrastructure Unit</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211031120029/https://www.health.govt.nz/our-work/life-stages/health-older-people?mega=Our%20work&amp;title=Health%20of%20older%20people" class="menu-header">Health of older people</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211031120029/https://www.health.govt.nz/our-work/health-workforce?mega=Our%20work&amp;title=Health%20workforce" class="menu-header">Health workforce</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211031120029/https://www.health.govt.nz/our-work/hospitals-and-specialist-care?mega=Our%20work&amp;title=Hospitals%20and%20specialist%20care" class="menu-header">Hospitals and specialist care</a>                              </li>
+                                                                </ul>
+                            <ul class="col list-unstyled no-menu-header">
+                                                                                <li>
+                <a href="/web/20211031120029/https://www.health.govt.nz/our-work/preventative-health-wellness/immunisation?mega=Our%20work&amp;title=Immunisation" class="menu-header">Immunisation</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211031120029/https://www.health.govt.nz/our-work/ionising-radiation-safety?mega=Our%20work&amp;title=Ionising%20radiation%20safety" class="menu-header">Ionising radiation safety</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211031120029/https://www.health.govt.nz/our-work/populations/maori-health?mega=Our%20work&amp;title=M%C4%81ori%20health" class="menu-header">Māori health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211031120029/https://www.health.govt.nz/our-work/life-stages/maternity-services?mega=Our%20work&amp;title=Maternity" class="menu-header">Maternity</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211031120029/https://www.health.govt.nz/our-work/regulation-health-and-disability-system/medicinal-cannabis-agency?mega=Our%20work&amp;title=Medicinal%20Cannabis%20Agency" class="menu-header">Medicinal cannabis</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211031120029/https://www.health.govt.nz/our-work/regulation-health-and-disability-system/medicines-control?mega=Our%20work&amp;title=Medicines%20control" class="menu-header">Medicines control</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211031120029/https://www.health.govt.nz/our-work/mental-health-and-addiction?mega=Our%20work&amp;title=Mental%20health%20and%20addiction" class="menu-header">Mental health and addiction</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211031120029/https://www.health.govt.nz/our-work/nursing?mega=Our%20work&amp;title=Nursing" class="menu-header">Nursing</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211031120029/https://www.health.govt.nz/our-work/preventative-health-wellness/nutrition?mega=Our%20work&amp;title=Nutrition" class="menu-header">Nutrition</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211031120029/https://www.health.govt.nz/our-work/preventative-health-wellness/oral-health?mega=Our%20work&amp;title=Oral%20health" class="menu-header">Oral health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211031120029/https://www.health.govt.nz/our-work/hospitals-and-specialist-care/organ-donation-and-transplantation?mega=Our%20work&amp;title=Organ%20donation%20and%20transplantation" class="menu-header">Organ donation and transplantation</a>                              </li>
+                                                                </ul>
+                            <ul class="col list-unstyled no-menu-header">
+                                                                                <li>
+                <a href="/web/20211031120029/https://www.health.govt.nz/our-work/populations/pacific-health?mega=Our%20work&amp;title=Pacific%20health" class="menu-header">Pacific health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211031120029/https://www.health.govt.nz/new-zealand-health-system/pay-equity-settlements?mega=Our%20work&amp;title=Pay%20equity%20settlements" class="menu-header">Pay equity</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211031120029/https://www.health.govt.nz/our-work/preventative-health-wellness/physical-activity?mega=Our%20work&amp;title=Physical%20activity" class="menu-header">Physical activity</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211031120029/https://www.health.govt.nz/our-work/hospitals-and-specialist-care/planned-care-services?mega=Our%20work&amp;title=Planned%20Care%20services" class="menu-header">Planned Care services</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211031120029/https://www.health.govt.nz/our-work/preventative-health-wellness?mega=Our%20work&amp;title=Preventative%20health/wellness" class="menu-header">Preventative health/wellness</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211031120029/https://www.health.govt.nz/our-work/primary-health-care?mega=Our%20work&amp;title=Primary%20health%20care" class="menu-header">Primary health care</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211031120029/https://www.health.govt.nz/our-work/public-health-workforce-development?mega=Our%20work&amp;title=Public%20health%20workforce%20development" class="menu-header">Public health workforce</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211031120029/https://www.health.govt.nz/our-work/regulation-health-and-disability-system?mega=Our%20work&amp;title=Regulation" class="menu-header">Regulation</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211031120029/https://www.health.govt.nz/our-work/preventative-health-wellness/tobacco-control?mega=Our%20work&amp;title=Tobacco%20control" class="menu-header">Tobacco control</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211031120029/https://www.health.govt.nz/our-work/regulation-health-and-disability-system/regulation-vaping-and-smokeless-tobacco-products?mega=Our%20work&amp;title=Vaping%20and%20smokeless%20tobacco%20products" class="menu-header">Vaping &amp; smokeless tobacco</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211031120029/https://www.health.govt.nz/our-work/who-code-nz?mega=Our%20work&amp;title=WHO%20Code%20in%20NZ" class="menu-header">WHO Code in NZ</a>                              </li>
+                      </ul>
+              </div>
+    </div>
+    <div class="feature-links">
+      <a href="/web/20211031120029/https://www.health.govt.nz/our-work?mega=Our%20work&amp;title=A-Z">View the full A-Z</a>    </div>
+  </div>
+</li>
+<li class="dropdown"><a href="/web/20211031120029/https://www.health.govt.nz/nz-health-statistics" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="megamenu-dropdown-778">Health statistics <b class="caret"></b></a>
+    <div id="megamenu-dropdown-778" class="dropdown-menu">
+    <div class="yamm-content">
+      <div class="row">
+                            <div class="col">
+            <h3><a href="/web/20211031120029/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets?mega=Health%20statistics&amp;title=Health%20statistics%20and%20data%20sets" class="menu-header">Statistics by topic</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211031120029/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/cancer-data-and-stats?mega=Health%20statistics&amp;title=Cancer">Cancer</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/diabetes-data-and-stats?mega=Health%20statistics&amp;title=Diabetes">Diabetes</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/mental-health-data-and-stats?mega=Health%20statistics&amp;title=Mental%20health">Mental health</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/maori-health-data-and-stats?mega=Health%20statistics&amp;title=M%C4%81ori%20health">Māori health</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/obesity-statistics?mega=Health%20statistics&amp;title=Obesity">Obesity</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/suicide-data-and-stats?mega=Health%20statistics&amp;title=Suicide">Suicide</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/tobacco-data-and-stats?mega=Health%20statistics&amp;title=Tobacco">Tobacco</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets?mega=Health%20statistics&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211031120029/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys?mega=Health%20statistics&amp;title=National%20collections%20and%20surveys" class="menu-header">About our surveys &amp; data collections</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211031120029/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/surveys/past-surveys/alcohol-and-drug-use-survey?mega=Health%20statistics&amp;title=Alcohol%20%26%20Drug%20Use%20Survey">Alcohol &amp; Drug Use Survey</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/national-collections-annual-maintenance-project?mega=Health%20statistics&amp;title=NCAMP">NCAMP</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/collections/new-zealand-cancer-registry-nzcr?mega=Health%20statistics&amp;title=NZ%20Cancer%20Registry">NZ Cancer Registry</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/surveys/new-zealand-health-survey?mega=Health%20statistics&amp;title=NZ%20Health%20Survey">NZ Health Survey</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/surveys/past-surveys/nutrition-survey?mega=Health%20statistics&amp;title=Nutrition%20Survey">Nutrition Survey</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/collections/primhd-mental-health-data?mega=Health%20statistics&amp;title=PRIMHD">PRIMHD</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys?mega=Health%20statistics&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211031120029/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology?mega=Health%20statistics&amp;title=Classification%20and%20Terminology" class="menu-header">Classification &amp; terminology</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211031120029/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology/using-icd-10-am-achi-acs/coding-queries/coding-query-database?mega=Health%20statistics&amp;title=Coding%20query%20database">Coding query database</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology/using-icd-10-am-achi-acs/courses-clinical-coding?mega=Health%20statistics&amp;title=Courses%20on%20clinical%20coding">Courses on clinical coding</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology/new-zealand-snomed-ct-national-release-centre?mega=Health%20statistics&amp;title=SNOMED%20CT">SNOMED CT</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology/using-icd-10-am-achi-acs?mega=Health%20statistics&amp;title=Using%20ICD-10-AM/ACHI/ACS">Using ICD-10-AM/ACHI/ACS</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology?mega=Health%20statistics&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211031120029/https://www.health.govt.nz/nz-health-statistics/data-references?mega=Health%20statistics&amp;title=Data%20references" class="menu-header">Data references</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211031120029/https://www.health.govt.nz/nz-health-statistics/data-references/code-tables?mega=Health%20statistics&amp;title=Code%20tables">Code tables</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/nz-health-statistics/data-references/data-dictionaries?mega=Health%20statistics&amp;title=Data%20dictionaries">Data dictionaries</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/nz-health-statistics/data-references/diagnosis-related-groups?mega=Health%20statistics&amp;title=Diagnosis-related%20groups">Diagnosis-related groups</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/nz-health-statistics/data-references/code-tables/common-code-tables/domicile-code-table?mega=Health%20statistics&amp;title=Domicile%20code%20table">Domicile code table</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/nz-health-statistics/data-references/mapping-tools?mega=Health%20statistics&amp;title=ICD%20mapping%20tools">ICD mapping tools</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/nz-health-statistics/data-references/weighted-inlier-equivalent-separations?mega=Health%20statistics&amp;title=Weighted%20Inlier%20Equivalent%20Separations">Weighted Inlier Equivalent Separations</a></li>
+                                  <li><a href="/web/20211031120029/https://www.health.govt.nz/nz-health-statistics/data-references?mega=Health%20statistics&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                        </div>
+    </div>
+    <div class="feature-links">
+      <h3 class="sr-only">Other related resources</h3>
+      <a href="/web/20211031120029/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/tier-1-health-statistics-release-calendar?mega=Health%20statistics&amp;title=Tier%201%20calendar">Release calendar for our Tier 1 statistics</a> <a href="/web/20211031120029/https://www.health.govt.nz/nz-health-statistics/about-data-collection?mega=Health%20statistics&amp;title=Enquiries">Data and survey enquiries</a>    </div>
+  </div>
+</li>
+<li class=""><a href="/web/20211031120029/https://www.health.govt.nz/publications" aria-haspopup="false">Publications</a></li>
+<li class=""><a href="/web/20211031120029/https://www.health.govt.nz/about-ministry" aria-haspopup="false">About us</a></li>
+<li class="visible-xs"><a href="/web/20211031120029/https://www.health.govt.nz/contactus" aria-haspopup="false">Contact us</a></li>
+</ul>
+                                  </nav>
+        </div>
+          </div>
+  </header>
+
+  <div class="main-container container">
+    <!-- announcement -->
+        <!-- /announcement -->
+
+    <header role="banner" id="page-header">
+
+          </header> <!-- /#page-header -->
+
+    <div class="row">
+
+      <section class="col-sm-12">
+                        <a id="main-content"></a>
+                                                                            <div class="breadcrumbs">
+            <ul><li><a href="/web/20211031120029/https://www.health.govt.nz/">Home</a></li><li><a href="/web/20211031120029/https://www.health.govt.nz/our-work">Our work</a></li><li><a href="/web/20211031120029/https://www.health.govt.nz/our-work/diseases-and-conditions">Diseases and conditions</a></li><li><a href="/web/20211031120029/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished" data-is-top-level="1" title="">COVID-19</a></li><li><a href="/web/20211031120029/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics" class="menu-node-unpublished menu-node-unpublished">Data and statistics</a></li><li><span class="current-breadcrumb">Vaccine data</span></li></ul>          </div>
+
+
+
+          <div class="region region-content">
+    <section id="block-system-main" class="block block-system clearfix">
+
+
+  <div class="bootstrap-threecol-stacked">
+
+      <div class="row"> <!-- @TODO: Add extra classes -->
+      <div class="panel-panel left col-xs-12 col-md-3 col-lg-3"><div class="panel-pane pane-block pane-menu-block-1 odd pane-top-link">
+
+        <span class="top-link"><a href="/web/20211031120029/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished active-trail" data-is-top-level="1">COVID-19</a></span>
+
+
+  <div class="pane-content">
+        <div class="menu-block-wrapper menu-block-1 menu-name-main-menu parent-mlid-1445 menu-level-2">
+  <ul class="menu nav"><li class="first collapsed menu-mlid-10163 health-advice depth-4"><a href="/web/20211031120029/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-health-advice-public" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished">Health advice</a></li>
+<li class="collapsed menu-mlid-10630 covid-19-vaccines- depth-4 section-overview hide-children"><a href="/web/20211031120029/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-vaccines" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished" data-is-top-level="1" title="">COVID-19 vaccines </a></li>
+<li class="collapsed menu-mlid-9997 health-professionals depth-4"><a href="/web/20211031120029/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-information-health-professionals" class="menu-node-unpublished menu-node-unpublished">Health professionals</a></li>
+<li class="collapsed menu-mlid-10019 specific-audiences depth-4"><a href="/web/20211031120029/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-information-specific-audiences" class="menu-node-unpublished">Specific audiences</a></li>
+<li class="expanded active-trail menu-mlid-10096 data-and-statistics depth-4"><a href="/web/20211031120029/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics" class="menu-node-unpublished menu-node-unpublished active-trail">Data and statistics</a><ul class="menu nav"><li class="first leaf menu-mlid-10062 current-cases depth-5 same-level-as-node"><a href="/web/20211031120029/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-current-cases" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Current cases</a></li>
+<li class="leaf menu-mlid-10146 case-demographics depth-5 same-level-as-node"><a href="/web/20211031120029/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-case-demographics">Case demographics</a></li>
+<li class="leaf menu-mlid-10097 source-of-cases depth-5 same-level-as-node"><a href="/web/20211031120029/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-source-cases" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Source of cases</a></li>
+<li class="leaf menu-mlid-10119 testing-for-covid-19 depth-5 same-level-as-node"><a href="/web/20211031120029/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/testing-covid-19" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Testing for COVID-19</a></li>
+<li class="leaf menu-mlid-10371 nz-covid-tracer-app-data depth-5 same-level-as-node"><a href="/web/20211031120029/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-nz-covid-tracer-app-data" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">NZ COVID Tracer app data</a></li>
+<li class="expanded active-trail active menu-mlid-10584 active vaccine-data depth-5 same-level-as-node"><a href="/web/20211031120029/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished active-trail active">Vaccine data</a><ul class="menu nav"><li class="first leaf menu-mlid-10867 covid-19-vaccination-uptake-rates-across-nz depth-6"><a href="/web/20211031120029/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-across-nz" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">COVID-19 Vaccination uptake rates across NZ</a></li>
+<li class="leaf menu-mlid-10868 covid-19-vaccination-uptake-rates---māori depth-6"><a href="/web/20211031120029/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-maori-communities-across-nz" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">COVID-19 Vaccination uptake rates - Māori</a></li>
+<li class="last leaf menu-mlid-10869 covid-19-vaccination-uptake-rates---pacific depth-6"><a href="/web/20211031120029/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-pacific-communities-across-nz" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">COVID-19 Vaccination uptake rates - Pacific</a></li>
+</ul></li>
+<li class="last leaf menu-mlid-10404 data-resources depth-5 same-level-as-node"><a href="/web/20211031120029/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-data-resources" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Data resources</a></li>
+</ul></li>
+<li class="collapsed menu-mlid-10369 response-planning depth-4"><a href="/web/20211031120029/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-response-planning" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Response planning</a></li>
+<li class="collapsed menu-mlid-10015 resources-and-tools depth-4"><a href="/web/20211031120029/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-resources-and-tools" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Resources and tools</a></li>
+<li class="last leaf menu-mlid-10004 news-and-media depth-4 section-overview hide-children"><a href="/web/20211031120029/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-news-and-media-updates" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">News and media</a></li>
+</ul></div>
+  </div>
+
+
+  </div>
+</div>      <div class="panel-panel middle col-xs-12 col-md-9 col-lg-9"><div class="panel-pane pane-page-title even">
+
+
+
+  <div class="pane-content">
+    <span id="skip-content" tabindex="-1"></span>    <h1>COVID-19: Vaccine data</h1>
+  </div>
+
+
+  </div>
+<div class="panel-pane pane-node-content odd">
+
+
+
+  <div class="pane-content">
+        <article id="node-12052" class="node node-page node-sticky view-mode-full clearfix" about="/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" typeof="sioc:Item foaf:Document">
+    <header>
+            <span property="dc:title" content="COVID-19: Vaccine data" class="rdf-meta element-hidden"></span>      </header>
+    <div class="field field-name-field-intro-text field-type-text-long field-label-hidden"><div class="field-items"><div class="field-item even"><p class="intro-text">Data and statistics about the rollout of COVID-19 vaccines in New Zealand.</p></div></div></div><div class="field field-name-body field-type-text-with-summary field-label-hidden"><div class="field-items"><div class="field-item even" property="content:encoded"><p>On this page:</p>
+
+<ul>
+	<li><a href="#daily">Daily updates</a>
+
+	<ul>
+		<li><a href="#total-vaccinations">Total vaccinations</a></li>
+		<li><a href="#ethnicity">Vaccinations by ethnicity</a></li>
+		<li><a href="#90pct">Vaccinations to 90% by DHB</a></li>
+	</ul>
+	</li>
+	<li><a href="#weekly-updates">Weekly updates</a>
+	<ul>
+		<li><a href="#model">Vaccinations against plan</a></li>
+		<li><a href="#uptake">Vaccinations uptake</a></li>
+		<li><a href="#by-day">Vaccinations by day</a></li>
+		<li><a href="#location">Vaccinations by DHB</a></li>
+		<li><a href="#group">Vaccinations by group</a></li>
+		<li><a href="#by_soh">Stock on hand</a></li>
+		<li><a href="#age">Vaccinations by age</a></li>
+		<li><a href="#workforce">Trained vaccinator and active vaccinator</a></li>
+		<li><a href="#group">Vaccinations by group</a></li>
+		<li><a href="#download">Details of vaccination&nbsp;data</a></li>
+	</ul>
+	</li>
+	<li><a href="#adverse-events">Adverse events from immunisations</a></li>
+</ul>
+
+<hr/><!--daily-->
+<h2><a id="daily" name="daily"></a>COVID-19 vaccinations: daily updates</h2>
+
+<div class="well well-sm">
+<p style="margin-top: 0"><strong>Data in this section is as at 11:59pm 30 October 2021 and is updated daily.</strong></p>
+</div>
+
+<h3><a id="total-vaccinations" name="total-vaccinations"></a>Total Vaccinations</h3>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">&nbsp;</th>
+			<th scope="col" style="text-align:right">Vaccinations yesterday</th>
+			<th scope="col" style="text-align:right">Cumulative total</th>
+			<th scope="col" style="text-align:right">Eligible population vaccinated %</th>
+			<th scope="col" style="text-align:right">Total population vaccinated %</th>
+			<th scope="col" style="text-align:right">Vaccinated or booked</th>
+			<th scope="col" style="text-align:right">Eligible vaccinated or booked %</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">First dose</th>
+			<td style="text-align:right">10,703</td>
+			<td style="text-align:right">3,704,382</td>
+			<td style="text-align:right">88%</td>
+			<td style="text-align:right">74%</td>
+			<td style="text-align:right">3,716,393</td>
+			<td style="text-align:right">88%</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Second dose</th>
+			<td style="text-align:right">31,914</td>
+			<td style="text-align:right">3,143,914</td>
+			<td style="text-align:right">75%</td>
+			<td style="text-align:right">63%</td>
+			<td style="text-align:right">3,377,648</td>
+			<td style="text-align:right">80%</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total doses</strong></th>
+			<td style="text-align:right"><strong>42,617</strong></td>
+			<td style="text-align:right"><strong>6,848,296</strong></td>
+		</tr>
+	</tbody>
+</table>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Total vaccinations" class="img-responsive" height="900" src="/web/20211031120029im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_summary-2021-10-31.png" width="5340"/></figure>
+
+<h5>Definitions</h5>
+
+<ul>
+	<li><strong>Cumulative total:</strong>&nbsp;All vaccinations that have been administered and entered into the COVID-19 Immunisation Register up until midnight of the night before the data is published.</li>
+	<li><strong>Eligible population vaccinated %:</strong>&nbsp;Vaccinations administered divided by HSU population estimates for the eligible population (12+).</li>
+	<li><strong>Total population vaccinated %:</strong>&nbsp;Vaccinations administered divided by HSU population estimates for the total population (0+).</li>
+	<li><strong>Vaccinated or booked:</strong>&nbsp;Count of individuals who have either received their vaccination or have booked via Book My Vaccine to receive a vaccination.</li>
+	<li><strong>Eligible vaccinated or booked %:</strong>&nbsp;Count of individuals who have either received their vaccination or have booked via Book My Vaccine to receive a vaccination divided by HSU population estimates for the eligible population (12+).</li>
+</ul>
+
+<p>HSU population estimates are available in the downloadable spreadsheet at the bottom of the page. Throughout the rest of this sheet doses per 1,000 are based on eligible (12+) population.</p>
+
+<p>Bookings are only counted if the site is using Book My Vaccine. Bookings made through other Patient Management Systems are not counted.</p>
+
+<hr/>
+<h3><a id="by_eth" name="ethnicity"></a>Cumulative vaccinations by ethnicity</h3>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">Ethnicity *</th>
+			<th scope="col" style="text-align:right">First dose administered</th>
+			<th scope="col" style="text-align:right">First doses per 1,000 people</th>
+			<th scope="col" style="text-align:right">Second dose administered</th>
+			<th scope="col" style="text-align:right">Second doses per 1,000 people</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">Māori</th>
+			<td style="text-align:right">409,335</td>
+			<td style="text-align:right">717</td>
+			<td style="text-align:right">298,612</td>
+			<td style="text-align:right">523</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Pacific Peoples</th>
+			<td style="text-align:right">243,481</td>
+			<td style="text-align:right">849</td>
+			<td style="text-align:right">195,885</td>
+			<td style="text-align:right">683</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Asian</th>
+			<td style="text-align:right">607,224</td>
+			<td style="text-align:right">&gt;950</td>
+			<td style="text-align:right">540,120</td>
+			<td style="text-align:right">902</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">European / Other</th>
+			<td style="text-align:right">2,410,341</td>
+			<td style="text-align:right">883</td>
+			<td style="text-align:right">2,080,939</td>
+			<td style="text-align:right">762</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Unknown</th>
+			<td style="text-align:right">34,001</td>
+			<td style="text-align:right">-</td>
+			<td style="text-align:right">28,358</td>
+			<td style="text-align:right">-</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total</strong></th>
+			<td style="text-align:right"><strong>3,704,382</strong></td>
+			<td style="text-align:right"><strong>880</strong></td>
+			<td style="text-align:right"><strong>3,143,914</strong></td>
+			<td style="text-align:right"><strong>747</strong></td>
+		</tr>
+	</tbody>
+</table>
+
+<p><strong>*</strong> The prioritised ethnicity classification system allocates each person to a single ethnic group, based on the ethnic groups they identify with. Where people identify with more than one group, they are assigned in this order of priority: Māori, Pacific Peoples, Asian, and European/Other. So, if a person identifies as being Māori and New Zealand European, the person is counted as Māori. See <a href="/web/20211031120029/https://www.health.govt.nz/publication/hiso-100012017-ethnicity-data-protocols">Ethnicity Data Protocols</a> for further information.</p>
+
+<p>Ethnicity breakdown by DHB of residence is available in the downloadable spreadsheet at the bottom of the page.</p>
+
+<hr/>
+<h3><a id="90pct" name="90pct"></a>Vaccinations to 90% by DHB</h3>
+
+<h4><a id="90pct all ethnicities" name="90pct all ethnicities"></a>All Ethnicities</h4>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">&nbsp;</th>
+			<th scope="col" style="text-align:right">First doses</th>
+			<th scope="col" style="text-align:right">First doses %</th>
+			<th scope="col" style="text-align:right">First doses to 90%</th>
+			<th scope="col" style="text-align:right">Second doses</th>
+			<th scope="col" style="text-align:right">Second doses %</th>
+			<th scope="col" style="text-align:right">Second doses to 90%</th>
+			<th scope="col" style="text-align:right">Population</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">Northland</th>
+			<td style="text-align:right">127,690</td>
+			<td style="text-align:right">79%</td>
+			<td style="text-align:right">17,498</td>
+			<td style="text-align:right">103,567</td>
+			<td style="text-align:right">64%</td>
+			<td style="text-align:right">41,621</td>
+			<td style="text-align:right">161,320</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waitemata</th>
+			<td style="text-align:right">479,602</td>
+			<td style="text-align:right">91%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">421,626</td>
+			<td style="text-align:right">80%</td>
+			<td style="text-align:right">51,852</td>
+			<td style="text-align:right">526,087</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Auckland</th>
+			<td style="text-align:right">398,266</td>
+			<td style="text-align:right">94%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">356,967</td>
+			<td style="text-align:right">84%</td>
+			<td style="text-align:right">24,595</td>
+			<td style="text-align:right">423,958</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Counties Manukau</th>
+			<td style="text-align:right">429,142</td>
+			<td style="text-align:right">89%</td>
+			<td style="text-align:right">5,354</td>
+			<td style="text-align:right">370,946</td>
+			<td style="text-align:right">77%</td>
+			<td style="text-align:right">63,550</td>
+			<td style="text-align:right">482,773</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waikato</th>
+			<td style="text-align:right">309,408</td>
+			<td style="text-align:right">87%</td>
+			<td style="text-align:right">12,050</td>
+			<td style="text-align:right">257,063</td>
+			<td style="text-align:right">72%</td>
+			<td style="text-align:right">64,395</td>
+			<td style="text-align:right">357,176</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Lakes</th>
+			<td style="text-align:right">75,958</td>
+			<td style="text-align:right">80%</td>
+			<td style="text-align:right">9,019</td>
+			<td style="text-align:right">61,754</td>
+			<td style="text-align:right">65%</td>
+			<td style="text-align:right">23,223</td>
+			<td style="text-align:right">94,419</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Bay of Plenty</th>
+			<td style="text-align:right">180,060</td>
+			<td style="text-align:right">83%</td>
+			<td style="text-align:right">15,187</td>
+			<td style="text-align:right">145,435</td>
+			<td style="text-align:right">67%</td>
+			<td style="text-align:right">49,812</td>
+			<td style="text-align:right">216,941</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Tairawhiti</th>
+			<td style="text-align:right">32,730</td>
+			<td style="text-align:right">78%</td>
+			<td style="text-align:right">5,038</td>
+			<td style="text-align:right">26,541</td>
+			<td style="text-align:right">63%</td>
+			<td style="text-align:right">11,228</td>
+			<td style="text-align:right">41,965</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Taranaki</th>
+			<td style="text-align:right">85,912</td>
+			<td style="text-align:right">84%</td>
+			<td style="text-align:right">6,020</td>
+			<td style="text-align:right">67,016</td>
+			<td style="text-align:right">66%</td>
+			<td style="text-align:right">24,916</td>
+			<td style="text-align:right">102,147</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hawkes Bay</th>
+			<td style="text-align:right">122,948</td>
+			<td style="text-align:right">84%</td>
+			<td style="text-align:right">8,066</td>
+			<td style="text-align:right">103,679</td>
+			<td style="text-align:right">71%</td>
+			<td style="text-align:right">27,335</td>
+			<td style="text-align:right">145,571</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">MidCentral</th>
+			<td style="text-align:right">131,287</td>
+			<td style="text-align:right">86%</td>
+			<td style="text-align:right">5,785</td>
+			<td style="text-align:right">109,785</td>
+			<td style="text-align:right">72%</td>
+			<td style="text-align:right">27,287</td>
+			<td style="text-align:right">152,302</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Whanganui</th>
+			<td style="text-align:right">46,084</td>
+			<td style="text-align:right">81%</td>
+			<td style="text-align:right">5,438</td>
+			<td style="text-align:right">38,844</td>
+			<td style="text-align:right">68%</td>
+			<td style="text-align:right">12,678</td>
+			<td style="text-align:right">57,247</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Capital and Coast</th>
+			<td style="text-align:right">249,784</td>
+			<td style="text-align:right">92%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">216,579</td>
+			<td style="text-align:right">80%</td>
+			<td style="text-align:right">27,478</td>
+			<td style="text-align:right">271,174</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hutt Valley</th>
+			<td style="text-align:right">114,495</td>
+			<td style="text-align:right">88%</td>
+			<td style="text-align:right">2,720</td>
+			<td style="text-align:right">96,207</td>
+			<td style="text-align:right">74%</td>
+			<td style="text-align:right">21,008</td>
+			<td style="text-align:right">130,239</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Wairarapa</th>
+			<td style="text-align:right">35,408</td>
+			<td style="text-align:right">85%</td>
+			<td style="text-align:right">1,876</td>
+			<td style="text-align:right">30,012</td>
+			<td style="text-align:right">72%</td>
+			<td style="text-align:right">7,272</td>
+			<td style="text-align:right">41,427</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Nelson Marlborough</th>
+			<td style="text-align:right">117,720</td>
+			<td style="text-align:right">87%</td>
+			<td style="text-align:right">4,449</td>
+			<td style="text-align:right">102,987</td>
+			<td style="text-align:right">76%</td>
+			<td style="text-align:right">19,182</td>
+			<td style="text-align:right">135,743</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">West Coast</th>
+			<td style="text-align:right">22,676</td>
+			<td style="text-align:right">81%</td>
+			<td style="text-align:right">2,439</td>
+			<td style="text-align:right">18,529</td>
+			<td style="text-align:right">66%</td>
+			<td style="text-align:right">6,586</td>
+			<td style="text-align:right">27,906</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Canterbury</th>
+			<td style="text-align:right">439,245</td>
+			<td style="text-align:right">91%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">353,349</td>
+			<td style="text-align:right">73%</td>
+			<td style="text-align:right">81,252</td>
+			<td style="text-align:right">482,890</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">South Canterbury</th>
+			<td style="text-align:right">45,463</td>
+			<td style="text-align:right">86%</td>
+			<td style="text-align:right">1,863</td>
+			<td style="text-align:right">39,061</td>
+			<td style="text-align:right">74%</td>
+			<td style="text-align:right">8,265</td>
+			<td style="text-align:right">52,584</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Southern</th>
+			<td style="text-align:right">258,419</td>
+			<td style="text-align:right">90%</td>
+			<td style="text-align:right">794</td>
+			<td style="text-align:right">222,297</td>
+			<td style="text-align:right">77%</td>
+			<td style="text-align:right">36,916</td>
+			<td style="text-align:right">288,015</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Overseas / Unknown</th>
+			<td style="text-align:right">2,085</td>
+			<td style="text-align:right">12%</td>
+			<td style="text-align:right">13,371</td>
+			<td style="text-align:right">1,670</td>
+			<td style="text-align:right">10%</td>
+			<td style="text-align:right">13,786</td>
+			<td style="text-align:right">17,173</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total</strong></th>
+			<td style="text-align:right"><strong>3,704,382</strong></td>
+			<td style="text-align:right"><strong>88%</strong></td>
+			<td style="text-align:right"><strong>83,769</strong></td>
+			<td style="text-align:right"><strong>3,143,914</strong></td>
+			<td style="text-align:right"><strong>75%</strong></td>
+			<td style="text-align:right"><strong>644,237</strong></td>
+			<td style="text-align:right"><strong>4,209,057</strong></td>
+		</tr>
+	</tbody>
+</table>
+
+<p>First/second doses % are the number of first/second doses administered divided by the eligible population. First/second doses to 90% are the number of doses required to reach 90% of the eligible population. For these two measures, the national total may not be the sum of DHB measures.</p>
+
+<h4><a id="90pct Māori" name="90pct Māori">Māori</a></h4>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">&nbsp;</th>
+			<th scope="col" style="text-align:right">First doses</th>
+			<th scope="col" style="text-align:right">First doses %</th>
+			<th scope="col" style="text-align:right">First doses to 90%</th>
+			<th scope="col" style="text-align:right">Second doses</th>
+			<th scope="col" style="text-align:right">Second doses %</th>
+			<th scope="col" style="text-align:right">Second doses to 90%</th>
+			<th scope="col" style="text-align:right">Population</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">Northland</th>
+			<td style="text-align:right">33,879</td>
+			<td style="text-align:right">67%</td>
+			<td style="text-align:right">11,560</td>
+			<td style="text-align:right">23,647</td>
+			<td style="text-align:right">47%</td>
+			<td style="text-align:right">21,792</td>
+			<td style="text-align:right">50,488</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waitemata</th>
+			<td style="text-align:right">32,825</td>
+			<td style="text-align:right">80%</td>
+			<td style="text-align:right">4,177</td>
+			<td style="text-align:right">25,340</td>
+			<td style="text-align:right">62%</td>
+			<td style="text-align:right">11,662</td>
+			<td style="text-align:right">41,113</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Auckland</th>
+			<td style="text-align:right">22,930</td>
+			<td style="text-align:right">83%</td>
+			<td style="text-align:right">2,083</td>
+			<td style="text-align:right">18,137</td>
+			<td style="text-align:right">65%</td>
+			<td style="text-align:right">6,876</td>
+			<td style="text-align:right">27,792</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Counties Manukau</th>
+			<td style="text-align:right">46,550</td>
+			<td style="text-align:right">73%</td>
+			<td style="text-align:right">10,594</td>
+			<td style="text-align:right">33,822</td>
+			<td style="text-align:right">53%</td>
+			<td style="text-align:right">23,322</td>
+			<td style="text-align:right">63,493</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waikato</th>
+			<td style="text-align:right">50,726</td>
+			<td style="text-align:right">73%</td>
+			<td style="text-align:right">12,010</td>
+			<td style="text-align:right">35,792</td>
+			<td style="text-align:right">51%</td>
+			<td style="text-align:right">26,944</td>
+			<td style="text-align:right">69,707</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Lakes</th>
+			<td style="text-align:right">19,595</td>
+			<td style="text-align:right">65%</td>
+			<td style="text-align:right">7,482</td>
+			<td style="text-align:right">13,903</td>
+			<td style="text-align:right">46%</td>
+			<td style="text-align:right">13,174</td>
+			<td style="text-align:right">30,085</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Bay of Plenty</th>
+			<td style="text-align:right">30,629</td>
+			<td style="text-align:right">64%</td>
+			<td style="text-align:right">12,332</td>
+			<td style="text-align:right">21,545</td>
+			<td style="text-align:right">45%</td>
+			<td style="text-align:right">21,416</td>
+			<td style="text-align:right">47,734</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Tairawhiti</th>
+			<td style="text-align:right">13,411</td>
+			<td style="text-align:right">68%</td>
+			<td style="text-align:right">4,444</td>
+			<td style="text-align:right">9,866</td>
+			<td style="text-align:right">50%</td>
+			<td style="text-align:right">7,989</td>
+			<td style="text-align:right">19,839</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Taranaki</th>
+			<td style="text-align:right">10,867</td>
+			<td style="text-align:right">68%</td>
+			<td style="text-align:right">3,447</td>
+			<td style="text-align:right">7,233</td>
+			<td style="text-align:right">45%</td>
+			<td style="text-align:right">7,081</td>
+			<td style="text-align:right">15,904</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hawkes Bay</th>
+			<td style="text-align:right">22,883</td>
+			<td style="text-align:right">67%</td>
+			<td style="text-align:right">7,770</td>
+			<td style="text-align:right">16,533</td>
+			<td style="text-align:right">49%</td>
+			<td style="text-align:right">14,120</td>
+			<td style="text-align:right">34,059</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">MidCentral</th>
+			<td style="text-align:right">17,342</td>
+			<td style="text-align:right">72%</td>
+			<td style="text-align:right">4,460</td>
+			<td style="text-align:right">12,563</td>
+			<td style="text-align:right">52%</td>
+			<td style="text-align:right">9,240</td>
+			<td style="text-align:right">24,225</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Whanganui</th>
+			<td style="text-align:right">8,806</td>
+			<td style="text-align:right">65%</td>
+			<td style="text-align:right">3,355</td>
+			<td style="text-align:right">6,614</td>
+			<td style="text-align:right">49%</td>
+			<td style="text-align:right">5,547</td>
+			<td style="text-align:right">13,512</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Capital and Coast</th>
+			<td style="text-align:right">21,548</td>
+			<td style="text-align:right">80%</td>
+			<td style="text-align:right">2,722</td>
+			<td style="text-align:right">16,788</td>
+			<td style="text-align:right">62%</td>
+			<td style="text-align:right">7,482</td>
+			<td style="text-align:right">26,967</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hutt Valley</th>
+			<td style="text-align:right">13,990</td>
+			<td style="text-align:right">73%</td>
+			<td style="text-align:right">3,221</td>
+			<td style="text-align:right">10,378</td>
+			<td style="text-align:right">54%</td>
+			<td style="text-align:right">6,833</td>
+			<td style="text-align:right">19,123</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Wairarapa</th>
+			<td style="text-align:right">4,418</td>
+			<td style="text-align:right">70%</td>
+			<td style="text-align:right">1,254</td>
+			<td style="text-align:right">3,183</td>
+			<td style="text-align:right">51%</td>
+			<td style="text-align:right">2,489</td>
+			<td style="text-align:right">6,302</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Nelson Marlborough</th>
+			<td style="text-align:right">7,951</td>
+			<td style="text-align:right">71%</td>
+			<td style="text-align:right">2,172</td>
+			<td style="text-align:right">6,037</td>
+			<td style="text-align:right">54%</td>
+			<td style="text-align:right">4,086</td>
+			<td style="text-align:right">11,248</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">West Coast</th>
+			<td style="text-align:right">1,992</td>
+			<td style="text-align:right">72%</td>
+			<td style="text-align:right">496</td>
+			<td style="text-align:right">1,451</td>
+			<td style="text-align:right">52%</td>
+			<td style="text-align:right">1,038</td>
+			<td style="text-align:right">2,765</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Canterbury</th>
+			<td style="text-align:right">28,438</td>
+			<td style="text-align:right">77%</td>
+			<td style="text-align:right">4,834</td>
+			<td style="text-align:right">20,004</td>
+			<td style="text-align:right">54%</td>
+			<td style="text-align:right">13,268</td>
+			<td style="text-align:right">36,969</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">South Canterbury</th>
+			<td style="text-align:right">2,458</td>
+			<td style="text-align:right">72%</td>
+			<td style="text-align:right">627</td>
+			<td style="text-align:right">1,828</td>
+			<td style="text-align:right">53%</td>
+			<td style="text-align:right">1,257</td>
+			<td style="text-align:right">3,428</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Southern</th>
+			<td style="text-align:right">17,908</td>
+			<td style="text-align:right">76%</td>
+			<td style="text-align:right">3,373</td>
+			<td style="text-align:right">13,811</td>
+			<td style="text-align:right">58%</td>
+			<td style="text-align:right">7,470</td>
+			<td style="text-align:right">23,646</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Overseas / Unknown</th>
+			<td style="text-align:right">189</td>
+			<td style="text-align:right">7%</td>
+			<td style="text-align:right">2,199</td>
+			<td style="text-align:right">137</td>
+			<td style="text-align:right">5%</td>
+			<td style="text-align:right">2,251</td>
+			<td style="text-align:right">2,653</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total</strong></th>
+			<td style="text-align:right"><strong>409,335</strong></td>
+			<td style="text-align:right"><strong>72%</strong></td>
+			<td style="text-align:right"><strong>104,612</strong></td>
+			<td style="text-align:right"><strong>298,612</strong></td>
+			<td style="text-align:right"><strong>52%</strong></td>
+			<td style="text-align:right"><strong>215,335</strong></td>
+			<td style="text-align:right"><strong>571,052</strong></td>
+		</tr>
+	</tbody>
+</table>
+
+<h4><a id="90pct Pacific Peoples" name="90pct Pacific Peoples"></a>Pacific Peoples</h4>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">&nbsp;</th>
+			<th scope="col" style="text-align:right">First doses</th>
+			<th scope="col" style="text-align:right">First doses %</th>
+			<th scope="col" style="text-align:right">First doses to 90%</th>
+			<th scope="col" style="text-align:right">Second doses</th>
+			<th scope="col" style="text-align:right">Second doses %</th>
+			<th scope="col" style="text-align:right">Second doses to 90%</th>
+			<th scope="col" style="text-align:right">Population</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">Northland</th>
+			<td style="text-align:right">2,366</td>
+			<td style="text-align:right">81%</td>
+			<td style="text-align:right">275</td>
+			<td style="text-align:right">1,740</td>
+			<td style="text-align:right">59%</td>
+			<td style="text-align:right">901</td>
+			<td style="text-align:right">2,934</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waitemata</th>
+			<td style="text-align:right">32,094</td>
+			<td style="text-align:right">85%</td>
+			<td style="text-align:right">1,722</td>
+			<td style="text-align:right">25,974</td>
+			<td style="text-align:right">69%</td>
+			<td style="text-align:right">7,842</td>
+			<td style="text-align:right">37,573</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Auckland</th>
+			<td style="text-align:right">39,554</td>
+			<td style="text-align:right">84%</td>
+			<td style="text-align:right">2,625</td>
+			<td style="text-align:right">32,161</td>
+			<td style="text-align:right">69%</td>
+			<td style="text-align:right">10,018</td>
+			<td style="text-align:right">46,866</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Counties Manukau</th>
+			<td style="text-align:right">97,005</td>
+			<td style="text-align:right">83%</td>
+			<td style="text-align:right">7,843</td>
+			<td style="text-align:right">78,432</td>
+			<td style="text-align:right">67%</td>
+			<td style="text-align:right">26,416</td>
+			<td style="text-align:right">116,498</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waikato</th>
+			<td style="text-align:right">9,153</td>
+			<td style="text-align:right">86%</td>
+			<td style="text-align:right">461</td>
+			<td style="text-align:right">7,268</td>
+			<td style="text-align:right">68%</td>
+			<td style="text-align:right">2,346</td>
+			<td style="text-align:right">10,682</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Lakes</th>
+			<td style="text-align:right">1,818</td>
+			<td style="text-align:right">80%</td>
+			<td style="text-align:right">239</td>
+			<td style="text-align:right">1,432</td>
+			<td style="text-align:right">63%</td>
+			<td style="text-align:right">625</td>
+			<td style="text-align:right">2,286</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Bay of Plenty</th>
+			<td style="text-align:right">4,013</td>
+			<td style="text-align:right">&gt;95%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">3,109</td>
+			<td style="text-align:right">85%</td>
+			<td style="text-align:right">202</td>
+			<td style="text-align:right">3,679</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Tairawhiti</th>
+			<td style="text-align:right">869</td>
+			<td style="text-align:right">90%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">673</td>
+			<td style="text-align:right">70%</td>
+			<td style="text-align:right">196</td>
+			<td style="text-align:right">965</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Taranaki</th>
+			<td style="text-align:right">1,054</td>
+			<td style="text-align:right">83%</td>
+			<td style="text-align:right">89</td>
+			<td style="text-align:right">795</td>
+			<td style="text-align:right">63%</td>
+			<td style="text-align:right">348</td>
+			<td style="text-align:right">1,270</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hawkes Bay</th>
+			<td style="text-align:right">5,113</td>
+			<td style="text-align:right">&gt;95%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">4,199</td>
+			<td style="text-align:right">84%</td>
+			<td style="text-align:right">319</td>
+			<td style="text-align:right">5,020</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">MidCentral</th>
+			<td style="text-align:right">3,777</td>
+			<td style="text-align:right">85%</td>
+			<td style="text-align:right">244</td>
+			<td style="text-align:right">2,931</td>
+			<td style="text-align:right">66%</td>
+			<td style="text-align:right">1,090</td>
+			<td style="text-align:right">4,468</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Whanganui</th>
+			<td style="text-align:right">1,046</td>
+			<td style="text-align:right">76%</td>
+			<td style="text-align:right">197</td>
+			<td style="text-align:right">832</td>
+			<td style="text-align:right">60%</td>
+			<td style="text-align:right">411</td>
+			<td style="text-align:right">1,381</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Capital and Coast</th>
+			<td style="text-align:right">15,665</td>
+			<td style="text-align:right">82%</td>
+			<td style="text-align:right">1,594</td>
+			<td style="text-align:right">12,613</td>
+			<td style="text-align:right">66%</td>
+			<td style="text-align:right">4,646</td>
+			<td style="text-align:right">19,177</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hutt Valley</th>
+			<td style="text-align:right">7,950</td>
+			<td style="text-align:right">80%</td>
+			<td style="text-align:right">955</td>
+			<td style="text-align:right">6,318</td>
+			<td style="text-align:right">64%</td>
+			<td style="text-align:right">2,587</td>
+			<td style="text-align:right">9,894</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Wairarapa</th>
+			<td style="text-align:right">689</td>
+			<td style="text-align:right">82%</td>
+			<td style="text-align:right">64</td>
+			<td style="text-align:right">566</td>
+			<td style="text-align:right">68%</td>
+			<td style="text-align:right">187</td>
+			<td style="text-align:right">837</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Nelson Marlborough</th>
+			<td style="text-align:right">3,609</td>
+			<td style="text-align:right">&gt;95%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">3,165</td>
+			<td style="text-align:right">&gt;95%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">2,115</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">West Coast</th>
+			<td style="text-align:right">232</td>
+			<td style="text-align:right">82%</td>
+			<td style="text-align:right">22</td>
+			<td style="text-align:right">177</td>
+			<td style="text-align:right">63%</td>
+			<td style="text-align:right">77</td>
+			<td style="text-align:right">282</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Canterbury</th>
+			<td style="text-align:right">10,752</td>
+			<td style="text-align:right">84%</td>
+			<td style="text-align:right">711</td>
+			<td style="text-align:right">8,103</td>
+			<td style="text-align:right">64%</td>
+			<td style="text-align:right">3,360</td>
+			<td style="text-align:right">12,737</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">South Canterbury</th>
+			<td style="text-align:right">790</td>
+			<td style="text-align:right">94%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">588</td>
+			<td style="text-align:right">70%</td>
+			<td style="text-align:right">165</td>
+			<td style="text-align:right">837</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Southern</th>
+			<td style="text-align:right">5,595</td>
+			<td style="text-align:right">93%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">4,516</td>
+			<td style="text-align:right">75%</td>
+			<td style="text-align:right">912</td>
+			<td style="text-align:right">6,031</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Overseas / Unknown</th>
+			<td style="text-align:right">337</td>
+			<td style="text-align:right">29%</td>
+			<td style="text-align:right">697</td>
+			<td style="text-align:right">293</td>
+			<td style="text-align:right">26%</td>
+			<td style="text-align:right">741</td>
+			<td style="text-align:right">1,149</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total</strong></th>
+			<td style="text-align:right"><strong>243,481</strong></td>
+			<td style="text-align:right"><strong>85%</strong></td>
+			<td style="text-align:right"><strong>14,532</strong></td>
+			<td style="text-align:right"><strong>195,885</strong></td>
+			<td style="text-align:right"><strong>68%</strong></td>
+			<td style="text-align:right"><strong>62,128</strong></td>
+			<td style="text-align:right"><strong>286,681</strong></td>
+		</tr>
+	</tbody>
+</table>
+<!--daily_end-->
+
+<hr/>
+<h2><a id="weekly-updates" name="weekly-updates"></a>COVID-19 vaccinations: weekly updates</h2>
+
+<div class="well well-sm">
+<p style="margin-top: 0"><strong>Data in this section is as at 11:59pm 26 October 2021 and is updated weekly on Wednesdays.</strong></p>
+</div>
+
+<h3><a id="model" model="" name="id="></a>Cumulative vaccinations</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccination doses administered compared to plan doses" class="img-responsive" height="830" src="/web/20211031120029im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/vaccineplanmodel_13.png" width="1780"/></figure>
+
+<p>Production plan figures are the volumes agreed with DHBs and national providers for expected vaccinations. These figures have been matched with expected supply. Detailed plans are available in the Excel file at the bottom of this page.</p>
+
+<p>The Stock received figures are the cumulative supply of doses to date.</p>
+
+<p>DHB capacity plans for the remainder of the year are undergoing review.</p>
+
+<hr/><!--
+<h3><a id="model" model="" name="id="></a>Cumulative vaccinations for last 6 weeks</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccination doses administered compared to plan doses - 6wks" class="img-responsive" height="830" src="/vaccineplanmodel_wks.png" width="1780" /></figure>
+
+<hr />
+-->
+<h3><a id="uptake" name="uptake"></a>Vaccine uptake</h3>
+
+<p>Maps and data related to uptake rates of the COVID-19 vaccine across the country are available on the pages linked below. These show&nbsp;vaccination records aggregated by area of residence for all New Zealand residents, Māori communities, and Pacific communities.</p>
+
+<ul>
+	<li><a href="/web/20211031120029/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-across-nz">COVID-19 Vaccination uptake rates across NZ</a></li>
+	<li><a href="/web/20211031120029/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-maori-communities-across-nz">COVID-19 Vaccination uptake rates within Māori communities across NZ</a></li>
+	<li><a href="/web/20211031120029/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-pacific-communities-across-nz">COVID-19 Vaccination uptake rates within Pacific communities across NZ</a></li>
+</ul>
+
+<h4><a id="uptake" name="uptake"></a>Vaccine uptake per rate ratio (unadjusted) Māori and Pacific compared with Non-Māori non-Pacific</h4>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine Uptake per 1,000 (HSU) Rate Ratio, Showing Prioritised Ethnicity, vs Non-Māori Non-Pacific, By Age Band" class="img-responsive" height="830" src="/web/20211031120029im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_mix_8.png" width="1780"/></figure>
+
+<p>In the Chart above, rate ratios tell us the rate Māori or Pacific People per population are being vaccinated compared with non-Māori non-Pacific. This comparison can be split by age group.</p>
+
+<ul>
+	<li>A rate of one means the groups being compared are being vaccinated at the same rate.</li>
+	<li>A rate over one means Māori (or Pacific) are being vaccinated at a higher rate than non-Māori non-Pacific.</li>
+	<li>A rate under one means Māori (or Pacific) are being vaccinated at a lower rate than non-Māori non-Pacific.</li>
+</ul>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<td colspan="2" style="border-top: 0 !important; border-bottom-color: #FDD6AF !important; border-right: 0 !important;">&nbsp;</td>
+			<th colspan="6" id="ac1">Māori</th>
+			<th colspan="6" id="ac8">Pacific Peoples</th>
+		</tr>
+		<tr>
+			<th id="ar1">DHB</th>
+			<th>Dose number</th>
+			<th headers="ac1" id="ac2">65+</th>
+			<th headers="ac1" id="ac3">50-64</th>
+			<th headers="ac1" id="ac4">35-49</th>
+			<th headers="ac1" id="ac5">20-34</th>
+			<th headers="ac1" id="ac6">12-19</th>
+			<th headers="ac1" id="ac7">All ages</th>
+			<th headers="ac8" id="ac9">65+</th>
+			<th headers="ac8" id="ac10">50-64</th>
+			<th headers="ac8" id="ac11">35-49</th>
+			<th headers="ac8" id="ac12">20-34</th>
+			<th headers="ac8" id="ac13">12-19</th>
+			<th headers="ac8" id="ac14">All ages</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th headers="ar1" id="ar2" rowspan="2">National</th>
+			<th headers="ar1 ar2" id="ar3">Dose 1</th>
+			<td headers="ar1 ar2 ar3 ac1 ac2" style="background-color:green; color: #FFF;"><strong>0.99</strong></td>
+			<td headers="ar1 ar2 ar3 ac1 ac3" style="background-color:mediumseagreen"><strong>0.93</strong></td>
+			<td headers="ar1 ar2 ar3 ac1 ac4" style="background-color:yellow"><strong>0.79</strong></td>
+			<td headers="ar1 ar2 ar3 ac1 ac5" style="background-color:coral"><strong>0.67</strong></td>
+			<td headers="ar1 ar2 ar3 ac1 ac6" style="background-color:orange"><strong>0.71</strong></td>
+			<td headers="ar1 ar2 ar3 ac1 ac7" style="background-color:yellow"><strong>0.77</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac9" style="background-color:mediumseagreen"><strong>0.94</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac10" style="background-color:green; color: #FFF;"><strong>0.99</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac11" style="background-color:green; color: #FFF;"><strong>0.98</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac12" style="background-color:lightgreen"><strong>0.89</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac13" style="background-color:mediumseagreen"><strong>0.90</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac14" style="background-color:mediumseagreen"><strong>0.93</strong></td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar2" id="ar4">Dose 2</th>
+			<td headers="ar1 ar2 ar4 ac1 ac2" style="background-color:green; color: #FFF;"><strong>0.96</strong></td>
+			<td headers="ar1 ar2 ar4 ac1 ac3" style="background-color:lightgreen"><strong>0.87</strong></td>
+			<td headers="ar1 ar2 ar4 ac1 ac4" style="background-color:coral"><strong>0.68</strong></td>
+			<td headers="ar1 ar2 ar4 ac1 ac5" style="background-color:crimson; color: #FFF;"><strong>0.51</strong></td>
+			<td headers="ar1 ar2 ar4 ac1 ac6" style="background-color:crimson; color: #FFF;"><strong>0.57</strong></td>
+			<td headers="ar1 ar2 ar4 ac1 ac7" style="background-color:coral"><strong>0.65</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac9" style="background-color:mediumseagreen"><strong>0.92</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac10" style="background-color:green; color: #FFF;"><strong>0.99</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac11" style="background-color:green; color: #FFF;"><strong>0.97</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac12" style="background-color:palegreen"><strong>0.82</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac13" style="background-color:lightgreen"><strong>0.86</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac14" style="background-color:lightgreen"><strong>0.86</strong></td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar5" rowspan="2">Northland</th>
+			<th headers="ar1 ar5" id="ar6">Dose 1</th>
+			<td headers="ar1 ar5 ar6 ac1 ac2" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar5 ar6 ac1 ac3" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar5 ar6 ac1 ac4" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar5 ar6 ac1 ac5" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar5 ar6 ac1 ac6" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar5 ar6 ac1 ac7" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar5 ar6 ac8 ac9" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar5 ar6 ac8 ac10" style="background-color:green; color: #FFF;">1.06</td>
+			<td headers="ar1 ar5 ar6 ac8 ac11" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar5 ar6 ac8 ac12" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar5 ar6 ac8 ac13" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar5 ar6 ac8 ac14" style="background-color:mediumseagreen">0.94</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar5" id="ar7">Dose 2</th>
+			<td headers="ar1 ar5 ar7 ac1 ac2" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar5 ar7 ac1 ac3" style="background-color:lightgreen">0.87</td>
+			<td headers="ar1 ar5 ar7 ac1 ac4" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar5 ar7 ac1 ac5" style="background-color:crimson; color: #FFF;">0.49</td>
+			<td headers="ar1 ar5 ar7 ac1 ac6" style="background-color:crimson; color: #FFF;">0.59</td>
+			<td headers="ar1 ar5 ar7 ac1 ac7" style="background-color:tomato">0.63</td>
+			<td headers="ar1 ar5 ar7 ac8 ac9" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar5 ar7 ac8 ac10" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar5 ar7 ac8 ac11" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar5 ar7 ac8 ac12" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar5 ar7 ac8 ac13" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar5 ar7 ac8 ac14" style="background-color:palegreen">0.80</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar8" rowspan="2">Auckland Metro</th>
+			<th headers="ar1 ar8" id="ar9">Dose 1</th>
+			<td headers="ar1 ar8 ar9 ac1 ac2" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar8 ar9 ac1 ac3" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar8 ar9 ac1 ac4" style="background-color:palegreen">0.81</td>
+			<td headers="ar1 ar8 ar9 ac1 ac5" style="background-color:orange">0.72</td>
+			<td headers="ar1 ar8 ar9 ac1 ac6" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar8 ar9 ac1 ac7" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar8 ar9 ac8 ac9" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar8 ar9 ac8 ac10" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar8 ar9 ac8 ac11" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar8 ar9 ac8 ac12" style="background-color:palegreen">0.81</td>
+			<td headers="ar1 ar8 ar9 ac8 ac13" style="background-color:palegreen">0.84</td>
+			<td headers="ar1 ar8 ar9 ac8 ac14" style="background-color:lightgreen">0.88</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar8" id="ar10">Dose 2</th>
+			<td headers="ar1 ar8 ar10 ac1 ac2" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar8 ar10 ac1 ac3" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar8 ar10 ac1 ac4" style="background-color:coral">0.69</td>
+			<td headers="ar1 ar8 ar10 ac1 ac5" style="background-color:crimson; color: #FFF;">0.54</td>
+			<td headers="ar1 ar8 ar10 ac1 ac6" style="background-color:crimson; color: #FFF;">0.59</td>
+			<td headers="ar1 ar8 ar10 ac1 ac7" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar8 ar10 ac8 ac9" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar8 ar10 ac8 ac10" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar8 ar10 ac8 ac11" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar8 ar10 ac8 ac12" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar8 ar10 ac8 ac13" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar8 ar10 ac8 ac14" style="background-color:yellow">0.78</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar11" rowspan="2">Waikato</th>
+			<th headers="ar1 ar11" id="ar12">Dose 1</th>
+			<td headers="ar1 ar11 ar12 ac1 ac2" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar11 ar12 ac1 ac3" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar11 ar12 ac1 ac4" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar11 ar12 ac1 ac5" style="background-color:coral">0.69</td>
+			<td headers="ar1 ar11 ar12 ac1 ac6" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar11 ar12 ac1 ac7" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar11 ar12 ac8 ac9" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar11 ar12 ac8 ac10" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar11 ar12 ac8 ac11" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar11 ar12 ac8 ac12" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar11 ar12 ac8 ac13" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar11 ar12 ac8 ac14" style="background-color:mediumseagreen">0.94</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar11" id="ar13">Dose 2</th>
+			<td headers="ar1 ar11 ar13 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar11 ar13 ac1 ac3" style="background-color:lightgreen">0.87</td>
+			<td headers="ar1 ar11 ar13 ac1 ac4" style="background-color:coral">0.68</td>
+			<td headers="ar1 ar11 ar13 ac1 ac5" style="background-color:crimson; color: #FFF;">0.50</td>
+			<td headers="ar1 ar11 ar13 ac1 ac6" style="background-color:crimson; color: #FFF;">0.57</td>
+			<td headers="ar1 ar11 ar13 ac1 ac7" style="background-color:tomato">0.64</td>
+			<td headers="ar1 ar11 ar13 ac8 ac9" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar11 ar13 ac8 ac10" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar11 ar13 ac8 ac11" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar11 ar13 ac8 ac12" style="background-color:palegreen">0.84</td>
+			<td headers="ar1 ar11 ar13 ac8 ac13" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar11 ar13 ac8 ac14" style="background-color:lightgreen">0.87</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar14" rowspan="2">Bay of Plenty</th>
+			<th headers="ar1 ar14" id="ar15">Dose 1</th>
+			<td headers="ar1 ar14 ar15 ac1 ac2" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar14 ar15 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar14 ar15 ac1 ac4" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar14 ar15 ac1 ac5" style="background-color:crimson; color: #FFF;">0.57</td>
+			<td headers="ar1 ar14 ar15 ac1 ac6" style="background-color:tomato">0.64</td>
+			<td headers="ar1 ar14 ar15 ac1 ac7" style="background-color:orange">0.72</td>
+			<td headers="ar1 ar14 ar15 ac8 ac9" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar14 ar15 ac8 ac10" style="background-color:green; color: #FFF;">1.09</td>
+			<td headers="ar1 ar14 ar15 ac8 ac11" style="background-color:green; color: #FFF;">1.47</td>
+			<td headers="ar1 ar14 ar15 ac8 ac12" style="background-color:green; color: #FFF;">1.52</td>
+			<td headers="ar1 ar14 ar15 ac8 ac13" style="background-color:lightgreen">0.87</td>
+			<td headers="ar1 ar14 ar15 ac8 ac14" style="background-color:green; color: #FFF;">1.23</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar14" id="ar16">Dose 2</th>
+			<td headers="ar1 ar14 ar16 ac1 ac2" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar14 ar16 ac1 ac3" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar14 ar16 ac1 ac4" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar14 ar16 ac1 ac5" style="background-color:crimson; color: #FFF;">0.46</td>
+			<td headers="ar1 ar14 ar16 ac1 ac6" style="background-color:crimson; color: #FFF;">0.54</td>
+			<td headers="ar1 ar14 ar16 ac1 ac7" style="background-color:tomato">0.60</td>
+			<td headers="ar1 ar14 ar16 ac8 ac9" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar14 ar16 ac8 ac10" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar14 ar16 ac8 ac11" style="background-color:green; color: #FFF;">1.60</td>
+			<td headers="ar1 ar14 ar16 ac8 ac12" style="background-color:green; color: #FFF;">1.78</td>
+			<td headers="ar1 ar14 ar16 ac8 ac13" style="background-color:yellow">0.77</td>
+			<td headers="ar1 ar14 ar16 ac8 ac14" style="background-color:green; color: #FFF;">1.15</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar17" rowspan="2">Tairawhiti</th>
+			<th headers="ar1 ar17" id="ar18">Dose 1</th>
+			<td headers="ar1 ar17 ar18 ac1 ac2" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar17 ar18 ac1 ac3" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar17 ar18 ac1 ac4" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar17 ar18 ac1 ac5" style="background-color:tomato">0.62</td>
+			<td headers="ar1 ar17 ar18 ac1 ac6" style="background-color:coral">0.69</td>
+			<td headers="ar1 ar17 ar18 ac1 ac7" style="background-color:yellow">0.76</td>
+			<td headers="ar1 ar17 ar18 ac8 ac9" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar17 ar18 ac8 ac10" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar17 ar18 ac8 ac11" style="background-color:green; color: #FFF;">1.10</td>
+			<td headers="ar1 ar17 ar18 ac8 ac12" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar17 ar18 ac8 ac13" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar17 ar18 ac8 ac14" style="background-color:green; color: #FFF;">1.01</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar17" id="ar19">Dose 2</th>
+			<td headers="ar1 ar17 ar19 ac1 ac2" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar17 ar19 ac1 ac3" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar17 ar19 ac1 ac4" style="background-color:coral">0.68</td>
+			<td headers="ar1 ar17 ar19 ac1 ac5" style="background-color:crimson; color: #FFF;">0.49</td>
+			<td headers="ar1 ar17 ar19 ac1 ac6" style="background-color:crimson; color: #FFF;">0.55</td>
+			<td headers="ar1 ar17 ar19 ac1 ac7" style="background-color:tomato">0.64</td>
+			<td headers="ar1 ar17 ar19 ac8 ac9" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar17 ar19 ac8 ac10" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar17 ar19 ac8 ac11" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar17 ar19 ac8 ac12" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar17 ar19 ac8 ac13" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar17 ar19 ac8 ac14" style="background-color:mediumseagreen">0.90</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar20" rowspan="2">Lakes</th>
+			<th headers="ar1 ar20" id="ar21">Dose 1</th>
+			<td headers="ar1 ar20 ar21 ac1 ac2" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar20 ar21 ac1 ac3" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar20 ar21 ac1 ac4" style="background-color:yellow">0.76</td>
+			<td headers="ar1 ar20 ar21 ac1 ac5" style="background-color:crimson; color: #FFF;">0.58</td>
+			<td headers="ar1 ar20 ar21 ac1 ac6" style="background-color:coral">0.65</td>
+			<td headers="ar1 ar20 ar21 ac1 ac7" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar20 ar21 ac8 ac9" style="background-color:green; color: #FFF;">1.06</td>
+			<td headers="ar1 ar20 ar21 ac8 ac10" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar20 ar21 ac8 ac11" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar20 ar21 ac8 ac12" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar20 ar21 ac8 ac13" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar20 ar21 ac8 ac14" style="background-color:mediumseagreen">0.90</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar20" id="ar22">Dose 2</th>
+			<td headers="ar1 ar20 ar22 ac1 ac2" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar20 ar22 ac1 ac3" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar20 ar22 ac1 ac4" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar20 ar22 ac1 ac5" style="background-color:crimson; color: #FFF;">0.44</td>
+			<td headers="ar1 ar20 ar22 ac1 ac6" style="background-color:crimson; color: #FFF;">0.53</td>
+			<td headers="ar1 ar20 ar22 ac1 ac7" style="background-color:tomato">0.61</td>
+			<td headers="ar1 ar20 ar22 ac8 ac9" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar20 ar22 ac8 ac10" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar20 ar22 ac8 ac11" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar20 ar22 ac8 ac12" style="background-color:palegreen">0.83</td>
+			<td headers="ar1 ar20 ar22 ac8 ac13" style="background-color:lightgreen">0.86</td>
+			<td headers="ar1 ar20 ar22 ac8 ac14" style="background-color:palegreen">0.83</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar23" rowspan="2">Taranaki</th>
+			<th headers="ar1 ar23" id="ar24">Dose 1</th>
+			<td headers="ar1 ar23 ar24 ac1 ac2" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar23 ar24 ac1 ac3" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar23 ar24 ac1 ac4" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar23 ar24 ac1 ac5" style="background-color:coral">0.68</td>
+			<td headers="ar1 ar23 ar24 ac1 ac6" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar23 ar24 ac1 ac7" style="background-color:yellow">0.77</td>
+			<td headers="ar1 ar23 ar24 ac8 ac9" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar23 ar24 ac8 ac10" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar23 ar24 ac8 ac11" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar23 ar24 ac8 ac12" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar23 ar24 ac8 ac13" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar23 ar24 ac8 ac14" style="background-color:mediumseagreen">0.94</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar23" id="ar25">Dose 2</th>
+			<td headers="ar1 ar23 ar25 ac1 ac2" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar23 ar25 ac1 ac3" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar23 ar25 ac1 ac4" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar23 ar25 ac1 ac5" style="background-color:crimson; color: #FFF;">0.52</td>
+			<td headers="ar1 ar23 ar25 ac1 ac6" style="background-color:crimson; color: #FFF;">0.56</td>
+			<td headers="ar1 ar23 ar25 ac1 ac7" style="background-color:tomato">0.64</td>
+			<td headers="ar1 ar23 ar25 ac8 ac9" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar23 ar25 ac8 ac10" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar23 ar25 ac8 ac11" style="background-color:green; color: #FFF;">1.21</td>
+			<td headers="ar1 ar23 ar25 ac8 ac12" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar23 ar25 ac8 ac13" style="background-color:lightgreen">0.87</td>
+			<td headers="ar1 ar23 ar25 ac8 ac14" style="background-color:lightgreen">0.89</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar26" rowspan="2">Whanganui</th>
+			<th headers="ar1 ar26" id="ar27">Dose 1</th>
+			<td headers="ar1 ar26 ar27 ac1 ac2" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar26 ar27 ac1 ac3" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar26 ar27 ac1 ac4" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar26 ar27 ac1 ac5" style="background-color:coral">0.65</td>
+			<td headers="ar1 ar26 ar27 ac1 ac6" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar26 ar27 ac1 ac7" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar26 ar27 ac8 ac9" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar26 ar27 ac8 ac10" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar26 ar27 ac8 ac11" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar26 ar27 ac8 ac12" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar26 ar27 ac8 ac13" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar26 ar27 ac8 ac14" style="background-color:lightgreen">0.87</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar26" id="ar28">Dose 2</th>
+			<td headers="ar1 ar26 ar28 ac1 ac2" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar26 ar28 ac1 ac3" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar26 ar28 ac1 ac4" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar26 ar28 ac1 ac5" style="background-color:crimson; color: #FFF;">0.51</td>
+			<td headers="ar1 ar26 ar28 ac1 ac6" style="background-color:tomato">0.60</td>
+			<td headers="ar1 ar26 ar28 ac1 ac7" style="background-color:coral">0.65</td>
+			<td headers="ar1 ar26 ar28 ac8 ac9" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar26 ar28 ac8 ac10" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar26 ar28 ac8 ac11" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar26 ar28 ac8 ac12" style="background-color:palegreen">0.83</td>
+			<td headers="ar1 ar26 ar28 ac8 ac13" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar26 ar28 ac8 ac14" style="background-color:palegreen">0.80</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar29" rowspan="2">Hawke&#39;s Bay</th>
+			<th headers="ar1 ar29" id="ar30">Dose 1</th>
+			<td headers="ar1 ar29 ar30 ac1 ac2" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar29 ar30 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar29 ar30 ac1 ac4" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar29 ar30 ac1 ac5" style="background-color:crimson; color: #FFF;">0.59</td>
+			<td headers="ar1 ar29 ar30 ac1 ac6" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar29 ar30 ac1 ac7" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar29 ar30 ac8 ac9" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar29 ar30 ac8 ac10" style="background-color:green; color: #FFF;">1.05</td>
+			<td headers="ar1 ar29 ar30 ac8 ac11" style="background-color:green; color: #FFF;">1.42</td>
+			<td headers="ar1 ar29 ar30 ac8 ac12" style="background-color:green; color: #FFF;">1.32</td>
+			<td headers="ar1 ar29 ar30 ac8 ac13" style="background-color:lightgreen">0.88</td>
+			<td headers="ar1 ar29 ar30 ac8 ac14" style="background-color:green; color: #FFF;">1.16</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar29" id="ar31">Dose 2</th>
+			<td headers="ar1 ar29 ar31 ac1 ac2" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar29 ar31 ac1 ac3" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar29 ar31 ac1 ac4" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar29 ar31 ac1 ac5" style="background-color:crimson; color: #FFF;">0.47</td>
+			<td headers="ar1 ar29 ar31 ac1 ac6" style="background-color:crimson; color: #FFF;">0.57</td>
+			<td headers="ar1 ar29 ar31 ac1 ac7" style="background-color:tomato">0.61</td>
+			<td headers="ar1 ar29 ar31 ac8 ac9" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar29 ar31 ac8 ac10" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar29 ar31 ac8 ac11" style="background-color:green; color: #FFF;">1.48</td>
+			<td headers="ar1 ar29 ar31 ac8 ac12" style="background-color:green; color: #FFF;">1.48</td>
+			<td headers="ar1 ar29 ar31 ac8 ac13" style="background-color:lightgreen">0.86</td>
+			<td headers="ar1 ar29 ar31 ac8 ac14" style="background-color:green; color: #FFF;">1.10</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar32" rowspan="2">MidCentral</th>
+			<th headers="ar1 ar32" id="ar33">Dose 1</th>
+			<td headers="ar1 ar32 ar33 ac1 ac2" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar32 ar33 ac1 ac3" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar32 ar33 ac1 ac4" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar32 ar33 ac1 ac5" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar32 ar33 ac1 ac6" style="background-color:orange">0.72</td>
+			<td headers="ar1 ar32 ar33 ac1 ac7" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar32 ar33 ac8 ac9" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar32 ar33 ac8 ac10" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar32 ar33 ac8 ac11" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar32 ar33 ac8 ac12" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar32 ar33 ac8 ac13" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar32 ar33 ac8 ac14" style="background-color:mediumseagreen">0.94</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar32" id="ar34">Dose 2</th>
+			<td headers="ar1 ar32 ar34 ac1 ac2" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar32 ar34 ac1 ac3" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar32 ar34 ac1 ac4" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar32 ar34 ac1 ac5" style="background-color:crimson; color: #FFF;">0.58</td>
+			<td headers="ar1 ar32 ar34 ac1 ac6" style="background-color:tomato">0.60</td>
+			<td headers="ar1 ar32 ar34 ac1 ac7" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar32 ar34 ac8 ac9" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar32 ar34 ac8 ac10" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar32 ar34 ac8 ac11" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar32 ar34 ac8 ac12" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar32 ar34 ac8 ac13" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar32 ar34 ac8 ac14" style="background-color:lightgreen">0.85</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar35" rowspan="2">Wairarapa</th>
+			<th headers="ar1 ar35" id="ar36">Dose 1</th>
+			<td headers="ar1 ar35 ar36 ac1 ac2" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar35 ar36 ac1 ac3" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar35 ar36 ac1 ac4" style="background-color:palegreen">0.84</td>
+			<td headers="ar1 ar35 ar36 ac1 ac5" style="background-color:orange">0.72</td>
+			<td headers="ar1 ar35 ar36 ac1 ac6" style="background-color:yellow">0.77</td>
+			<td headers="ar1 ar35 ar36 ac1 ac7" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar35 ar36 ac8 ac9" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar35 ar36 ac8 ac10" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar35 ar36 ac8 ac11" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar35 ar36 ac8 ac12" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar35 ar36 ac8 ac13" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar35 ar36 ac8 ac14" style="background-color:mediumseagreen">0.92</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar35" id="ar37">Dose 2</th>
+			<td headers="ar1 ar35 ar37 ac1 ac2" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar35 ar37 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar35 ar37 ac1 ac4" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar35 ar37 ac1 ac5" style="background-color:crimson; color: #FFF;">0.55</td>
+			<td headers="ar1 ar35 ar37 ac1 ac6" style="background-color:tomato">0.63</td>
+			<td headers="ar1 ar35 ar37 ac1 ac7" style="background-color:tomato">0.64</td>
+			<td headers="ar1 ar35 ar37 ac8 ac9" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar35 ar37 ac8 ac10" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar35 ar37 ac8 ac11" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar35 ar37 ac8 ac12" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar35 ar37 ac8 ac13" style="background-color:palegreen">0.84</td>
+			<td headers="ar1 ar35 ar37 ac8 ac14" style="background-color:lightgreen">0.86</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar38" rowspan="2">Capital &amp; Coast and Hutt Valley</th>
+			<th headers="ar1 ar38" id="ar39">Dose 1</th>
+			<td headers="ar1 ar38 ar39 ac1 ac2" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar38 ar39 ac1 ac3" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar38 ar39 ac1 ac4" style="background-color:palegreen">0.83</td>
+			<td headers="ar1 ar38 ar39 ac1 ac5" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar38 ar39 ac1 ac6" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar38 ar39 ac1 ac7" style="background-color:palegreen">0.81</td>
+			<td headers="ar1 ar38 ar39 ac8 ac9" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar38 ar39 ac8 ac10" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar38 ar39 ac8 ac11" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar38 ar39 ac8 ac12" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar38 ar39 ac8 ac13" style="background-color:palegreen">0.84</td>
+			<td headers="ar1 ar38 ar39 ac8 ac14" style="background-color:lightgreen">0.86</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar38" id="ar40">Dose 2</th>
+			<td headers="ar1 ar38 ar40 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar38 ar40 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar38 ar40 ac1 ac4" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar38 ar40 ac1 ac5" style="background-color:tomato">0.63</td>
+			<td headers="ar1 ar38 ar40 ac1 ac6" style="background-color:tomato">0.62</td>
+			<td headers="ar1 ar38 ar40 ac1 ac7" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar38 ar40 ac8 ac9" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar38 ar40 ac8 ac10" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar38 ar40 ac8 ac11" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar38 ar40 ac8 ac12" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar38 ar40 ac8 ac13" style="background-color:yellow">0.76</td>
+			<td headers="ar1 ar38 ar40 ac8 ac14" style="background-color:palegreen">0.80</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar41" rowspan="2">Nelson Marlborough</th>
+			<th headers="ar1 ar41" id="ar42">Dose 1</th>
+			<td headers="ar1 ar41 ar42 ac1 ac2" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar41 ar42 ac1 ac3" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar41 ar42 ac1 ac4" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar41 ar42 ac1 ac5" style="background-color:coral">0.69</td>
+			<td headers="ar1 ar41 ar42 ac1 ac6" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar41 ar42 ac1 ac7" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar41 ar42 ac8 ac9" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar41 ar42 ac8 ac10" style="background-color:green; color: #FFF;">1.28</td>
+			<td headers="ar1 ar41 ar42 ac8 ac11" style="background-color:green; color: #FFF;">2.45</td>
+			<td headers="ar1 ar41 ar42 ac8 ac12" style="background-color:green; color: #FFF;">2.89</td>
+			<td headers="ar1 ar41 ar42 ac8 ac13" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar41 ar42 ac8 ac14" style="background-color:green; color: #FFF;">1.97</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar41" id="ar43">Dose 2</th>
+			<td headers="ar1 ar41 ar43 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar41 ar43 ac1 ac3" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar41 ar43 ac1 ac4" style="background-color:orange">0.72</td>
+			<td headers="ar1 ar41 ar43 ac1 ac5" style="background-color:crimson; color: #FFF;">0.57</td>
+			<td headers="ar1 ar41 ar43 ac1 ac6" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar41 ar43 ac1 ac7" style="background-color:coral">0.69</td>
+			<td headers="ar1 ar41 ar43 ac8 ac9" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar41 ar43 ac8 ac10" style="background-color:green; color: #FFF;">1.26</td>
+			<td headers="ar1 ar41 ar43 ac8 ac11" style="background-color:green; color: #FFF;">2.57</td>
+			<td headers="ar1 ar41 ar43 ac8 ac12" style="background-color:green; color: #FFF;">3.47</td>
+			<td headers="ar1 ar41 ar43 ac8 ac13" style="background-color:green; color: #FFF;">1.05</td>
+			<td headers="ar1 ar41 ar43 ac8 ac14" style="background-color:green; color: #FFF;">1.95</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar44" rowspan="2">West Coast</th>
+			<th headers="ar1 ar44" id="ar45">Dose 1</th>
+			<td headers="ar1 ar44 ar45 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar44 ar45 ac1 ac3" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar44 ar45 ac1 ac4" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar44 ar45 ac1 ac5" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar44 ar45 ac1 ac6" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar44 ar45 ac1 ac7" style="background-color:lightgreen">0.86</td>
+			<td headers="ar1 ar44 ar45 ac8 ac9" style="background-color:green; color: #FFF;">1.33</td>
+			<td headers="ar1 ar44 ar45 ac8 ac10" style="background-color:green; color: #FFF;">1.06</td>
+			<td headers="ar1 ar44 ar45 ac8 ac11" style="background-color:green; color: #FFF;">1.07</td>
+			<td headers="ar1 ar44 ar45 ac8 ac12" style="background-color:green; color: #FFF;">1.24</td>
+			<td headers="ar1 ar44 ar45 ac8 ac13" style="background-color:palegreen">0.83</td>
+			<td headers="ar1 ar44 ar45 ac8 ac14" style="background-color:green; color: #FFF;">0.99</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar44" id="ar46">Dose 2</th>
+			<td headers="ar1 ar44 ar46 ac1 ac2" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar44 ar46 ac1 ac3" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar44 ar46 ac1 ac4" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar44 ar46 ac1 ac5" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar44 ar46 ac1 ac6" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar44 ar46 ac1 ac7" style="background-color:yellow">0.76</td>
+			<td headers="ar1 ar44 ar46 ac8 ac9" style="background-color:green; color: #FFF;">1.33</td>
+			<td headers="ar1 ar44 ar46 ac8 ac10" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar44 ar46 ac8 ac11" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar44 ar46 ac8 ac12" style="background-color:green; color: #FFF;">1.57</td>
+			<td headers="ar1 ar44 ar46 ac8 ac13" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar44 ar46 ac8 ac14" style="background-color:mediumseagreen">0.91</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar47" rowspan="2">Canterbury</th>
+			<th headers="ar1 ar47" id="ar48">Dose 1</th>
+			<td headers="ar1 ar47 ar48 ac1 ac2" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar47 ar48 ac1 ac3" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar47 ar48 ac1 ac4" style="background-color:palegreen">0.83</td>
+			<td headers="ar1 ar47 ar48 ac1 ac5" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar47 ar48 ac1 ac6" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar47 ar48 ac1 ac7" style="background-color:palegreen">0.81</td>
+			<td headers="ar1 ar47 ar48 ac8 ac9" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar47 ar48 ac8 ac10" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar47 ar48 ac8 ac11" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar47 ar48 ac8 ac12" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar47 ar48 ac8 ac13" style="background-color:lightgreen">0.88</td>
+			<td headers="ar1 ar47 ar48 ac8 ac14" style="background-color:lightgreen">0.89</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar47" id="ar49">Dose 2</th>
+			<td headers="ar1 ar47 ar49 ac1 ac2" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar47 ar49 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar47 ar49 ac1 ac4" style="background-color:yellow">0.77</td>
+			<td headers="ar1 ar47 ar49 ac1 ac5" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar47 ar49 ac1 ac6" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar47 ar49 ac1 ac7" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar47 ar49 ac8 ac9" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar47 ar49 ac8 ac10" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar47 ar49 ac8 ac11" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar47 ar49 ac8 ac12" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar47 ar49 ac8 ac13" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar47 ar49 ac8 ac14" style="background-color:lightgreen">0.85</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar50" rowspan="2">South Canterbury</th>
+			<th headers="ar1 ar50" id="ar51">Dose 1</th>
+			<td headers="ar1 ar50 ar51 ac1 ac2" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar50 ar51 ac1 ac3" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar50 ar51 ac1 ac4" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar50 ar51 ac1 ac5" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar50 ar51 ac1 ac6" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar50 ar51 ac1 ac7" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar50 ar51 ac8 ac9" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar50 ar51 ac8 ac10" style="background-color:green; color: #FFF;">1.09</td>
+			<td headers="ar1 ar50 ar51 ac8 ac11" style="background-color:green; color: #FFF;">1.18</td>
+			<td headers="ar1 ar50 ar51 ac8 ac12" style="background-color:green; color: #FFF;">1.23</td>
+			<td headers="ar1 ar50 ar51 ac8 ac13" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar50 ar51 ac8 ac14" style="background-color:green; color: #FFF;">1.06</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar50" id="ar52">Dose 2</th>
+			<td headers="ar1 ar50 ar52 ac1 ac2" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar50 ar52 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar50 ar52 ac1 ac4" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar50 ar52 ac1 ac5" style="background-color:tomato">0.63</td>
+			<td headers="ar1 ar50 ar52 ac1 ac6" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar50 ar52 ac1 ac7" style="background-color:coral">0.69</td>
+			<td headers="ar1 ar50 ar52 ac8 ac9" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar50 ar52 ac8 ac10" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar50 ar52 ac8 ac11" style="background-color:green; color: #FFF;">1.09</td>
+			<td headers="ar1 ar50 ar52 ac8 ac12" style="background-color:green; color: #FFF;">1.15</td>
+			<td headers="ar1 ar50 ar52 ac8 ac13" style="background-color:green; color: #FFF;">1.05</td>
+			<td headers="ar1 ar50 ar52 ac8 ac14" style="background-color:lightgreen">0.89</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar53" rowspan="2">Southern</th>
+			<th headers="ar1 ar53" id="ar54">Dose 1</th>
+			<td headers="ar1 ar53 ar54 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar53 ar54 ac1 ac3" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar53 ar54 ac1 ac4" style="background-color:palegreen">0.83</td>
+			<td headers="ar1 ar53 ar54 ac1 ac5" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar53 ar54 ac1 ac6" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar53 ar54 ac1 ac7" style="background-color:palegreen">0.81</td>
+			<td headers="ar1 ar53 ar54 ac8 ac9" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar53 ar54 ac8 ac10" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar53 ar54 ac8 ac11" style="background-color:green; color: #FFF;">1.07</td>
+			<td headers="ar1 ar53 ar54 ac8 ac12" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar53 ar54 ac8 ac13" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar53 ar54 ac8 ac14" style="background-color:green; color: #FFF;">1.01</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar53" id="ar55">Dose 2</th>
+			<td headers="ar1 ar53 ar55 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar53 ar55 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar53 ar55 ac1 ac4" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar53 ar55 ac1 ac5" style="background-color:coral">0.66</td>
+			<td headers="ar1 ar53 ar55 ac1 ac6" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar53 ar55 ac1 ac7" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar53 ar55 ac8 ac9" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar53 ar55 ac8 ac10" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar53 ar55 ac8 ac11" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar53 ar55 ac8 ac12" style="background-color:green; color: #FFF;">1.05</td>
+			<td headers="ar1 ar53 ar55 ac8 ac13" style="background-color:lightgreen">0.87</td>
+			<td headers="ar1 ar53 ar55 ac8 ac14" style="background-color:mediumseagreen">0.93</td>
+		</tr>
+	</tbody>
+</table>
+
+<p>This table shows the rate of doses administered (per 1,000 population) to Māori or Pacific Peoples, relative to the rate of doses for Non-Māori and Non-Pacific groups. Less than one means the group is receiving a lower proportion of doses than would be expected if equity is being achieved. More than one means they are receiving a higher proportion of doses than would be expected if equity is being achieved. Exactly one means doses administered are in line with their proportion of population.</p>
+
+<ul>
+	<li><a download="" href="/web/20211031120029/https://www.health.govt.nz/system/files/documents/pages/rateratioexplainer_2.docx">Rate Ratio Explainer (Word, 434 KB)</a></li>
+</ul>
+
+<p>At all ages the size (weightings) of the age groups becomes a major contributing factor to comparative ratios, which is why the all ages (12+) figure may not appear to be in line with the age splits.</p>
+
+<h4><a id="uptake" name="uptake"></a>Vaccine uptake per 1,000 people by ethnicity</h4>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine uptake per 1,000 people by ethnicity" class="img-responsive" height="830" src="/web/20211031120029im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_eth_8.png" width="1780"/></figure>
+
+<h4><a id="uptake" name="uptake"></a>Vaccine uptake per 1,000 people by age band</h4>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine uptake per 1,000 people by age band" class="img-responsive" height="1030" src="/web/20211031120029im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_age_9.png" width="1780"/></figure>
+
+<h4><a id="uptake" name="location"></a>Vaccine uptake per 1,000 people by DHB of residence</h4>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine uptake per 1,000 people by DHB of residence" class="img-responsive" height="1030" src="/web/20211031120029im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_dhb_4.png" width="1780"/></figure>
+<!--
+<hr />
+<h3><a id="by_dhb_plan" name="dhb_plan"></a>Cumulative vaccination plan for DHBs</h3>
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">DHB of service</th>
+			<th scope="col" style="text-align:right">Actuals to Sunday 24 October</th>
+			<th scope="col" style="text-align:right">DHB Plan to Sunday 24 October</th>
+			<th scope="col" style="text-align:right">Variance</th>
+			<th scope="col" style="text-align:right">% of Plan</th>
+			<th scope="col" style="text-align:right">Week to date</th>
+		</tr>
+	</thead>
+	<tbody> --><!--plan--><!--
+<tr><td nowrap="nowrap">Auckland Metro</td><td>190621</td><td>205515</td><td>-14894</td><td>93%</td><td>9913</td></tr>
+<tr><td nowrap="nowrap">Bay of Plenty</td><td>22841</td><td>14255</td><td>8586</td><td>160%</td><td>1843</td></tr>
+<tr><td nowrap="nowrap">Canterbury</td><td>50558</td><td>39266</td><td>11292</td><td>129%</td><td>2769</td></tr>
+<tr><td nowrap="nowrap">Capital & Coast and Hutt Valley</td><td>48758</td><td>39742</td><td>9016</td><td>123%</td><td>1796</td></tr>
+<tr><td nowrap="nowrap">Hawke's Bay</td><td>15319</td><td>18205</td><td>-2886</td><td>84%</td><td>1351</td></tr>
+<tr><td nowrap="nowrap">Lakes</td><td>13437</td><td>12810</td><td>627</td><td>105%</td><td>731</td></tr>
+<tr><td nowrap="nowrap">MidCentral</td><td>10708</td><td>7237</td><td>3471</td><td>148%</td><td>1191</td></tr>
+<tr><td nowrap="nowrap">Nelson Marlborough</td><td>30198</td><td>18574</td><td>11624</td><td>163%</td><td>1285</td></tr>
+<tr><td nowrap="nowrap">Northland</td><td>21469</td><td>24762</td><td>-3293</td><td>87%</td><td>1257</td></tr>
+<tr><td nowrap="nowrap">South Canterbury</td><td>8106</td><td>8033</td><td>73</td><td>101%</td><td>389</td></tr>
+<tr><td nowrap="nowrap">Southern</td><td>35234</td><td>34594</td><td>640</td><td>102%</td><td>1794</td></tr>
+<tr><td nowrap="nowrap">Tairāwhiti</td><td>4579</td><td>4928</td><td>-349</td><td>93%</td><td>290</td></tr>
+<tr><td nowrap="nowrap">Taranaki</td><td>5619</td><td>5297</td><td>322</td><td>106%</td><td>168</td></tr>
+<tr><td nowrap="nowrap">Waikato</td><td>36070</td><td>32842</td><td>3228</td><td>110%</td><td>1905</td></tr>
+<tr><td nowrap="nowrap">Wairarapa</td><td>4516</td><td>4960</td><td>-444</td><td>91%</td><td>468</td></tr>
+<tr><td nowrap="nowrap">West Coast</td><td>3533</td><td>3300</td><td>233</td><td>107%</td><td>336</td></tr>
+<tr><td nowrap="nowrap">Whanganui</td><td>6982</td><td>4711</td><td>2271</td><td>148%</td><td>612</td></tr>
+<tr><td nowrap="nowrap">Other Sites</td><td>24890</td><td>14575</td><td>10315</td><td>171%</td><td>613</td></tr>
+<tr><td nowrap="nowrap">Total</td><td>533438</td><td>493606</td><td>39832</td><td>108%</td><td>28711</td></tr>
+!--plan_end--><!--	</tbody>
+</table>
+
+
+<p>The information provided in this table is based on cumulative DHB plans to the last week ending on Sunday. The final column shows vaccinations administered since Sunday by DHB of service to reconcile total actuals in this table to other total numbers shown.   On-going, and as we roll-out the vaccination programme, we anticipate that there could be a potential variance of up to ten percent (plus or minus) between DHB Plans and actual vaccination numbers. This is on the basis that, for example, an unplanned significant event could affect roll-out implementation or some DHBs might exceed their planned vaccination numbers.
+</p>
+-->
+
+<hr/>
+<h3><a id="by_dhb" name="location"></a>Cumulative vaccinations by DHB</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Cumulative vaccinations for DHBs" class="img-responsive" height="830" src="/web/20211031120029im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/dhbstacked_12.png" width="1780"/></figure>
+
+<hr/>
+<h3><a id="by-day" name="by-day"></a>Vaccinations by day</h3>
+
+<figure class="image-captioned img-responsive"><img alt="Vaccination doses administered per day" class="img-responsive" height="830" src="/web/20211031120029im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/vaccinebyday_12.png" width="1780"/></figure>
+
+<p>This chart shows the count of vaccinations administered on a given day from the COVID-19 Immunisation Register. Note some records are entered in the register at a later date than the immunisation was received. This means that the figures for a given date may move for some time after that date.</p>
+
+<hr/>
+<h3><a id="group" name="group"></a>Vaccinations by group by week</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccinations by group" class="img-responsive" height="830" src="/web/20211031120029im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/vaccinebygroupwk_12.png" width="1780"/></figure>
+
+<hr/>
+<h3><a id="group_d" name="group_d"></a>Cumulative vaccinations by group</h3>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">Priority Group</th>
+			<th scope="col" style="text-align:right">First dose administered</th>
+			<th scope="col" style="text-align:right">Second dose administered</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">Group 1</th>
+			<td style="text-align:right">66,767</td>
+			<td style="text-align:right">65,205</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Group 2</th>
+			<td style="text-align:right">661,231</td>
+			<td style="text-align:right">621,689</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Group 3</th>
+			<td style="text-align:right">793,481</td>
+			<td style="text-align:right">746,741</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Group 4</th>
+			<td style="text-align:right">2,136,491</td>
+			<td style="text-align:right">1,585,195</td>
+		</tr>
+	</tbody>
+</table>
+
+<p>For definitions of the groups and further detail see the downloadable spreadsheet at the bottom of the page.</p>
+
+<hr/>
+<h3><a id="by_soh" name="stockonhand"></a>Vaccine available for distribution at week end</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine available for distribution at week end" class="img-responsive" height="830" src="/web/20211031120029im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/stockonhand_13.png" width="1780"/></figure>
+
+<p>Vaccine available for distribution is stock (in doses) held at central warehouses. It does not include stock in transit or available at sites ready for use.</p>
+
+<hr/>
+<h3><a id="by_eth" name="ethnicity"></a>Total cumulative doses per 1,000 people by ethnicity</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Total cumulative doses per 1,000 people by ethnicity" class="img-responsive" height="830" src="/web/20211031120029im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/ethnicity_12.png" width="1780"/></figure>
+
+<p>This chart shows both first and second doses. As a result this chart may exceed 1,000 doses per 1,000 people.</p>
+
+<p><strong>*</strong> The prioritised ethnicity classification system allocates each person to a single ethnic group, based on the ethnic groups they identify with. Where people identify with more than one group, they are assigned in this order of priority: Māori, Pacific Peoples, Asian, and European/Other. So, if a person identifies as being Māori and New Zealand European, the person is counted as Māori. See <a href="/web/20211031120029/https://www.health.govt.nz/publication/hiso-100012017-ethnicity-data-protocols">Ethnicity Data Protocols</a> for further information.</p>
+
+<p>Ethnicity breakdown by DHB of residence is available in the downloadable spreadsheet at the bottom of the page.</p>
+
+<hr/>
+<h3><a id="by_age" name="age"></a>Cumulative vaccinations by age</h3>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">Age</th>
+			<th scope="col" style="text-align:right">First dose administered</th>
+			<th scope="col" style="text-align:right">First doses per 1,000 people</th>
+			<th scope="col" style="text-align:right">Fully vaccinated</th>
+			<th scope="col" style="text-align:right">Fully vaccinated per 1,000 people</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">12 - 19 years</th>
+			<td style="text-align:right">403,029</td>
+			<td style="text-align:right">802</td>
+			<td style="text-align:right">279,575</td>
+			<td style="text-align:right">557</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">20 - 34 years</th>
+			<td style="text-align:right">845,409</td>
+			<td style="text-align:right">817</td>
+			<td style="text-align:right">604,676</td>
+			<td style="text-align:right">585</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">35 - 49 years</th>
+			<td style="text-align:right">824,175</td>
+			<td style="text-align:right">862</td>
+			<td style="text-align:right">670,851</td>
+			<td style="text-align:right">701</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">50 - 64 years</th>
+			<td style="text-align:right">836,170</td>
+			<td style="text-align:right">901</td>
+			<td style="text-align:right">749,933</td>
+			<td style="text-align:right">809</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">65 and over</th>
+			<td style="text-align:right">749,187</td>
+			<td style="text-align:right">950</td>
+			<td style="text-align:right">713,795</td>
+			<td style="text-align:right">905</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total</strong></th>
+			<td style="text-align:right"><strong>3,657,970</strong></td>
+			<td style="text-align:right"><strong>869</strong></td>
+			<td style="text-align:right"><strong>3,018,830</strong></td>
+			<td style="text-align:right"><strong>717</strong></td>
+		</tr>
+	</tbody>
+</table>
+
+<p>Age breakdown by ethnicity and gender is available in the downloadable spreadsheet at the bottom of the page.</p>
+
+<hr/>
+<h3><a id="workforce" name="workforce"></a>Trained vaccinators and active vaccinators</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Trained vaccinators and active vaccinators" class="img-responsive" height="830" src="/web/20211031120029im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/workforce_12.png" width="1780"/></figure>
+
+<p><strong>Trained vaccinators</strong> are individuals who have completed the COVID-19 training. Many trained people are only able to offer a small number of hours to the COVID-19 vaccination programme.</p>
+
+<p><strong>Active vaccinators</strong> are trained individuals who are actively vaccinating. The number of active vaccinators does not reflect the hours worked vaccinating. For example, one vaccinator may work 40 hours in a week at one DHB and will show as 1 vaccinator in the headcount. In another DHB, 4 vaccinators may work 10 hours each (total 40 hours), but will show as 4 vaccinators in the headcount for that week.</p>
+
+<p>Both counts of trained and active vaccinators are cumulative. The difference between the two is due to a number of factors. This includes: individuals being trained in anticipation of future sites being opened (the largest factor); rostering; leave or non-availability; local health priorities; sites opening and closing.</p>
+
+<hr/>
+<h3><a id="usage" name="usage"></a>Wastage of vaccine stock</h3>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">&nbsp;</th>
+			<th scope="col">Wastage</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">New Zealand</th>
+			<td>0.29%</td>
+		</tr>
+	</tbody>
+</table>
+
+<p>Wastage is vials that have been reported as wasted since 13 July in the Inventory portal by DHBs or central warehouses divided by vials used over the same time frame.</p>
+
+<h3><a id="download" name="download"></a>Details of vaccination data</h3>
+
+<p>Download a spreadsheet containing key vaccination data. This includes HSU based population estimates for calculating vaccine uptake rates.</p>
+
+<p><a download="" href="/web/20211031120029/https://www.health.govt.nz/system/files/documents/pages/covid_vaccinations_26_10_2021.xlsx">COVID-19 vaccination data through 26 Oct 2021 (Excel, 363 KB)</a></p>
+
+<p>This spreadsheet is based on the information made available at the time of publishing and may be subject to changes. Please take note of any notes and caveats on each sheet.</p>
+
+<p>The below attachments provide some analysis on our progress on equity. The two PDF files are high level summaries of overall progress. The Excel documents are interactive and provides the ability to delve further into those overall numbers. NB: These Excel workbooks use features that are non-compatible with versions of MS Office 2016 and earlier.</p>
+
+<ul>
+	<li><a download="" href="/web/20211031120029/https://www.health.govt.nz/system/files/documents/pages/211024_-_cvip_equity_-_rate_ratios_by_ethnicity_ageband_and_dhb.pdf">Covid-19 Vaccine Rate Ratios by Ethnicity, Ageband and DHB (PDF, 642 KB)</a></li>
+	<li><a download="" href="/web/20211031120029/https://www.health.govt.nz/system/files/documents/pages/211024_-_cvip_equity_-_uptake_by_ethnicity_ageband_and_dhb.pdf">Covid-19 Vaccine Uptake by Ethnicity, Ageband and DHB (PDF, 550 KB)</a></li>
+	<li><a download="" href="/web/20211031120029/https://www.health.govt.nz/system/files/documents/pages/211024_-_cvip_equity_-_level_1_ethnicity_uptake_and_rate_ratios.xlsx">Covid-19 Vaccine Equity - Level 1 Ethnicity Uptake and Rate Ratios (Excel, 152 KB)</a></li>
+	<li><a download="" href="/web/20211031120029/https://www.health.govt.nz/system/files/documents/pages/211024_-_cvip_equity_-_level_2_ethnicity_uptake_and_rate_ratios.xlsx">Covid-19 Vaccine Equity - Level 2 Ethnicity Uptake and Rate Ratios (Excel, 378 KB)</a></li>
+	<li><a download="" href="/web/20211031120029/https://www.health.govt.nz/system/files/documents/pages/211024_-_cvip_equity_-_rate_ratios_and_uptake_over_time.xlsx">Rate Ratios and Uptake Over Time (Excel, 996 KB)</a></li>
+</ul>
+
+<hr/>
+<h3><a id="adverse-events" name="adverse-events"></a>Adverse events following&nbsp;immunisations (AEFI)</h3>
+
+<p>Like all medicines, the COVID-19 vaccine may cause side effects in some people. These are common, are usually mild, don&rsquo;t last long and won&rsquo;t stop people from having the second dose or going about daily life. Serious allergic reactions do occur but are extremely rare.</p>
+
+<p>Suspected AEFI to COVID-19 vaccines are reported to the <a href="https://web.archive.org/web/20211031120029/https://nzphvc.otago.ac.nz/">Centre for Adverse Reactions Monitoring</a> (CARM).&nbsp;<a href="https://web.archive.org/web/20211031120029/https://www.medsafe.govt.nz/">Medsafe</a> is closely monitoring the AEFI reported from the use of the COVID-19 vaccine and will report regularly on their findings.&nbsp;</p>
+
+<p><a href="https://web.archive.org/web/20211031120029/https://www.medsafe.govt.nz/COVID-19/vaccine-report-overview.asp">View Medsafe data on COVID-19 vaccine adverse effects following immunisation</a></p>
+</div></div></div>    </article>
+  </div>
+
+
+  </div>
+<div class="panel-pane pane-node-links even">
+
+
+
+  <div class="pane-content">
+          </div>
+
+
+  </div>
+
+<div class="panel-pane pane-views pane-sub-pages even">
+
+        <h2 class="pane-title h3">In this section</h2>
+
+
+  <div class="pane-content">
+        <div class="view view-sub-pages view-id-sub_pages view-display-id-block view-dom-id-16bf3d21455a1afd665dabb9ad0eb65b">
+
+
+
+      <div class="view-content">
+      <div class="item-list">    <ul>          <li class="views-row views-row-1 views-row-odd views-row-first">
+  <div class="views-field views-field-title">        <div class="field-content">
+<div class="views-field views-field-title">
+  <h3 class="field-content">
+    <a href="/web/20211031120029/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-across-nz">COVID-19 Vaccination uptake rates across NZ</a>  </h3>
+</div></div>  </div>
+  <span class="views-field views-field-body">        <span class="field-content">This page provides information related to uptake rates of the COVID-19 vaccine across the country.
+</span>  </span>
+  <span class="views-field views-field-view-node">        <span class="field-content"><a href="/web/20211031120029/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-across-nz">Read more</a></span>  </span></li>
+          <li class="views-row views-row-2 views-row-even">
+  <div class="views-field views-field-title">        <div class="field-content">
+<div class="views-field views-field-title">
+  <h3 class="field-content">
+    <a href="/web/20211031120029/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-maori-communities-across-nz">COVID-19 Vaccination uptake rates within Māori communities across NZ</a>  </h3>
+</div></div>  </div>
+  <span class="views-field views-field-body">        <span class="field-content">This page provides information related to uptake rates of the COVID-19 vaccine within Māori communities across New Zealand.
+</span>  </span>
+  <span class="views-field views-field-view-node">        <span class="field-content"><a href="/web/20211031120029/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-maori-communities-across-nz">Read more</a></span>  </span></li>
+          <li class="views-row views-row-3 views-row-odd views-row-last">
+  <div class="views-field views-field-title">        <div class="field-content">
+<div class="views-field views-field-title">
+  <h3 class="field-content">
+    <a href="/web/20211031120029/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-pacific-communities-across-nz">COVID-19 Vaccination uptake rates within Pacific communities across NZ</a>  </h3>
+</div></div>  </div>
+  <span class="views-field views-field-body">        <span class="field-content">This page provides information related to uptake rates of the COVID-19 vaccine within Pacific communities across New Zealand.
+</span>  </span>
+  <span class="views-field views-field-view-node">        <span class="field-content"><a href="/web/20211031120029/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-pacific-communities-across-nz">Read more</a></span>  </span></li>
+      </ul></div>    </div>
+
+
+
+
+
+
+</div>  </div>
+
+
+  </div>
+</div>          </div>
+
+  </div>
+
+</section>
+  </div>
+      </section>
+
+
+    </div>
+    <div id="content-footer-wrapper" class="clearfix">
+      <div id="content-footer" class="clearfix">
+                  <p class="page_updated">Page last updated: <span class="date">31 October 2021</span></p>                  <div class="region region-content-footer">
+    <section id="block-moh-tools-page-tools" class="block block-moh-tools clearfix">
+  <a href="#" data-placement="top" data-title="Share this content." data-html="true" data-content="<p>Share this page on some of the most popular social networking and content sites on the internet.</p><div class='service-links'><ul><li><a href='https://twitter.com/share?url=https%3A//www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data&amp;text=COVID-19%3A%20Vaccine%20data' title='Share this on Twitter' class='service-links-twitter' rel='nofollow'><img typeof='foaf:Image' class='img-responsive' src='https://www.health.govt.nz/sites/all/modules/contrib/service_links/images/twitter.png' alt='Twitter' /> Twitter</a></li>
+<li><a href='https://www.facebook.com/sharer.php?u=https%3A//www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data&amp;t=COVID-19%3A%20Vaccine%20data' title='Share on Facebook' class='service-links-facebook' rel='nofollow'><img typeof='foaf:Image' class='img-responsive' src='https://www.health.govt.nz/sites/all/modules/contrib/service_links/images/facebook.png' alt='Facebook' /> Facebook</a></li>
+</ul></div>" class="share-this-content"><i class="fa fa-share"></i> Share</a><a href="#" title="print this page" class="print"><i class="fa fa-print"></i> Print</a><a href="https://web.archive.org/web/20211031120029/https://www.health.govt.nz/forward?path=node/12052" title="Email this page" class="email"><i class="fa fa-envelope"></i> Email</a><a href="/web/20211031120029/https://www.health.govt.nz/feedback?ref=https%3A//www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="Feedback" class="rss"><i class="fa fa-comment"></i> Feedback</a></section>
+
+  </div>
+      </div>
+    </div>
+
+  </div>
+  <footer class="footer container">
+    <h2 class="hidden">Site Footer</h2>
+    <div class="footer-default">
+      <div class="row">
+        <div class="col-sm-6 col-md-6">
+          <div class="field field-name-field-tax-first-column-links">
+            <ul class="field-items"><li class="field-item"><a href="https://web.archive.org/web/20211031120029/https://www.health.govt.nz/node/492" class="">About this site</a></li><li class="field-item"><a href="https://web.archive.org/web/20211031120029/https://www.health.govt.nz/node/524" class="">Contact us</a></li><li class="field-item"><a href="https://web.archive.org/web/20211031120029/https://www.health.govt.nz/node/488" class="">Other Ministry of Health websites</a></li><li class="field-item"><a href="https://web.archive.org/web/20211031120029/https://www.health.govt.nz/node/7497" class="">Official Information Act requests</a></li><li class="field-item"><a href="https://web.archive.org/web/20211031120029/https://www.health.govt.nz/about-ministry/information-releases" class="">Information releases</a></li><li class="field-item"><a href="https://web.archive.org/web/20211031120029/https://consult.health.govt.nz/" class="">Consultations</a></li></ul>
+          </div>
+        </div>
+        <div class="col-sm-6 col-md-6">
+          <div class="field field-name-field-tax-footer-body field-type-text-long field-label-hidden"><div class="field-items"><div class="field-item even"><h3>Where to go for help</h3>
+
+<table>
+	<tbody>
+		<tr>
+			<th scope="row">Emergencies</th>
+			<td><strong>Dial <a href="tel:111">111</a></strong> (for ambulance, fire or police)</td>
+		</tr>
+		<tr>
+			<th scope="row">Healthline</th>
+			<td><strong>Dial <a href="tel:0800611116">0800 611 116</a></strong></td>
+		</tr>
+		<tr>
+			<th scope="row">Poisons</th>
+			<td><strong>Dial <a href="tel:0800764766">0800 POISON</a> </strong>(<a href="tel:0800764766">0800 764 766</a>)</td>
+		</tr>
+		<tr>
+			<th scope="row">Mental health crisis</th>
+			<td><strong><a href="/web/20211031120029/https://www.health.govt.nz/your-health/services-and-support/health-care-services/mental-health-services/crisis-assessment-teams">Emergency contact numbers</a></strong></td>
+		</tr>
+	</tbody>
+</table>
+</div></div></div>        </div>
+      </div>
+      <div class="row">
+        <div class="sub-footer">
+          <div class="column col-sm-12 col-md-3">
+            <a href="https://web.archive.org/web/20211031120029/https://www.govt.nz/">
+              <img src="/web/20211031120029im_/https://www.health.govt.nz/sites/all/themes/mohpub_bootstrap/images/nzgovtlogo_white.png" width="152" height="16" alt="govt.nz - connecting you to New Zealand central &amp; local government services" title="govt.nz - connecting you to New Zealand central &amp; local government services"/>
+            </a>
+          </div>
+          <div class="column col-sm-12 col-md-9">
+          <span class="bottom-menu-moh with-v-divider">&copy; Ministry of Health – Manatū Hauora</span><ul class="bottom-menu-list"><li class="bottom-menu-list-item with-v-divider"><a href="https://web.archive.org/web/20211031120029/https://www.health.govt.nz/sitemap" class="">Site map</a></li><li class="bottom-menu-list-item with-v-divider"><a href="https://web.archive.org/web/20211031120029/https://www.health.govt.nz/about-site/privacy-and-security" class="">Privacy &amp; security</a></li><li class="bottom-menu-list-item with-v-divider"><a href="https://web.archive.org/web/20211031120029/https://www.health.govt.nz/about-site/copyright" class="">Copyright</a></li></ul>          </div>
+        </div>
+      </div>
+    </div>
+    <div class="footer-print">&copy; Ministry of Health – Manatū Hauora</div>
+  </footer>
+  <a class="scrollToTop">Back to top <i class="fas fa-arrow-up"></i></a>
+</div>
+  <script src="https://web.archive.org/web/20211031120029js_/https://www.health.govt.nz/sites/default/files/js/js_akZOsKtodu3PdnQzY3_ElOfujkLxJcowmaWgHTBBLOE.js"></script>
+</body>
+</html>
+<!--
+     FILE ARCHIVED ON 12:00:29 Oct 31, 2021 AND RETRIEVED FROM THE
+     INTERNET ARCHIVE ON 03:15:11 Nov 07, 2021.
+     JAVASCRIPT APPENDED BY WAYBACK MACHINE, COPYRIGHT INTERNET ARCHIVE.
+
+     ALL OTHER CONTENT MAY ALSO BE PROTECTED BY COPYRIGHT (17 U.S.C.
+     SECTION 108(a)(3)).
+-->
+<!--
+playback timings (ms):
+  captures_list: 222.583
+  exclusion.robots: 0.154
+  exclusion.robots.policy: 0.147
+  RedisCDXSource: 7.515
+  esindex: 0.023
+  LoadShardBlock: 175.383 (3)
+  PetaboxLoader3.datanode: 172.888 (4)
+  CDXLines.iter: 26.179 (3)
+  load_resource: 140.959
+  PetaboxLoader3.resolve: 43.43
+-->

--- a/data/rawSite/2021-10-31.html
+++ b/data/rawSite/2021-10-31.html
@@ -1,0 +1,2523 @@
+
+<!DOCTYPE html>
+<html lang="en" dir="ltr" prefix="" class="no-js">
+<head><script src="//archive.org/includes/analytics.js?v=cf34f82" type="text/javascript"></script>
+<script type="text/javascript">window.addEventListener('DOMContentLoaded',function(){var v=archive_analytics.values;v.service='wb';v.server_name='wwwb-app211.us.archive.org';v.server_ms=338;archive_analytics.send_pageview({});});</script>
+<script type="text/javascript" src="/_static/js/bundle-playback.js?v=UfTkgsKx" charset="utf-8"></script>
+<script type="text/javascript" src="/_static/js/wombat.js?v=UHAOicsW" charset="utf-8"></script>
+<script type="text/javascript">
+  __wm.init("https://web.archive.org/web");
+  __wm.wombat("https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data","20211101145759","https://web.archive.org/","web","/_static/",
+	      "1635778679");
+</script>
+<link rel="stylesheet" type="text/css" href="/_static/css/banner-styles.css?v=omkqRugM" />
+<link rel="stylesheet" type="text/css" href="/_static/css/iconochive.css?v=qtvMKcIJ" />
+<!-- End Wayback Rewrite JS Include -->
+
+  <!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta name="format-detection" content="telephone=no"/>
+  <link rel="profile" href="http://www.w3.org/1999/xhtml/vocab"/>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+<link rel="shortcut icon" href="https://web.archive.org/web/20211101145759im_/https://www.health.govt.nz/sites/all/themes/mohpub_bootstrap/favicon.ico" type="image/vnd.microsoft.icon"/>
+<meta name="description" content="Dashboard of data and statistics about the rollout of COVID-19 vaccines in New Zealand"/>
+<meta name="generator" content="Drupal 7 (https://www.drupal.org)"/>
+<link rel="canonical" href="https://web.archive.org/web/20211101145759/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data"/>
+<link rel="shortlink" href="https://web.archive.org/web/20211101145759/https://www.health.govt.nz/node/12052"/>
+<meta property="og:site_name" content="Ministry of Health NZ"/>
+<meta property="og:type" content="article"/>
+<meta property="og:url" content="https://web.archive.org/web/20211101145759/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data"/>
+<meta property="og:title" content="COVID-19: Vaccine data"/>
+<meta property="og:description" content="Dashboard of data and statistics about the rollout of COVID-19 vaccines in New Zealand"/>
+  <title>COVID-19: Vaccine data | Ministry of Health NZ</title>
+  <link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211101145759cs_/https://www.health.govt.nz/sites/default/files/css/css_lQaZfjVpwP_oGNqdtWCSpJT1EMqXdMiU84ekLLxQnc4.css" media="all"/>
+<link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211101145759cs_/https://www.health.govt.nz/sites/default/files/css/css_jqUBpWfMaxMiP7LismdZVlyVv8azUJSE2yaH58nj0cE.css" media="all"/>
+<link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211101145759cs_/https://www.health.govt.nz/sites/default/files/css/css_Rb1wqFBC8VXCJC-BuNY53cvjjlj6UADGvqzo_f-1yN0.css" media="all"/>
+<link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211101145759cs_/https://www.health.govt.nz/sites/default/files/css/css_38_K1lHKg-98m4KKRfv57JBK0gvlKscexGt9MKoi0DE.css" media="all"/>
+<link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211101145759cs_/https://www.health.govt.nz/sites/default/files/css/css_r7NPyvpdYfAyZmk9zkK8OaFKEFj6er5ZJnam2H644DM.css" media="print"/>
+  <link rel="alternate stylesheet" type="text/css" href="/web/20211101145759cs_/https://www.health.govt.nz/sites/all/themes/mohpub_bootstrap/css/high-contrast.css" media="screen" title="High Contrast"/>
+  <script src="https://web.archive.org/web/20211101145759js_/https://www.health.govt.nz/sites/default/files/js/js_zS-CmNFGyegtLYJmqFRpxQvvQrfPIFrOMq_3T3C8sZE.js"></script>
+<script src="https://web.archive.org/web/20211101145759js_/https://www.health.govt.nz/sites/default/files/js/js_fNgZ4Okisfr70Q0yvAYsATgB0o_jD3-srhQQ-VHmlXE.js"></script>
+<script src="https://web.archive.org/web/20211101145759js_/https://www.health.govt.nz/sites/default/files/js/js_YAdPZfg12M1m7ROp3_gVJPS5sArqL0kYQgNRPoicvHE.js"></script>
+<script>(function(i,s,o,g,r,a,m){i["GoogleAnalyticsObject"]=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,"script","https://web.archive.org/web/20211101145759/https://www.google-analytics.com/analytics.js","ga");ga("create", "UA-3573389-24", {"cookieDomain":".www.health.govt.nz","siteSpeedSampleRate":15});ga("send", "pageview");</script>
+<script src="https://web.archive.org/web/20211101145759js_/https://www.health.govt.nz/sites/default/files/js/js_QAXZNPwLISRLHqyNpT4Vvr_iqD9foD6GTbEjlhIIjeo.js"></script>
+<script src="https://web.archive.org/web/20211101145759js_/https://www.health.govt.nz/sites/default/files/js/js_4VW9edmu3V8VjGJxFfXGAwkXeW2cJIa5h-6y7SgwVrk.js"></script>
+<script>    (function(h,o,t,j,a,r){
+        h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
+        h._hjSettings={hjid:930919,hjsv:6};
+        a=o.getElementsByTagName('head')[0];
+        r=o.createElement('script');r.async=1;
+        r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+        a.appendChild(r);
+    })(window,document,'https://web.archive.org/web/20211101145759/https://static.hotjar.com/c/hotjar-','.js?sv=');
+</script>
+<script>jQuery.extend(Drupal.settings, {"basePath":"\/","pathPrefix":"","ajaxPageState":{"theme":"mohpub_bootstrap","theme_token":"RBDui_qaBWPOh8IGpYVlqtYsjzKQmU2r-Xjk1tHJUSE","js":{"sites\/all\/modules\/custom\/table_d3chart\/js\/table_d3chart.js":1,"sites\/all\/modules\/custom\/moh_d3\/moh_d3.js":1,"sites\/all\/modules\/contrib\/jquery_update\/replace\/jquery\/1.7\/jquery.min.js":1,"misc\/jquery-extend-3.4.0.js":1,"misc\/jquery-html-prefilter-3.5.0-backport.js":1,"misc\/jquery.once.js":1,"misc\/drupal.js":1,"sites\/all\/modules\/contrib\/ckeditor_accordion\/js\/ckeditor-accordion.js":1,"sites\/all\/modules\/contrib\/extlink\/extlink.js":1,"modules\/field\/modules\/text\/text.js":1,"sites\/all\/modules\/contrib\/field_group\/field_group.js":1,"sites\/all\/modules\/contrib\/google_analytics\/googleanalytics.js":1,"0":1,"sites\/all\/libraries\/c3\/c3.js":1,"sites\/all\/libraries\/d3\/d3.min.js":1,"sites\/all\/modules\/contrib\/d3\/js\/d3.js":1,"sites\/all\/libraries\/d3.helpers\/d3.helpers.js":1,"sites\/all\/libraries\/d3.c3\/d3-c3.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/assets\/ios-fix.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/affix.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/alert.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/button.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/carousel.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/collapse.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/dropdown.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/modal.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/tooltip.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/popover.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/scrollspy.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/tab.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/transition.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/jquery.cookie.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/jquery.moh.announcement.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/svgeezy.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/fitvids.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/bootstrap-tabcollapse.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/jquery.scrollTo.min.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/script.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/jquery.google_analytics.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/bootstrap-accessibility.min.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/style-switcher.js":1,"1":1},"css":{"modules\/system\/system.base.css":1,"sites\/all\/modules\/contrib\/calendar\/css\/calendar_multiday.css":1,"sites\/all\/modules\/contrib\/ckeditor_accordion\/css\/ckeditor-accordion.css":1,"modules\/field\/theme\/field.css":1,"modules\/node\/node.css":1,"sites\/all\/modules\/contrib\/extlink\/extlink.css":1,"sites\/all\/modules\/contrib\/views\/css\/views.css":1,"sites\/all\/modules\/contrib\/ckeditor\/css\/ckeditor.css":1,"sites\/all\/modules\/contrib\/ctools\/css\/ctools.css":1,"sites\/all\/modules\/contrib\/panels\/css\/panels.css":1,"sites\/all\/libraries\/c3\/c3.css":1,"sites\/all\/libraries\/d3.c3\/d3-c3.css":1,"sites\/all\/themes\/mohpub_bootstrap\/fontawesome\/css\/fontawesome.min.css":1,"sites\/all\/themes\/mohpub_bootstrap\/fontawesome\/css\/solid.min.css":1,"sites\/all\/themes\/mohpub_bootstrap\/fontawesome\/css\/brands.min.css":1,"sites\/all\/modules\/features\/site_profile\/css\/fix-rubik-multiselect-height.css":1,"sites\/all\/themes\/mohpub_bootstrap\/css\/style.css":1,"sites\/all\/themes\/mohpub_bootstrap\/css\/responsive-tables.css":1,"sites\/all\/themes\/mohpub_bootstrap\/css\/print.css":1}},"field_group":{"div":"full"},"ckeditor_accordion":{"collapseAll":1},"extlink":{"extTarget":0,"extClass":"ext","extLabel":"(link is external)","extImgClass":0,"extIconPlacement":"append","extSubdomains":0,"extExclude":"","extInclude":"","extCssExclude":"","extCssExplicit":"","extAlert":0,"extAlertText":"This link will take you to an external web site. We are not responsible for their content.","mailtoClass":"mailto","mailtoLabel":"(link sends e-mail)"},"googleanalytics":{"trackOutbound":1,"trackMailto":1,"trackDownload":1,"trackDownloadExtensions":"7z|aac|arc|arj|asf|asx|avi|bin|csv|doc|exe|flv|gif|gz|gzip|hqx|jar|jpe?g|js|mp(2|3|4|e?g)|mov(ie)?|msi|msp|pdf|phps|png|ppt|qtm?|ra(m|r)?|sea|sit|tar|tgz|torrent|txt|wav|wma|wmv|wpd|xls|xml|z|zip|docx|xlsx|pptx|pptm|ppsx|ppsm|epub"},"mohD3":{"C3Types":["line","spline","step","area","area-spline","area-step","bar","scatter","pie","donut","gauge"],"graphRender":"line","graphLegend":true,"graphDefaultColors":"#2b8cbe, #abdda4, #7f7f7f, #92cddc, #dc8b0c","graphDefaultGroupedTooltip":0,"graphDefaultGridX":0,"graphDefaultGridY":0,"graphDefaultLegendPosition":"top-right","graphDefaultTooltip":1,"graphDefaultDataLabel":0,"graphLegendStep":"5","graphInteraction":true,"graphTypes":"","graphXaxisShow":true,"graphXaxisLabel":"","graphYaxisLabel":"","graphXaxisType":"category","graphXaxisCentered":false,"graphXaxisRotation":"","graphXaxisHeight":"","graphYaxisShow":true,"graphYaxisMax":"","graphYaxisMin":"","graphYaxisInverted":false,"graphYaxisCenter":"","graphYaxisPrefix":"","graphYaxisSuffix":"","graphYaxisPosition":"","graphY2axisShow":false,"graphY2axisSource":"","graphY2axisMax":"","graphY2axisMin":"","graphGroups":"","graphRotated":false,"graphIgnoreEmpty":false,"graphLineDot":true,"graphBarRatio":"0.9","graphDot":true,"graphDotR":"2.5","graphFocus":false},"tableD3":{"show":"View table data source","hide":"Hide table data source"},"urlIsAjaxTrusted":{"\/our-work\/diseases-and-conditions\/covid-19-novel-coronavirus\/covid-19-data-and-statistics\/covid-19-vaccine-data":true},"bootstrap":{"anchorsFix":1,"anchorsSmoothScrolling":1,"formHasError":1,"popoverEnabled":1,"popoverOptions":{"animation":1,"html":0,"placement":"right","selector":"","trigger":"click","triggerAutoclose":1,"title":"","content":"","delay":0,"container":"body"},"tooltipEnabled":1,"tooltipOptions":{"animation":1,"html":0,"placement":"auto left","selector":"","trigger":"hover focus","delay":0,"container":"body"}}});</script>
+  <!-- HTML5 element support for IE6-8 -->
+  <!--[if lt IE 9]>
+    <script src="/sites/all/themes/mohpub_bootstrap/js/assets/html5shiv.js"></script>
+    <script src="/sites/all/themes/mohpub_bootstrap/js/assets/respond.min.js"></script>
+  <![endif]-->
+</head>
+<body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-12052 node-type-page node-has-intro"><!-- BEGIN WAYBACK TOOLBAR INSERT -->
+<style type="text/css">
+body {
+  margin-top:0 !important;
+  padding-top:0 !important;
+  /*min-width:800px !important;*/
+}
+</style>
+<script>__wm.rw(0);</script>
+<div id="wm-ipp-base" lang="en" style="display:none;direction:ltr;">
+<div id="wm-ipp" style="position:fixed;left:0;top:0;right:0;">
+<div id="wm-ipp-inside">
+  <div style="position:relative;">
+    <div id="wm-logo" style="float:left;width:110px;padding-top:12px;">
+      <a href="/web/" title="Wayback Machine home page"><img src="/_static/images/toolbar/wayback-toolbar-logo-200.png" srcset="/_static/images/toolbar/wayback-toolbar-logo-100.png, /_static/images/toolbar/wayback-toolbar-logo-150.png 1.5x, /_static/images/toolbar/wayback-toolbar-logo-200.png 2x" alt="Wayback Machine" style="width:100px" border="0" /></a>
+    </div>
+    <div class="r" style="float:right;">
+      <div id="wm-btns" style="text-align:right;height:25px;">
+                  <div id="wm-save-snapshot-success">success</div>
+          <div id="wm-save-snapshot-fail">fail</div>
+          <a id="wm-save-snapshot-open" href="#"
+	     title="Share via My Web Archive" >
+            <span class="iconochive-web"></span>
+          </a>
+          <a href="https://archive.org/account/login.php"
+             title="Sign In"
+             id="wm-sign-in"
+          >
+            <span class="iconochive-person"></span>
+          </a>
+          <span id="wm-save-snapshot-in-progress" class="iconochive-web"></span>
+        	<a href="http://faq.web.archive.org/" title="Get some help using the Wayback Machine" style="top:-6px;"><span class="iconochive-question" style="color:rgb(87,186,244);font-size:160%;"></span></a>
+	<a id="wm-tb-close" href="#close" onclick="__wm.h(event);return false;" style="top:-2px;" title="Close the toolbar"><span class="iconochive-remove-circle" style="color:#888888;font-size:240%;"></span></a>
+      </div>
+      <div id="wm-share">
+          <a href="/web/20211101145759/http://web.archive.org/screenshot/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data"
+             id="wm-screenshot"
+             title="screenshot">
+            <span class="wm-icon-screen-shot"></span>
+          </a>
+          <a href="#"
+            id="wm-video"
+            title="video">
+            <span class="iconochive-movies"></span>
+          </a>
+	<a id="wm-share-facebook" href="#" data-url="https://web.archive.org/web/20211101145759/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="Share on Facebook" style="margin-right:5px;" target="_blank"><span class="iconochive-facebook" style="color:#3b5998;font-size:160%;"></span></a>
+	<a id="wm-share-twitter" href="#" data-url="https://web.archive.org/web/20211101145759/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="Share on Twitter" style="margin-right:5px;" target="_blank"><span class="iconochive-twitter" style="color:#1dcaff;font-size:160%;"></span></a>
+      </div>
+    </div>
+    <table class="c" style="">
+      <tbody>
+	<tr>
+	  <td class="u" colspan="2">
+	    <form target="_top" method="get" action="/web/submit" name="wmtb" id="wmtb"><input type="text" name="url" id="wmtbURL" value="https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" onfocus="this.focus();this.select();" /><input type="hidden" name="type" value="replay" /><input type="hidden" name="date" value="20211101145759" /><input type="submit" value="Go" /></form>
+	  </td>
+	  <td class="n" rowspan="2" style="width:110px;">
+	    <table>
+	      <tbody>
+		<!-- NEXT/PREV MONTH NAV AND MONTH INDICATOR -->
+		<tr class="m">
+		  <td class="b" nowrap="nowrap"><a href="https://web.archive.org/web/20211001060746/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="01 Oct 2021"><strong>Oct</strong></a></td>
+		  <td class="c" id="displayMonthEl" title="You are here: 14:57:59 Nov 01, 2021">NOV</td>
+		  <td class="f" nowrap="nowrap">Dec</td>
+		</tr>
+		<!-- NEXT/PREV CAPTURE NAV AND DAY OF MONTH INDICATOR -->
+		<tr class="d">
+		  <td class="b" nowrap="nowrap"><a href="https://web.archive.org/web/20211031120029/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="12:00:29 Oct 31, 2021"><img src="/_static/images/toolbar/wm_tb_prv_on.png" alt="Previous capture" width="14" height="16" border="0" /></a></td>
+		  <td class="c" id="displayDayEl" style="width:34px;font-size:24px;white-space:nowrap;" title="You are here: 14:57:59 Nov 01, 2021">01</td>
+		  <td class="f" nowrap="nowrap"><a href="https://web.archive.org/web/20211102161403/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="16:14:03 Nov 02, 2021"><img src="/_static/images/toolbar/wm_tb_nxt_on.png" alt="Next capture" width="14" height="16" border="0" /></a></td>
+		</tr>
+		<!-- NEXT/PREV YEAR NAV AND YEAR INDICATOR -->
+		<tr class="y">
+		  <td class="b" nowrap="nowrap">2020</td>
+		  <td class="c" id="displayYearEl" title="You are here: 14:57:59 Nov 01, 2021">2021</td>
+		  <td class="f" nowrap="nowrap">2022</td>
+		</tr>
+	      </tbody>
+	    </table>
+	  </td>
+	</tr>
+	<tr>
+	  <td class="s">
+	    	    <div id="wm-nav-captures">
+	      	      <a class="t" href="/web/20211101145759*/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="See a list of every capture for this URL">682 captures</a>
+	      <div class="r" title="Timespan for captures of this URL">07 Apr 2021 - 06 Nov 2021</div>
+	      </div>
+	  </td>
+	  <td class="k">
+	    <a href="" id="wm-graph-anchor">
+	      <div id="wm-ipp-sparkline" title="Explore captures for this URL" style="position: relative">
+		<canvas id="wm-sparkline-canvas" width="650" height="27" border="0"></canvas>
+	      </div>
+	    </a>
+	  </td>
+	</tr>
+      </tbody>
+    </table>
+    <div style="position:absolute;bottom:0;right:2px;text-align:right;">
+      <a id="wm-expand" class="wm-btn wm-closed" href="#expand" onclick="__wm.ex(event);return false;"><span id="wm-expand-icon" class="iconochive-down-solid"></span> <span style="font-size:80%">About this capture</span></a>
+    </div>
+  </div>
+    <div id="wm-capinfo" style="border-top:1px solid #777;display:none; overflow: hidden">
+                    <div id="wm-capinfo-collected-by">
+    <div style="background-color:#666;color:#fff;font-weight:bold;text-align:center">COLLECTED BY</div>
+    <div style="padding:3px;position:relative" id="wm-collected-by-content">
+            <div style="display:inline-block;vertical-align:top;width:50%;">
+			<span class="c-logo" style="background-image:url(https://archive.org/services/img/focused_crawls);"></span>
+		Organization: <a style="color:#33f;" href="https://archive.org/details/focused_crawls" target="_new"><span class="wm-title">Internet Archive</span></a>
+		<div style="max-height:75px;overflow:hidden;position:relative;">
+	  <div style="position:absolute;top:0;left:0;width:100%;height:75px;background:linear-gradient(to bottom,rgba(255,255,255,0) 0%,rgba(255,255,255,0) 90%,rgba(255,255,255,255) 100%);"></div>
+	  Focused crawls are collections of frequently-updated webcrawl data from narrow (as opposed to broad or wide) web crawls, often focused on a single domain or subdomain.<br />
+	</div>
+	      </div>
+      <div style="display:inline-block;vertical-align:top;width:49%;">
+			<span class="c-logo" style="background-image:url(https://archive.org/services/img/abc.net.au-news)"></span>
+		<div>Collection: <a style="color:#33f;" href="https://archive.org/details/abc.net.au-news" target="_new"><span class="wm-title">abc.net.au-news</span></a></div>
+	      </div>
+    </div>
+    </div>
+    <div id="wm-capinfo-timestamps">
+    <div style="background-color:#666;color:#fff;font-weight:bold;text-align:center" title="Timestamps for the elements of this page">TIMESTAMPS</div>
+    <div>
+      <div id="wm-capresources" style="margin:0 5px 5px 5px;max-height:250px;overflow-y:scroll !important"></div>
+      <div id="wm-capresources-loading" style="text-align:left;margin:0 20px 5px 5px;display:none"><img src="/_static/images/loading.gif" alt="loading" /></div>
+    </div>
+    </div>
+  </div></div></div></div><div id="wm-ipp-print">The Wayback Machine - https://web.archive.org/web/20211101145759/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data</div>
+<div id="donato" style="position:relative;width:100%;">
+  <div id="donato-base">
+    <iframe id="donato-if" src="https://archive.org/includes/donate.php?as_page=1&amp;platform=wb&amp;referer=https%3A//web.archive.org/web/20211101145759/https%3A//www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data"
+	    scrolling="no" frameborder="0" style="width:100%; height:100%">
+    </iframe>
+  </div>
+</div><script type="text/javascript">
+__wm.bt(650,27,25,2,"web","https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data","20211101145759",1996,"/_static/",["/_static/css/banner-styles.css?v=omkqRugM","/_static/css/iconochive.css?v=qtvMKcIJ"], "False");
+  __wm.rw(1);
+</script>
+<!-- END WAYBACK TOOLBAR INSERT -->
+<!--googleoff: all-->
+  <div id="skip-link">
+    <a href="#skip-content" id="skipper" class="element-invisible element-focusable">Skip to main content</a>
+  </div>
+    <div id="page">
+  <header id="navbar" role="banner" class="navbar container navbar-default">
+          <ul class="menu nav navbar-nav secondary"><li class="first leaf jobs depth-1"><a href="https://web.archive.org/web/20211101145759/https://careers.health.govt.nz/" title="">Jobs</a></li>
+<li class="leaf news depth-1"><a href="/web/20211101145759/https://www.health.govt.nz/news-media" data-is-top-level="0" title="">News</a></li>
+<li class="leaf contact-us depth-1"><a href="/web/20211101145759/https://www.health.govt.nz/about-ministry/contact-us" title="">Contact us</a></li>
+<li class="leaf facebook depth-1"><a href="https://web.archive.org/web/20211101145759/https://www.facebook.com/minhealthnz/">Facebook</a></li>
+<li class="leaf twitter depth-1"><a href="https://web.archive.org/web/20211101145759/https://twitter.com/minhealthnz" data-is-top-level="0" title="">Twitter</a></li>
+<li class="last leaf youtube depth-1"><a href="https://web.archive.org/web/20211101145759/https://www.youtube.com/user/minhealthnz" data-is-top-level="0" title="">Youtube</a></li>
+</ul>        <div class="container">
+      <div class="navbar-header">
+                <a class="logo navbar-btn pull-left" href="/web/20211101145759/https://www.health.govt.nz/" title="Home">
+          <img src="/web/20211101145759im_/https://www.health.govt.nz/sites/all/themes/mohpub_bootstrap/images/mohlogo.svg" alt="Ministry of Health"/>
+        </a>
+                  <div class="region region-header-top">
+    <section id="block-apachesolr-panels-search-form" class="block block-apachesolr-panels clearfix">
+
+
+  <form action="/web/20211101145759/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" method="post" id="apachesolr-panels-search-block" accept-charset="UTF-8"><div><div class="form-item form-item-apachesolr-panels-search-form form-type-textfield form-group"> <label class="control-label" for="edit-apachesolr-panels-search-form">Search</label>
+<input title="Enter the terms you wish to search for." class="form-control form-text" type="text" id="edit-apachesolr-panels-search-form" name="apachesolr_panels_search_form" value="" size="15" maxlength="128"/></div><input type="hidden" name="form_build_id" value="form-J0EYn4BHifzGiKte19bQBjK4Gm_fyWANzYwLpJB-FKA"/>
+<input type="hidden" name="form_id" value="apachesolr_panels_search_block"/>
+<div class="form-actions form-wrapper form-group" id="edit-actions"><button type="submit" id="edit-submit" name="op" value="Search" class="btn btn-primary form-submit">Search</button>
+</div></div></form>
+</section>
+  </div>
+        <!-- .btn-navbar is used as the toggle for collapsed navbar content -->
+        <button aria-expanded="false" aria-controls="megamenu" type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+                    <span class="menu-text">Menu</span><span class="sr-only">Toggle navigation</span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+
+        </button>
+      </div>
+
+              <div class="navbar-collapse collapse">
+          <nav id="megamenu" role="navigation">
+                          <h2 class="element-invisible">Main menu</h2><ul id="main-menu" class="menu nav navbar-nav yamm navbar"><li class="first dropdown"><a href="/web/20211101145759/https://www.health.govt.nz/your-health" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="megamenu-dropdown-780">Your health <b class="caret"></b></a>
+    <div id="megamenu-dropdown-780" class="dropdown-menu">
+    <div class="yamm-content">
+      <div class="row">
+                            <div class="col">
+            <h3><a href="/web/20211101145759/https://www.health.govt.nz/your-health/conditions-and-treatments?mega=Your%20health&amp;title=Conditions%20%26%20treatments" class="menu-header">Conditions &amp; treatments</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211101145759/https://www.health.govt.nz/your-health/conditions-and-treatments/mental-health/depression?mega=Your%20health&amp;title=Depression">Depression</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/diabetes?mega=Your%20health&amp;title=Diabetes">Diabetes</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/influenza?mega=Your%20health&amp;title=Influenza">Influenza</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/measles?mega=Your%20health&amp;title=Measles">Measles</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/meningococcal-disease-including-meningitis?mega=Your%20health&amp;title=Meningococcal%20disease">Meningococcal disease</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/mumps?mega=Your%20health&amp;title=Mumps">Mumps</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/respiratory-syncytial-virus-rsv?mega=Your%20health&amp;title=RSV">RSV</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/sore-throat?mega=Your%20health&amp;title=Sore%20throat">Sore throat</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/your-health/conditions-and-treatments?mega=Your%20health&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211101145759/https://www.health.govt.nz/your-health/healthy-living?mega=Your%20health&amp;title=Healthy%20living" class="menu-header">Healthy living</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211101145759/https://www.health.govt.nz/your-health/healthy-living/drinking-water?mega=Your%20health&amp;title=Drinking-water">Drinking-water</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/your-health/healthy-living/food-activity-and-sleep/green-prescriptions?mega=Your%20health&amp;title=Green%20Prescriptions">Green Prescriptions</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/your-health/healthy-living/food-activity-and-sleep/healthy-eating?mega=Your%20health&amp;title=Healthy%20eating">Healthy eating</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/your-health/healthy-living/immunisation?mega=Your%20health&amp;title=Immunisation">Immunisation</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/your-health/healthy-living/food-activity-and-sleep/physical-activity?mega=Your%20health&amp;title=Physical%20activity">Physical activity</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/your-health/healthy-living/addictions/quitting-smoking?mega=Your%20health&amp;title=Smoking">Smoking</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/your-health/healthy-living/teeth-and-gums?mega=Your%20health&amp;title=Teeth%20and%20gums">Teeth and gums</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/your-health/healthy-living?mega=Your%20health&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211101145759/https://www.health.govt.nz/your-health/pregnancy-and-kids?mega=Your%20health&amp;title=Pregnancy%20and%20kids" class="menu-header">Pregnancy and kids</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211101145759/https://www.health.govt.nz/your-health/pregnancy-and-kids/birth-and-afterwards?mega=Your%20health&amp;title=Birth%20and%20afterwards">Birth and afterwards</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/your-health/pregnancy-and-kids/first-year/helpful-advice-during-first-year/breastfeeding-perfect-you-and-your-baby?mega=Your%20health&amp;title=Breastfeeding">Breastfeeding</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/your-health/pregnancy-and-kids/pregnancy?mega=Your%20health&amp;title=Pregnancy">Pregnancy</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/your-health/pregnancy-and-kids/services-and-support-during-pregnancy?mega=Your%20health&amp;title=Services%20and%20support%20during%20pregnancy">Services and support during pregnancy</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/your-health/pregnancy-and-kids/services-and-support-you-and-your-child?mega=Your%20health&amp;title=Services%20and%20support%20for%20you%20and%20your%20child">Services and support for you and your child</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/your-health/pregnancy-and-kids/first-year?mega=Your%20health&amp;title=The%20first%20year">The first year</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/your-health/pregnancy-and-kids/under-fives?mega=Your%20health&amp;title=Under%20fives">Under fives</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/your-health/pregnancy-and-kids?mega=Your%20health&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211101145759/https://www.health.govt.nz/your-health/services-and-support?mega=Your%20health&amp;title=Services%20and%20support" class="menu-header">Services &amp; support</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211101145759/https://www.health.govt.nz/your-health/services-and-support/health-care-services/help-alcohol-and-drug-problems?mega=Your%20health&amp;title=Alcohol%20and%20drugs">Alcohol and drugs</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/your-health/services-and-support/disability-services?mega=Your%20health&amp;title=Disability%20services">Disability services</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/your-health/services-and-support/health-care-services/earthquake-support-line?mega=Your%20health&amp;title=Earthquake%20Support%20Line">Earthquake Support Line</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/your-health/services-and-support/health-care-services/healthline?mega=Your%20health&amp;title=Healthline">Healthline</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/your-health/services-and-support/health-care-services/mental-health-services?mega=Your%20health&amp;title=Mental%20health%20services">Mental health services</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/your-health/services-and-support/health-care-services/maori-health-provider-directory?mega=Your%20health&amp;title=M%C4%81ori%20health%20providers">Māori health providers</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/your-health/services-and-support/health-care-services/services-older-people/rest-home-certification-and-audits?mega=Your%20health&amp;title=Rest%20home%20certification">Rest home certification</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/your-health/services-and-support/health-care-services/hospitals-and-specialist-services/travel-assistance?mega=Your%20health&amp;title=Travel%20assistance">Travel assistance</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/your-health/services-and-support?mega=Your%20health&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                        </div>
+    </div>
+    <div class="feature-links">
+      <h3 class="sr-only">Other related resources</h3>
+      <a href="/web/20211101145759/https://www.health.govt.nz/your-health/full-a-z?mega=Your%20health&amp;title=A-Z">View the full A-Z</a>    </div>
+  </div>
+</li>
+<li class="dropdown"><a href="/web/20211101145759/https://www.health.govt.nz/new-zealand-health-system" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="megamenu-dropdown-6076">NZ health system <b class="caret"></b></a>
+    <div id="megamenu-dropdown-6076" class="dropdown-menu">
+    <div class="yamm-content">
+      <div class="row">
+                            <div class="col">
+            <h3><a href="/web/20211101145759/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people?mega=NZ%20health%20system&amp;title=Key%20organisations" class="menu-header">Key organisations</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211101145759/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/crown-entities-and-statutory-boards?mega=NZ%20health%20system&amp;title=Crown%20entities%20%26%20agencies">Crown entities &amp; agencies</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/district-health-boards?mega=NZ%20health%20system&amp;title=District%20health%20boards">District health boards</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/non-governmental-organisations?mega=NZ%20health%20system&amp;title=Non-governmental%20organisations">Non-governmental organisations</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/primary-health-organisations?mega=NZ%20health%20system&amp;title=Primary%20health%20organisations">Primary health organisations</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/public-health-units?mega=NZ%20health%20system&amp;title=Public%20health%20units">Public health units</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people?mega=NZ%20health%20system&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211101145759/https://www.health.govt.nz/new-zealand-health-system/health-system-indicators-framework?mega=NZ%20health%20system&amp;title=Health%20System%20Indicators%20framework" class="menu-header">Health System Indicators framework</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211101145759/https://www.health.govt.nz/new-zealand-health-system/health-system-indicators-framework?mega=NZ%20health%20system&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211101145759/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services?mega=NZ%20health%20system&amp;title=Eligibility%20for%20public%20health%20services" class="menu-header">Eligibility for public health services</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211101145759/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services/guide-eligibility-publicly-funded-health-services?mega=NZ%20health%20system&amp;title=Guide%20to%20eligibility">Guide to eligibility</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services/eligibility-questions-and-answers-consumers?mega=NZ%20health%20system&amp;title=Q%26A%20for%20consumers">Q&amp;A for consumers</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services/eligibility-questions-and-answers-service-providers?mega=NZ%20health%20system&amp;title=Q%26A%20for%20service%20providers">Q&amp;A for service providers</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services/reciprocal-health-agreements?mega=NZ%20health%20system&amp;title=Reciprocal%20health%20agreements">Reciprocal health agreements</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services?mega=NZ%20health%20system&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211101145759/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements?mega=NZ%20health%20system&amp;title=Claims%2C%20provider%20payments%20and%20entitlements" class="menu-header">Claims &amp; provider payments</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211101145759/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/carer-support-claims?mega=NZ%20health%20system&amp;title=Carer%20Support">Carer Support</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/high-use-health-card-payments?mega=NZ%20health%20system&amp;title=High%20Use%20Health%20Card%20payments">High Use Health Card payments</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/between-travel-settlement?mega=NZ%20health%20system&amp;title=In-Between%20Travel%20Settlement">In-Between Travel Settlement</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/maternity-claim-forms?mega=NZ%20health%20system&amp;title=Maternity%20claim%20forms">Maternity claim forms</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/national-travel-assistance?mega=NZ%20health%20system&amp;title=National%20travel%20assistance%20claims">National travel assistance claims</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements?mega=NZ%20health%20system&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                        </div>
+    </div>
+    <div class="feature-links">
+      <h3 class="sr-only">Other related resources</h3>
+      <a href="/web/20211101145759/https://www.health.govt.nz/new-zealand-health-system/overview-health-system?mega=NZ%20health%20system&amp;title=Overview">Overview of the health system</a>  <a href="/web/20211101145759/https://www.health.govt.nz/new-zealand-health-system/my-dhb?mega=NZ%20health%20system&amp;title=Mydhb">My DHB</a> <a href="/web/20211101145759/https://www.health.govt.nz/new-zealand-health-system/system-level-measures-framework?mega=NZ%20health%20system&amp;title=SLM">System level measures</a>  <a href="/web/20211101145759/https://www.health.govt.nz/publication/new-zealand-health-strategy-2016?mega=NZ%20health%20system&amp;title=HealthStrategy">NZ Health Strategy</a>    </div>
+  </div>
+</li>
+<li class="dropdown"><a href="/web/20211101145759/https://www.health.govt.nz/our-work" class="dropdown-toggle active-trail" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="megamenu-dropdown-776">Our work <b class="caret"></b></a>
+  <div id="megamenu-dropdown-776" class="dropdown-menu">
+    <div class="yamm-content">
+      <div class="row">
+                            <ul class="col list-unstyled no-menu-header">
+                                                                                <li>
+                <a href="/web/20211101145759/https://www.health.govt.nz/our-work/hospitals-and-specialist-care/acute-care?mega=Our%20work&amp;title=Acute%20care" class="menu-header">Acute care</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211101145759/https://www.health.govt.nz/our-work/diseases-and-conditions/antimicrobial-resistance?mega=Our%20work&amp;title=Antimicrobial%20resistance" class="menu-header">Antimicrobial resistance</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211101145759/https://www.health.govt.nz/our-work/populations/asian-and-migrant-health?mega=Our%20work&amp;title=Asian%20and%20migrant%20health" class="menu-header">Asian and migrant health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211101145759/https://www.health.govt.nz/our-work/border-health?mega=Our%20work&amp;title=Border%20health" class="menu-header">Border health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211101145759/https://www.health.govt.nz/our-work/life-stages/breastfeeding?mega=Our%20work&amp;title=Breastfeeding" class="menu-header">Breastfeeding</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211101145759/https://www.health.govt.nz/our-work/diseases-and-conditions/cancer?mega=Our%20work&amp;title=Cancer" class="menu-header">Cancer</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211101145759/https://www.health.govt.nz/our-work/regulation-health-and-disability-system/certification-health-care-services?mega=Our%20work&amp;title=Certification%20of%20health%20care%20services" class="menu-header">Certification of health care services</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211101145759/https://www.health.govt.nz/our-work/life-stages/child-health?mega=Our%20work&amp;title=Child%20health" class="menu-header">Child health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211101145759/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus?mega=Our%20work&amp;title=COVID-19" class="menu-header">COVID-19 (novel coronavirus)</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211101145759/https://www.health.govt.nz/our-work/diseases-and-conditions/diabetes?mega=Our%20work&amp;title=Diabetes" class="menu-header">Diabetes</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211101145759/https://www.health.govt.nz/our-work/digital-health?mega=Our%20work&amp;title=Digital%20health" class="menu-header">Digital health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211101145759/https://www.health.govt.nz/our-work/disability-services?mega=Our%20work&amp;title=Disability%20services" class="menu-header">Disability services</a>                              </li>
+                                                                </ul>
+                            <ul class="col list-unstyled no-menu-header">
+                                                                                <li>
+                <a href="/web/20211101145759/https://www.health.govt.nz/our-work/diseases-and-conditions?mega=Our%20work&amp;title=Diseases%20and%20conditions" class="menu-header">Diseases and conditions</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211101145759/https://www.health.govt.nz/our-work/hospitals-and-specialist-care/emergency-departments?mega=Our%20work&amp;title=Emergency%20departments" class="menu-header">Emergency departments</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211101145759/https://www.health.govt.nz/our-work/emergency-management?mega=Our%20work&amp;title=Emergency%20management" class="menu-header">Emergency management</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211101145759/https://www.health.govt.nz/our-work/environmental-health?mega=Our%20work&amp;title=Environmental%20health" class="menu-header">Environmental health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211101145759/https://www.health.govt.nz/our-work/preventative-health-wellness/family-violence?mega=Our%20work&amp;title=Family%20violence" class="menu-header">Family violence</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211101145759/https://www.health.govt.nz/our-work/preventative-health-wellness/fluoride-and-oral-health?mega=Our%20work&amp;title=Fluoride%20and%20oral%20health" class="menu-header">Fluoride and oral health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211101145759/https://www.health.govt.nz/our-work/health-identity?mega=Our%20work&amp;title=Health%20identity" class="menu-header">Health identity</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211101145759/https://www.health.govt.nz/our-work/digital-health/digital-health-sector-architecture-standards-and-governance/health-information-standards-0?mega=Our%20work&amp;title=Health%20information%20standards" class="menu-header">Health information standards</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211101145759/https://www.health.govt.nz/our-work/health-infrastructure-unit-hiu?mega=Our%20work&amp;title=Health%20Infrastructure%20Unit" class="menu-header">Health Infrastructure Unit</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211101145759/https://www.health.govt.nz/our-work/life-stages/health-older-people?mega=Our%20work&amp;title=Health%20of%20older%20people" class="menu-header">Health of older people</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211101145759/https://www.health.govt.nz/our-work/health-workforce?mega=Our%20work&amp;title=Health%20workforce" class="menu-header">Health workforce</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211101145759/https://www.health.govt.nz/our-work/hospitals-and-specialist-care?mega=Our%20work&amp;title=Hospitals%20and%20specialist%20care" class="menu-header">Hospitals and specialist care</a>                              </li>
+                                                                </ul>
+                            <ul class="col list-unstyled no-menu-header">
+                                                                                <li>
+                <a href="/web/20211101145759/https://www.health.govt.nz/our-work/preventative-health-wellness/immunisation?mega=Our%20work&amp;title=Immunisation" class="menu-header">Immunisation</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211101145759/https://www.health.govt.nz/our-work/ionising-radiation-safety?mega=Our%20work&amp;title=Ionising%20radiation%20safety" class="menu-header">Ionising radiation safety</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211101145759/https://www.health.govt.nz/our-work/populations/maori-health?mega=Our%20work&amp;title=M%C4%81ori%20health" class="menu-header">Māori health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211101145759/https://www.health.govt.nz/our-work/life-stages/maternity-services?mega=Our%20work&amp;title=Maternity" class="menu-header">Maternity</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211101145759/https://www.health.govt.nz/our-work/regulation-health-and-disability-system/medicinal-cannabis-agency?mega=Our%20work&amp;title=Medicinal%20Cannabis%20Agency" class="menu-header">Medicinal cannabis</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211101145759/https://www.health.govt.nz/our-work/regulation-health-and-disability-system/medicines-control?mega=Our%20work&amp;title=Medicines%20control" class="menu-header">Medicines control</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211101145759/https://www.health.govt.nz/our-work/mental-health-and-addiction?mega=Our%20work&amp;title=Mental%20health%20and%20addiction" class="menu-header">Mental health and addiction</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211101145759/https://www.health.govt.nz/our-work/nursing?mega=Our%20work&amp;title=Nursing" class="menu-header">Nursing</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211101145759/https://www.health.govt.nz/our-work/preventative-health-wellness/nutrition?mega=Our%20work&amp;title=Nutrition" class="menu-header">Nutrition</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211101145759/https://www.health.govt.nz/our-work/preventative-health-wellness/oral-health?mega=Our%20work&amp;title=Oral%20health" class="menu-header">Oral health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211101145759/https://www.health.govt.nz/our-work/hospitals-and-specialist-care/organ-donation-and-transplantation?mega=Our%20work&amp;title=Organ%20donation%20and%20transplantation" class="menu-header">Organ donation and transplantation</a>                              </li>
+                                                                </ul>
+                            <ul class="col list-unstyled no-menu-header">
+                                                                                <li>
+                <a href="/web/20211101145759/https://www.health.govt.nz/our-work/populations/pacific-health?mega=Our%20work&amp;title=Pacific%20health" class="menu-header">Pacific health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211101145759/https://www.health.govt.nz/new-zealand-health-system/pay-equity-settlements?mega=Our%20work&amp;title=Pay%20equity%20settlements" class="menu-header">Pay equity</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211101145759/https://www.health.govt.nz/our-work/preventative-health-wellness/physical-activity?mega=Our%20work&amp;title=Physical%20activity" class="menu-header">Physical activity</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211101145759/https://www.health.govt.nz/our-work/hospitals-and-specialist-care/planned-care-services?mega=Our%20work&amp;title=Planned%20Care%20services" class="menu-header">Planned Care services</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211101145759/https://www.health.govt.nz/our-work/preventative-health-wellness?mega=Our%20work&amp;title=Preventative%20health/wellness" class="menu-header">Preventative health/wellness</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211101145759/https://www.health.govt.nz/our-work/primary-health-care?mega=Our%20work&amp;title=Primary%20health%20care" class="menu-header">Primary health care</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211101145759/https://www.health.govt.nz/our-work/public-health-workforce-development?mega=Our%20work&amp;title=Public%20health%20workforce%20development" class="menu-header">Public health workforce</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211101145759/https://www.health.govt.nz/our-work/regulation-health-and-disability-system?mega=Our%20work&amp;title=Regulation" class="menu-header">Regulation</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211101145759/https://www.health.govt.nz/our-work/preventative-health-wellness/tobacco-control?mega=Our%20work&amp;title=Tobacco%20control" class="menu-header">Tobacco control</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211101145759/https://www.health.govt.nz/our-work/regulation-health-and-disability-system/regulation-vaping-and-smokeless-tobacco-products?mega=Our%20work&amp;title=Vaping%20and%20smokeless%20tobacco%20products" class="menu-header">Vaping &amp; smokeless tobacco</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211101145759/https://www.health.govt.nz/our-work/who-code-nz?mega=Our%20work&amp;title=WHO%20Code%20in%20NZ" class="menu-header">WHO Code in NZ</a>                              </li>
+                      </ul>
+              </div>
+    </div>
+    <div class="feature-links">
+      <a href="/web/20211101145759/https://www.health.govt.nz/our-work?mega=Our%20work&amp;title=A-Z">View the full A-Z</a>    </div>
+  </div>
+</li>
+<li class="dropdown"><a href="/web/20211101145759/https://www.health.govt.nz/nz-health-statistics" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="megamenu-dropdown-778">Health statistics <b class="caret"></b></a>
+    <div id="megamenu-dropdown-778" class="dropdown-menu">
+    <div class="yamm-content">
+      <div class="row">
+                            <div class="col">
+            <h3><a href="/web/20211101145759/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets?mega=Health%20statistics&amp;title=Health%20statistics%20and%20data%20sets" class="menu-header">Statistics by topic</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211101145759/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/cancer-data-and-stats?mega=Health%20statistics&amp;title=Cancer">Cancer</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/diabetes-data-and-stats?mega=Health%20statistics&amp;title=Diabetes">Diabetes</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/mental-health-data-and-stats?mega=Health%20statistics&amp;title=Mental%20health">Mental health</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/maori-health-data-and-stats?mega=Health%20statistics&amp;title=M%C4%81ori%20health">Māori health</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/obesity-statistics?mega=Health%20statistics&amp;title=Obesity">Obesity</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/suicide-data-and-stats?mega=Health%20statistics&amp;title=Suicide">Suicide</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/tobacco-data-and-stats?mega=Health%20statistics&amp;title=Tobacco">Tobacco</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets?mega=Health%20statistics&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211101145759/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys?mega=Health%20statistics&amp;title=National%20collections%20and%20surveys" class="menu-header">About our surveys &amp; data collections</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211101145759/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/surveys/past-surveys/alcohol-and-drug-use-survey?mega=Health%20statistics&amp;title=Alcohol%20%26%20Drug%20Use%20Survey">Alcohol &amp; Drug Use Survey</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/national-collections-annual-maintenance-project?mega=Health%20statistics&amp;title=NCAMP">NCAMP</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/collections/new-zealand-cancer-registry-nzcr?mega=Health%20statistics&amp;title=NZ%20Cancer%20Registry">NZ Cancer Registry</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/surveys/new-zealand-health-survey?mega=Health%20statistics&amp;title=NZ%20Health%20Survey">NZ Health Survey</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/surveys/past-surveys/nutrition-survey?mega=Health%20statistics&amp;title=Nutrition%20Survey">Nutrition Survey</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/collections/primhd-mental-health-data?mega=Health%20statistics&amp;title=PRIMHD">PRIMHD</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys?mega=Health%20statistics&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211101145759/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology?mega=Health%20statistics&amp;title=Classification%20and%20Terminology" class="menu-header">Classification &amp; terminology</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211101145759/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology/using-icd-10-am-achi-acs/coding-queries/coding-query-database?mega=Health%20statistics&amp;title=Coding%20query%20database">Coding query database</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology/using-icd-10-am-achi-acs/courses-clinical-coding?mega=Health%20statistics&amp;title=Courses%20on%20clinical%20coding">Courses on clinical coding</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology/new-zealand-snomed-ct-national-release-centre?mega=Health%20statistics&amp;title=SNOMED%20CT">SNOMED CT</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology/using-icd-10-am-achi-acs?mega=Health%20statistics&amp;title=Using%20ICD-10-AM/ACHI/ACS">Using ICD-10-AM/ACHI/ACS</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology?mega=Health%20statistics&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211101145759/https://www.health.govt.nz/nz-health-statistics/data-references?mega=Health%20statistics&amp;title=Data%20references" class="menu-header">Data references</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211101145759/https://www.health.govt.nz/nz-health-statistics/data-references/code-tables?mega=Health%20statistics&amp;title=Code%20tables">Code tables</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/nz-health-statistics/data-references/data-dictionaries?mega=Health%20statistics&amp;title=Data%20dictionaries">Data dictionaries</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/nz-health-statistics/data-references/diagnosis-related-groups?mega=Health%20statistics&amp;title=Diagnosis-related%20groups">Diagnosis-related groups</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/nz-health-statistics/data-references/code-tables/common-code-tables/domicile-code-table?mega=Health%20statistics&amp;title=Domicile%20code%20table">Domicile code table</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/nz-health-statistics/data-references/mapping-tools?mega=Health%20statistics&amp;title=ICD%20mapping%20tools">ICD mapping tools</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/nz-health-statistics/data-references/weighted-inlier-equivalent-separations?mega=Health%20statistics&amp;title=Weighted%20Inlier%20Equivalent%20Separations">Weighted Inlier Equivalent Separations</a></li>
+                                  <li><a href="/web/20211101145759/https://www.health.govt.nz/nz-health-statistics/data-references?mega=Health%20statistics&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                        </div>
+    </div>
+    <div class="feature-links">
+      <h3 class="sr-only">Other related resources</h3>
+      <a href="/web/20211101145759/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/tier-1-health-statistics-release-calendar?mega=Health%20statistics&amp;title=Tier%201%20calendar">Release calendar for our Tier 1 statistics</a> <a href="/web/20211101145759/https://www.health.govt.nz/nz-health-statistics/about-data-collection?mega=Health%20statistics&amp;title=Enquiries">Data and survey enquiries</a>    </div>
+  </div>
+</li>
+<li class=""><a href="/web/20211101145759/https://www.health.govt.nz/publications" aria-haspopup="false">Publications</a></li>
+<li class=""><a href="/web/20211101145759/https://www.health.govt.nz/about-ministry" aria-haspopup="false">About us</a></li>
+<li class="visible-xs"><a href="/web/20211101145759/https://www.health.govt.nz/contactus" aria-haspopup="false">Contact us</a></li>
+</ul>
+                                  </nav>
+        </div>
+          </div>
+  </header>
+
+  <div class="main-container container">
+    <!-- announcement -->
+        <!-- /announcement -->
+
+    <header role="banner" id="page-header">
+
+          </header> <!-- /#page-header -->
+
+    <div class="row">
+
+      <section class="col-sm-12">
+                        <a id="main-content"></a>
+                                                                            <div class="breadcrumbs">
+            <ul><li><a href="/web/20211101145759/https://www.health.govt.nz/">Home</a></li><li><a href="/web/20211101145759/https://www.health.govt.nz/our-work">Our work</a></li><li><a href="/web/20211101145759/https://www.health.govt.nz/our-work/diseases-and-conditions">Diseases and conditions</a></li><li><a href="/web/20211101145759/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished" data-is-top-level="1" title="">COVID-19</a></li><li><a href="/web/20211101145759/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics" class="menu-node-unpublished menu-node-unpublished">Data and statistics</a></li><li><span class="current-breadcrumb">Vaccine data</span></li></ul>          </div>
+
+
+
+          <div class="region region-content">
+    <section id="block-system-main" class="block block-system clearfix">
+
+
+  <div class="bootstrap-threecol-stacked">
+
+      <div class="row"> <!-- @TODO: Add extra classes -->
+      <div class="panel-panel left col-xs-12 col-md-3 col-lg-3"><div class="panel-pane pane-block pane-menu-block-1 odd pane-top-link">
+
+        <span class="top-link"><a href="/web/20211101145759/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished active-trail" data-is-top-level="1">COVID-19</a></span>
+
+
+  <div class="pane-content">
+        <div class="menu-block-wrapper menu-block-1 menu-name-main-menu parent-mlid-1445 menu-level-2">
+  <ul class="menu nav"><li class="first collapsed menu-mlid-10163 health-advice depth-4"><a href="/web/20211101145759/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-health-advice-public" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished">Health advice</a></li>
+<li class="collapsed menu-mlid-10630 covid-19-vaccines- depth-4 section-overview hide-children"><a href="/web/20211101145759/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-vaccines" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished" data-is-top-level="1" title="">COVID-19 vaccines </a></li>
+<li class="collapsed menu-mlid-9997 health-professionals depth-4"><a href="/web/20211101145759/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-information-health-professionals" class="menu-node-unpublished menu-node-unpublished">Health professionals</a></li>
+<li class="collapsed menu-mlid-10019 specific-audiences depth-4"><a href="/web/20211101145759/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-information-specific-audiences" class="menu-node-unpublished">Specific audiences</a></li>
+<li class="expanded active-trail menu-mlid-10096 data-and-statistics depth-4"><a href="/web/20211101145759/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics" class="menu-node-unpublished menu-node-unpublished active-trail">Data and statistics</a><ul class="menu nav"><li class="first leaf menu-mlid-10062 current-cases depth-5 same-level-as-node"><a href="/web/20211101145759/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-current-cases" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Current cases</a></li>
+<li class="leaf menu-mlid-10146 case-demographics depth-5 same-level-as-node"><a href="/web/20211101145759/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-case-demographics">Case demographics</a></li>
+<li class="leaf menu-mlid-10097 source-of-cases depth-5 same-level-as-node"><a href="/web/20211101145759/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-source-cases" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Source of cases</a></li>
+<li class="leaf menu-mlid-10119 testing-for-covid-19 depth-5 same-level-as-node"><a href="/web/20211101145759/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/testing-covid-19" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Testing for COVID-19</a></li>
+<li class="leaf menu-mlid-10371 nz-covid-tracer-app-data depth-5 same-level-as-node"><a href="/web/20211101145759/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-nz-covid-tracer-app-data" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">NZ COVID Tracer app data</a></li>
+<li class="expanded active-trail active menu-mlid-10584 active vaccine-data depth-5 same-level-as-node"><a href="/web/20211101145759/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished active-trail active">Vaccine data</a><ul class="menu nav"><li class="first leaf menu-mlid-10867 covid-19-vaccination-uptake-rates-across-nz depth-6"><a href="/web/20211101145759/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-across-nz" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">COVID-19 Vaccination uptake rates across NZ</a></li>
+<li class="leaf menu-mlid-10868 covid-19-vaccination-uptake-rates---māori depth-6"><a href="/web/20211101145759/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-maori-communities-across-nz" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">COVID-19 Vaccination uptake rates - Māori</a></li>
+<li class="last leaf menu-mlid-10869 covid-19-vaccination-uptake-rates---pacific depth-6"><a href="/web/20211101145759/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-pacific-communities-across-nz" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">COVID-19 Vaccination uptake rates - Pacific</a></li>
+</ul></li>
+<li class="last leaf menu-mlid-10404 data-resources depth-5 same-level-as-node"><a href="/web/20211101145759/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-data-resources" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Data resources</a></li>
+</ul></li>
+<li class="collapsed menu-mlid-10369 response-planning depth-4"><a href="/web/20211101145759/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-response-planning" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Response planning</a></li>
+<li class="collapsed menu-mlid-10015 resources-and-tools depth-4"><a href="/web/20211101145759/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-resources-and-tools" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Resources and tools</a></li>
+<li class="last leaf menu-mlid-10004 news-and-media depth-4 section-overview hide-children"><a href="/web/20211101145759/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-news-and-media-updates" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">News and media</a></li>
+</ul></div>
+  </div>
+
+
+  </div>
+</div>      <div class="panel-panel middle col-xs-12 col-md-9 col-lg-9"><div class="panel-pane pane-page-title even">
+
+
+
+  <div class="pane-content">
+    <span id="skip-content" tabindex="-1"></span>    <h1>COVID-19: Vaccine data</h1>
+  </div>
+
+
+  </div>
+<div class="panel-pane pane-node-content odd">
+
+
+
+  <div class="pane-content">
+        <article id="node-12052" class="node node-page node-sticky view-mode-full clearfix" about="/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" typeof="sioc:Item foaf:Document">
+    <header>
+            <span property="dc:title" content="COVID-19: Vaccine data" class="rdf-meta element-hidden"></span>      </header>
+    <div class="field field-name-field-intro-text field-type-text-long field-label-hidden"><div class="field-items"><div class="field-item even"><p class="intro-text">Data and statistics about the rollout of COVID-19 vaccines in New Zealand.</p></div></div></div><div class="field field-name-body field-type-text-with-summary field-label-hidden"><div class="field-items"><div class="field-item even" property="content:encoded"><p>On this page:</p>
+
+<ul>
+	<li><a href="#daily">Daily updates</a>
+
+	<ul>
+		<li><a href="#total-vaccinations">Total vaccinations</a></li>
+		<li><a href="#ethnicity">Vaccinations by ethnicity</a></li>
+		<li><a href="#90pct">Vaccinations to 90% by DHB</a></li>
+	</ul>
+	</li>
+	<li><a href="#weekly-updates">Weekly updates</a>
+	<ul>
+		<li><a href="#model">Vaccinations against plan</a></li>
+		<li><a href="#uptake">Vaccinations uptake</a></li>
+		<li><a href="#by-day">Vaccinations by day</a></li>
+		<li><a href="#location">Vaccinations by DHB</a></li>
+		<li><a href="#group">Vaccinations by group</a></li>
+		<li><a href="#by_soh">Stock on hand</a></li>
+		<li><a href="#age">Vaccinations by age</a></li>
+		<li><a href="#workforce">Trained vaccinator and active vaccinator</a></li>
+		<li><a href="#group">Vaccinations by group</a></li>
+		<li><a href="#download">Details of vaccination&nbsp;data</a></li>
+	</ul>
+	</li>
+	<li><a href="#adverse-events">Adverse events from immunisations</a></li>
+</ul>
+
+<hr/><!--daily-->
+<h2><a id="daily" name="daily"></a>COVID-19 vaccinations: daily updates</h2>
+
+<div class="well well-sm">
+<p style="margin-top: 0"><strong>Data in this section is as at 11:59pm 31 October 2021 and is updated daily.</strong></p>
+</div>
+
+<h3><a id="total-vaccinations" name="total-vaccinations"></a>Total Vaccinations</h3>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">&nbsp;</th>
+			<th scope="col" style="text-align:right">Vaccinations yesterday</th>
+			<th scope="col" style="text-align:right">Cumulative total</th>
+			<th scope="col" style="text-align:right">Eligible population vaccinated %</th>
+			<th scope="col" style="text-align:right">Total population vaccinated %</th>
+			<th scope="col" style="text-align:right">Vaccinated or booked</th>
+			<th scope="col" style="text-align:right">Eligible vaccinated or booked %</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">First dose</th>
+			<td style="text-align:right">4,867</td>
+			<td style="text-align:right">3,709,315</td>
+			<td style="text-align:right">88%</td>
+			<td style="text-align:right">74%</td>
+			<td style="text-align:right">3,721,154</td>
+			<td style="text-align:right">88%</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Second dose</th>
+			<td style="text-align:right">15,303</td>
+			<td style="text-align:right">3,159,301</td>
+			<td style="text-align:right">75%</td>
+			<td style="text-align:right">63%</td>
+			<td style="text-align:right">3,385,006</td>
+			<td style="text-align:right">80%</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total doses</strong></th>
+			<td style="text-align:right"><strong>20,170</strong></td>
+			<td style="text-align:right"><strong>6,868,616</strong></td>
+		</tr>
+	</tbody>
+</table>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Total vaccinations" class="img-responsive" height="900" src="/web/20211101145759im_/https://www.health.govt.nz/sites/default/files/images/uptake_summary_8.png" width="5340"/></figure>
+
+<h5>Definitions</h5>
+
+<ul>
+	<li><strong>Cumulative total:</strong>&nbsp;All vaccinations that have been administered and entered into the COVID-19 Immunisation Register up until midnight of the night before the data is published.</li>
+	<li><strong>Eligible population vaccinated %:</strong>&nbsp;Vaccinations administered divided by HSU population estimates for the eligible population (12+).</li>
+	<li><strong>Total population vaccinated %:</strong>&nbsp;Vaccinations administered divided by HSU population estimates for the total population (0+).</li>
+	<li><strong>Vaccinated or booked:</strong>&nbsp;Count of individuals who have either received their vaccination or have booked via Book My Vaccine to receive a vaccination.</li>
+	<li><strong>Eligible vaccinated or booked %:</strong>&nbsp;Count of individuals who have either received their vaccination or have booked via Book My Vaccine to receive a vaccination divided by HSU population estimates for the eligible population (12+).</li>
+</ul>
+
+<p>HSU population estimates are available in the downloadable spreadsheet at the bottom of the page. Throughout the rest of this sheet doses per 1,000 are based on eligible (12+) population.</p>
+
+<p>Bookings are only counted if the site is using Book My Vaccine. Bookings made through other Patient Management Systems are not counted.</p>
+
+<hr/>
+<h3><a id="by_eth" name="ethnicity"></a>Cumulative vaccinations by ethnicity</h3>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">Ethnicity *</th>
+			<th scope="col" style="text-align:right">First dose administered</th>
+			<th scope="col" style="text-align:right">First doses per 1,000 people</th>
+			<th scope="col" style="text-align:right">Second dose administered</th>
+			<th scope="col" style="text-align:right">Second doses per 1,000 people</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">Māori</th>
+			<td style="text-align:right">410,683</td>
+			<td style="text-align:right">719</td>
+			<td style="text-align:right">300,709</td>
+			<td style="text-align:right">527</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Pacific Peoples</th>
+			<td style="text-align:right">244,009</td>
+			<td style="text-align:right">851</td>
+			<td style="text-align:right">197,188</td>
+			<td style="text-align:right">688</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Asian</th>
+			<td style="text-align:right">607,681</td>
+			<td style="text-align:right">&gt;950</td>
+			<td style="text-align:right">543,063</td>
+			<td style="text-align:right">907</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">European / Other</th>
+			<td style="text-align:right">2,412,941</td>
+			<td style="text-align:right">884</td>
+			<td style="text-align:right">2,089,841</td>
+			<td style="text-align:right">765</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Unknown</th>
+			<td style="text-align:right">34,001</td>
+			<td style="text-align:right">-</td>
+			<td style="text-align:right">28,500</td>
+			<td style="text-align:right">-</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total</strong></th>
+			<td style="text-align:right"><strong>3,709,315</strong></td>
+			<td style="text-align:right"><strong>881</strong></td>
+			<td style="text-align:right"><strong>3,159,301</strong></td>
+			<td style="text-align:right"><strong>751</strong></td>
+		</tr>
+	</tbody>
+</table>
+
+<p><strong>*</strong> The prioritised ethnicity classification system allocates each person to a single ethnic group, based on the ethnic groups they identify with. Where people identify with more than one group, they are assigned in this order of priority: Māori, Pacific Peoples, Asian, and European/Other. So, if a person identifies as being Māori and New Zealand European, the person is counted as Māori. See <a href="/web/20211101145759/https://www.health.govt.nz/publication/hiso-100012017-ethnicity-data-protocols">Ethnicity Data Protocols</a> for further information.</p>
+
+<p>Ethnicity breakdown by DHB of residence is available in the downloadable spreadsheet at the bottom of the page.</p>
+
+<hr/>
+<h3><a id="90pct" name="90pct"></a>Vaccinations to 90% by DHB</h3>
+
+<h4><a id="90pct all ethnicities" name="90pct all ethnicities"></a>All Ethnicities</h4>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">&nbsp;</th>
+			<th scope="col" style="text-align:right">First doses</th>
+			<th scope="col" style="text-align:right">First doses %</th>
+			<th scope="col" style="text-align:right">First doses to 90%</th>
+			<th scope="col" style="text-align:right">Second doses</th>
+			<th scope="col" style="text-align:right">Second doses %</th>
+			<th scope="col" style="text-align:right">Second doses to 90%</th>
+			<th scope="col" style="text-align:right">Population</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">Northland</th>
+			<td style="text-align:right">127,753</td>
+			<td style="text-align:right">79%</td>
+			<td style="text-align:right">17,435</td>
+			<td style="text-align:right">103,689</td>
+			<td style="text-align:right">64%</td>
+			<td style="text-align:right">41,499</td>
+			<td style="text-align:right">161,320</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waitemata</th>
+			<td style="text-align:right">480,049</td>
+			<td style="text-align:right">91%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">423,578</td>
+			<td style="text-align:right">81%</td>
+			<td style="text-align:right">49,900</td>
+			<td style="text-align:right">526,087</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Auckland</th>
+			<td style="text-align:right">398,544</td>
+			<td style="text-align:right">94%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">358,316</td>
+			<td style="text-align:right">85%</td>
+			<td style="text-align:right">23,246</td>
+			<td style="text-align:right">423,958</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Counties Manukau</th>
+			<td style="text-align:right">429,723</td>
+			<td style="text-align:right">89%</td>
+			<td style="text-align:right">4,773</td>
+			<td style="text-align:right">372,728</td>
+			<td style="text-align:right">77%</td>
+			<td style="text-align:right">61,768</td>
+			<td style="text-align:right">482,773</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waikato</th>
+			<td style="text-align:right">309,731</td>
+			<td style="text-align:right">87%</td>
+			<td style="text-align:right">11,727</td>
+			<td style="text-align:right">258,044</td>
+			<td style="text-align:right">72%</td>
+			<td style="text-align:right">63,414</td>
+			<td style="text-align:right">357,176</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Lakes</th>
+			<td style="text-align:right">76,233</td>
+			<td style="text-align:right">81%</td>
+			<td style="text-align:right">8,744</td>
+			<td style="text-align:right">62,138</td>
+			<td style="text-align:right">66%</td>
+			<td style="text-align:right">22,839</td>
+			<td style="text-align:right">94,419</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Bay of Plenty</th>
+			<td style="text-align:right">180,360</td>
+			<td style="text-align:right">83%</td>
+			<td style="text-align:right">14,887</td>
+			<td style="text-align:right">146,574</td>
+			<td style="text-align:right">68%</td>
+			<td style="text-align:right">48,673</td>
+			<td style="text-align:right">216,941</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Tairawhiti</th>
+			<td style="text-align:right">32,821</td>
+			<td style="text-align:right">78%</td>
+			<td style="text-align:right">4,948</td>
+			<td style="text-align:right">26,626</td>
+			<td style="text-align:right">63%</td>
+			<td style="text-align:right">11,142</td>
+			<td style="text-align:right">41,965</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Taranaki</th>
+			<td style="text-align:right">86,021</td>
+			<td style="text-align:right">84%</td>
+			<td style="text-align:right">5,911</td>
+			<td style="text-align:right">67,480</td>
+			<td style="text-align:right">66%</td>
+			<td style="text-align:right">24,452</td>
+			<td style="text-align:right">102,147</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hawkes Bay</th>
+			<td style="text-align:right">123,225</td>
+			<td style="text-align:right">85%</td>
+			<td style="text-align:right">7,789</td>
+			<td style="text-align:right">104,086</td>
+			<td style="text-align:right">72%</td>
+			<td style="text-align:right">26,928</td>
+			<td style="text-align:right">145,571</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">MidCentral</th>
+			<td style="text-align:right">131,441</td>
+			<td style="text-align:right">86%</td>
+			<td style="text-align:right">5,631</td>
+			<td style="text-align:right">110,273</td>
+			<td style="text-align:right">72%</td>
+			<td style="text-align:right">26,799</td>
+			<td style="text-align:right">152,302</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Whanganui</th>
+			<td style="text-align:right">46,122</td>
+			<td style="text-align:right">81%</td>
+			<td style="text-align:right">5,400</td>
+			<td style="text-align:right">38,881</td>
+			<td style="text-align:right">68%</td>
+			<td style="text-align:right">12,641</td>
+			<td style="text-align:right">57,247</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Capital and Coast</th>
+			<td style="text-align:right">249,910</td>
+			<td style="text-align:right">92%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">217,398</td>
+			<td style="text-align:right">80%</td>
+			<td style="text-align:right">26,659</td>
+			<td style="text-align:right">271,174</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hutt Valley</th>
+			<td style="text-align:right">114,709</td>
+			<td style="text-align:right">88%</td>
+			<td style="text-align:right">2,506</td>
+			<td style="text-align:right">97,185</td>
+			<td style="text-align:right">75%</td>
+			<td style="text-align:right">20,030</td>
+			<td style="text-align:right">130,239</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Wairarapa</th>
+			<td style="text-align:right">35,433</td>
+			<td style="text-align:right">86%</td>
+			<td style="text-align:right">1,851</td>
+			<td style="text-align:right">30,046</td>
+			<td style="text-align:right">73%</td>
+			<td style="text-align:right">7,238</td>
+			<td style="text-align:right">41,427</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Nelson Marlborough</th>
+			<td style="text-align:right">117,863</td>
+			<td style="text-align:right">87%</td>
+			<td style="text-align:right">4,306</td>
+			<td style="text-align:right">103,259</td>
+			<td style="text-align:right">76%</td>
+			<td style="text-align:right">18,910</td>
+			<td style="text-align:right">135,743</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">West Coast</th>
+			<td style="text-align:right">22,811</td>
+			<td style="text-align:right">82%</td>
+			<td style="text-align:right">2,304</td>
+			<td style="text-align:right">18,802</td>
+			<td style="text-align:right">67%</td>
+			<td style="text-align:right">6,313</td>
+			<td style="text-align:right">27,906</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Canterbury</th>
+			<td style="text-align:right">440,277</td>
+			<td style="text-align:right">91%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">356,328</td>
+			<td style="text-align:right">74%</td>
+			<td style="text-align:right">78,273</td>
+			<td style="text-align:right">482,890</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">South Canterbury</th>
+			<td style="text-align:right">45,539</td>
+			<td style="text-align:right">87%</td>
+			<td style="text-align:right">1,787</td>
+			<td style="text-align:right">39,217</td>
+			<td style="text-align:right">75%</td>
+			<td style="text-align:right">8,109</td>
+			<td style="text-align:right">52,584</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Southern</th>
+			<td style="text-align:right">258,702</td>
+			<td style="text-align:right">90%</td>
+			<td style="text-align:right">512</td>
+			<td style="text-align:right">222,975</td>
+			<td style="text-align:right">77%</td>
+			<td style="text-align:right">36,238</td>
+			<td style="text-align:right">288,015</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Overseas / Unknown</th>
+			<td style="text-align:right">2,048</td>
+			<td style="text-align:right">12%</td>
+			<td style="text-align:right">13,408</td>
+			<td style="text-align:right">1,678</td>
+			<td style="text-align:right">10%</td>
+			<td style="text-align:right">13,778</td>
+			<td style="text-align:right">17,173</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total</strong></th>
+			<td style="text-align:right"><strong>3,709,315</strong></td>
+			<td style="text-align:right"><strong>88%</strong></td>
+			<td style="text-align:right"><strong>78,836</strong></td>
+			<td style="text-align:right"><strong>3,159,301</strong></td>
+			<td style="text-align:right"><strong>75%</strong></td>
+			<td style="text-align:right"><strong>628,850</strong></td>
+			<td style="text-align:right"><strong>4,209,057</strong></td>
+		</tr>
+	</tbody>
+</table>
+
+<p>First/second doses % are the number of first/second doses administered divided by the eligible population. First/second doses to 90% are the number of doses required to reach 90% of the eligible population. For these two measures, the national total may not be the sum of DHB measures.</p>
+
+<h4><a id="90pct Māori" name="90pct Māori">Māori</a></h4>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">&nbsp;</th>
+			<th scope="col" style="text-align:right">First doses</th>
+			<th scope="col" style="text-align:right">First doses %</th>
+			<th scope="col" style="text-align:right">First doses to 90%</th>
+			<th scope="col" style="text-align:right">Second doses</th>
+			<th scope="col" style="text-align:right">Second doses %</th>
+			<th scope="col" style="text-align:right">Second doses to 90%</th>
+			<th scope="col" style="text-align:right">Population</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">Northland</th>
+			<td style="text-align:right">33,913</td>
+			<td style="text-align:right">67%</td>
+			<td style="text-align:right">11,526</td>
+			<td style="text-align:right">23,698</td>
+			<td style="text-align:right">47%</td>
+			<td style="text-align:right">21,741</td>
+			<td style="text-align:right">50,488</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waitemata</th>
+			<td style="text-align:right">32,913</td>
+			<td style="text-align:right">80%</td>
+			<td style="text-align:right">4,089</td>
+			<td style="text-align:right">25,533</td>
+			<td style="text-align:right">62%</td>
+			<td style="text-align:right">11,469</td>
+			<td style="text-align:right">41,113</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Auckland</th>
+			<td style="text-align:right">22,972</td>
+			<td style="text-align:right">83%</td>
+			<td style="text-align:right">2,041</td>
+			<td style="text-align:right">18,246</td>
+			<td style="text-align:right">66%</td>
+			<td style="text-align:right">6,767</td>
+			<td style="text-align:right">27,792</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Counties Manukau</th>
+			<td style="text-align:right">46,733</td>
+			<td style="text-align:right">74%</td>
+			<td style="text-align:right">10,411</td>
+			<td style="text-align:right">34,134</td>
+			<td style="text-align:right">54%</td>
+			<td style="text-align:right">23,010</td>
+			<td style="text-align:right">63,493</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waikato</th>
+			<td style="text-align:right">50,840</td>
+			<td style="text-align:right">73%</td>
+			<td style="text-align:right">11,896</td>
+			<td style="text-align:right">35,994</td>
+			<td style="text-align:right">52%</td>
+			<td style="text-align:right">26,742</td>
+			<td style="text-align:right">69,707</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Lakes</th>
+			<td style="text-align:right">19,783</td>
+			<td style="text-align:right">66%</td>
+			<td style="text-align:right">7,294</td>
+			<td style="text-align:right">14,123</td>
+			<td style="text-align:right">47%</td>
+			<td style="text-align:right">12,954</td>
+			<td style="text-align:right">30,085</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Bay of Plenty</th>
+			<td style="text-align:right">30,719</td>
+			<td style="text-align:right">64%</td>
+			<td style="text-align:right">12,242</td>
+			<td style="text-align:right">21,719</td>
+			<td style="text-align:right">46%</td>
+			<td style="text-align:right">21,242</td>
+			<td style="text-align:right">47,734</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Tairawhiti</th>
+			<td style="text-align:right">13,481</td>
+			<td style="text-align:right">68%</td>
+			<td style="text-align:right">4,374</td>
+			<td style="text-align:right">9,925</td>
+			<td style="text-align:right">50%</td>
+			<td style="text-align:right">7,930</td>
+			<td style="text-align:right">19,839</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Taranaki</th>
+			<td style="text-align:right">10,890</td>
+			<td style="text-align:right">68%</td>
+			<td style="text-align:right">3,424</td>
+			<td style="text-align:right">7,294</td>
+			<td style="text-align:right">46%</td>
+			<td style="text-align:right">7,020</td>
+			<td style="text-align:right">15,904</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hawkes Bay</th>
+			<td style="text-align:right">23,020</td>
+			<td style="text-align:right">68%</td>
+			<td style="text-align:right">7,633</td>
+			<td style="text-align:right">16,645</td>
+			<td style="text-align:right">49%</td>
+			<td style="text-align:right">14,008</td>
+			<td style="text-align:right">34,059</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">MidCentral</th>
+			<td style="text-align:right">17,370</td>
+			<td style="text-align:right">72%</td>
+			<td style="text-align:right">4,432</td>
+			<td style="text-align:right">12,620</td>
+			<td style="text-align:right">52%</td>
+			<td style="text-align:right">9,182</td>
+			<td style="text-align:right">24,225</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Whanganui</th>
+			<td style="text-align:right">8,819</td>
+			<td style="text-align:right">65%</td>
+			<td style="text-align:right">3,342</td>
+			<td style="text-align:right">6,616</td>
+			<td style="text-align:right">49%</td>
+			<td style="text-align:right">5,545</td>
+			<td style="text-align:right">13,512</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Capital and Coast</th>
+			<td style="text-align:right">21,563</td>
+			<td style="text-align:right">80%</td>
+			<td style="text-align:right">2,707</td>
+			<td style="text-align:right">16,869</td>
+			<td style="text-align:right">63%</td>
+			<td style="text-align:right">7,401</td>
+			<td style="text-align:right">26,967</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hutt Valley</th>
+			<td style="text-align:right">14,047</td>
+			<td style="text-align:right">73%</td>
+			<td style="text-align:right">3,164</td>
+			<td style="text-align:right">10,529</td>
+			<td style="text-align:right">55%</td>
+			<td style="text-align:right">6,682</td>
+			<td style="text-align:right">19,123</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Wairarapa</th>
+			<td style="text-align:right">4,439</td>
+			<td style="text-align:right">70%</td>
+			<td style="text-align:right">1,233</td>
+			<td style="text-align:right">3,193</td>
+			<td style="text-align:right">51%</td>
+			<td style="text-align:right">2,479</td>
+			<td style="text-align:right">6,302</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Nelson Marlborough</th>
+			<td style="text-align:right">7,972</td>
+			<td style="text-align:right">71%</td>
+			<td style="text-align:right">2,151</td>
+			<td style="text-align:right">6,057</td>
+			<td style="text-align:right">54%</td>
+			<td style="text-align:right">4,066</td>
+			<td style="text-align:right">11,248</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">West Coast</th>
+			<td style="text-align:right">2,020</td>
+			<td style="text-align:right">73%</td>
+			<td style="text-align:right">468</td>
+			<td style="text-align:right">1,487</td>
+			<td style="text-align:right">54%</td>
+			<td style="text-align:right">1,002</td>
+			<td style="text-align:right">2,765</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Canterbury</th>
+			<td style="text-align:right">28,580</td>
+			<td style="text-align:right">77%</td>
+			<td style="text-align:right">4,692</td>
+			<td style="text-align:right">20,206</td>
+			<td style="text-align:right">55%</td>
+			<td style="text-align:right">13,066</td>
+			<td style="text-align:right">36,969</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">South Canterbury</th>
+			<td style="text-align:right">2,462</td>
+			<td style="text-align:right">72%</td>
+			<td style="text-align:right">623</td>
+			<td style="text-align:right">1,831</td>
+			<td style="text-align:right">53%</td>
+			<td style="text-align:right">1,254</td>
+			<td style="text-align:right">3,428</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Southern</th>
+			<td style="text-align:right">17,957</td>
+			<td style="text-align:right">76%</td>
+			<td style="text-align:right">3,324</td>
+			<td style="text-align:right">13,852</td>
+			<td style="text-align:right">59%</td>
+			<td style="text-align:right">7,429</td>
+			<td style="text-align:right">23,646</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Overseas / Unknown</th>
+			<td style="text-align:right">190</td>
+			<td style="text-align:right">7%</td>
+			<td style="text-align:right">2,198</td>
+			<td style="text-align:right">138</td>
+			<td style="text-align:right">5%</td>
+			<td style="text-align:right">2,250</td>
+			<td style="text-align:right">2,653</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total</strong></th>
+			<td style="text-align:right"><strong>410,683</strong></td>
+			<td style="text-align:right"><strong>72%</strong></td>
+			<td style="text-align:right"><strong>103,264</strong></td>
+			<td style="text-align:right"><strong>300,709</strong></td>
+			<td style="text-align:right"><strong>53%</strong></td>
+			<td style="text-align:right"><strong>213,238</strong></td>
+			<td style="text-align:right"><strong>571,052</strong></td>
+		</tr>
+	</tbody>
+</table>
+
+<h4><a id="90pct Pacific Peoples" name="90pct Pacific Peoples"></a>Pacific Peoples</h4>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">&nbsp;</th>
+			<th scope="col" style="text-align:right">First doses</th>
+			<th scope="col" style="text-align:right">First doses %</th>
+			<th scope="col" style="text-align:right">First doses to 90%</th>
+			<th scope="col" style="text-align:right">Second doses</th>
+			<th scope="col" style="text-align:right">Second doses %</th>
+			<th scope="col" style="text-align:right">Second doses to 90%</th>
+			<th scope="col" style="text-align:right">Population</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">Northland</th>
+			<td style="text-align:right">2,369</td>
+			<td style="text-align:right">81%</td>
+			<td style="text-align:right">272</td>
+			<td style="text-align:right">1,741</td>
+			<td style="text-align:right">59%</td>
+			<td style="text-align:right">900</td>
+			<td style="text-align:right">2,934</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waitemata</th>
+			<td style="text-align:right">32,147</td>
+			<td style="text-align:right">86%</td>
+			<td style="text-align:right">1,669</td>
+			<td style="text-align:right">26,167</td>
+			<td style="text-align:right">70%</td>
+			<td style="text-align:right">7,649</td>
+			<td style="text-align:right">37,573</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Auckland</th>
+			<td style="text-align:right">39,630</td>
+			<td style="text-align:right">85%</td>
+			<td style="text-align:right">2,549</td>
+			<td style="text-align:right">32,370</td>
+			<td style="text-align:right">69%</td>
+			<td style="text-align:right">9,809</td>
+			<td style="text-align:right">46,866</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Counties Manukau</th>
+			<td style="text-align:right">97,234</td>
+			<td style="text-align:right">83%</td>
+			<td style="text-align:right">7,614</td>
+			<td style="text-align:right">78,976</td>
+			<td style="text-align:right">68%</td>
+			<td style="text-align:right">25,872</td>
+			<td style="text-align:right">116,498</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waikato</th>
+			<td style="text-align:right">9,163</td>
+			<td style="text-align:right">86%</td>
+			<td style="text-align:right">451</td>
+			<td style="text-align:right">7,307</td>
+			<td style="text-align:right">68%</td>
+			<td style="text-align:right">2,307</td>
+			<td style="text-align:right">10,682</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Lakes</th>
+			<td style="text-align:right">1,824</td>
+			<td style="text-align:right">80%</td>
+			<td style="text-align:right">233</td>
+			<td style="text-align:right">1,445</td>
+			<td style="text-align:right">63%</td>
+			<td style="text-align:right">612</td>
+			<td style="text-align:right">2,286</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Bay of Plenty</th>
+			<td style="text-align:right">4,026</td>
+			<td style="text-align:right">&gt;95%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">3,136</td>
+			<td style="text-align:right">85%</td>
+			<td style="text-align:right">175</td>
+			<td style="text-align:right">3,679</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Tairawhiti</th>
+			<td style="text-align:right">874</td>
+			<td style="text-align:right">91%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">676</td>
+			<td style="text-align:right">70%</td>
+			<td style="text-align:right">192</td>
+			<td style="text-align:right">965</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Taranaki</th>
+			<td style="text-align:right">1,058</td>
+			<td style="text-align:right">83%</td>
+			<td style="text-align:right">85</td>
+			<td style="text-align:right">798</td>
+			<td style="text-align:right">63%</td>
+			<td style="text-align:right">345</td>
+			<td style="text-align:right">1,270</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hawkes Bay</th>
+			<td style="text-align:right">5,119</td>
+			<td style="text-align:right">&gt;95%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">4,212</td>
+			<td style="text-align:right">84%</td>
+			<td style="text-align:right">306</td>
+			<td style="text-align:right">5,020</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">MidCentral</th>
+			<td style="text-align:right">3,782</td>
+			<td style="text-align:right">85%</td>
+			<td style="text-align:right">239</td>
+			<td style="text-align:right">2,945</td>
+			<td style="text-align:right">66%</td>
+			<td style="text-align:right">1,076</td>
+			<td style="text-align:right">4,468</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Whanganui</th>
+			<td style="text-align:right">1,046</td>
+			<td style="text-align:right">76%</td>
+			<td style="text-align:right">197</td>
+			<td style="text-align:right">833</td>
+			<td style="text-align:right">60%</td>
+			<td style="text-align:right">410</td>
+			<td style="text-align:right">1,381</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Capital and Coast</th>
+			<td style="text-align:right">15,678</td>
+			<td style="text-align:right">82%</td>
+			<td style="text-align:right">1,581</td>
+			<td style="text-align:right">12,650</td>
+			<td style="text-align:right">66%</td>
+			<td style="text-align:right">4,609</td>
+			<td style="text-align:right">19,177</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hutt Valley</th>
+			<td style="text-align:right">7,976</td>
+			<td style="text-align:right">81%</td>
+			<td style="text-align:right">929</td>
+			<td style="text-align:right">6,417</td>
+			<td style="text-align:right">65%</td>
+			<td style="text-align:right">2,488</td>
+			<td style="text-align:right">9,894</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Wairarapa</th>
+			<td style="text-align:right">689</td>
+			<td style="text-align:right">82%</td>
+			<td style="text-align:right">64</td>
+			<td style="text-align:right">567</td>
+			<td style="text-align:right">68%</td>
+			<td style="text-align:right">186</td>
+			<td style="text-align:right">837</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Nelson Marlborough</th>
+			<td style="text-align:right">3,620</td>
+			<td style="text-align:right">&gt;95%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">3,174</td>
+			<td style="text-align:right">&gt;95%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">2,115</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">West Coast</th>
+			<td style="text-align:right">232</td>
+			<td style="text-align:right">82%</td>
+			<td style="text-align:right">22</td>
+			<td style="text-align:right">179</td>
+			<td style="text-align:right">63%</td>
+			<td style="text-align:right">75</td>
+			<td style="text-align:right">282</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Canterbury</th>
+			<td style="text-align:right">10,814</td>
+			<td style="text-align:right">85%</td>
+			<td style="text-align:right">649</td>
+			<td style="text-align:right">8,176</td>
+			<td style="text-align:right">64%</td>
+			<td style="text-align:right">3,287</td>
+			<td style="text-align:right">12,737</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">South Canterbury</th>
+			<td style="text-align:right">792</td>
+			<td style="text-align:right">95%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">591</td>
+			<td style="text-align:right">71%</td>
+			<td style="text-align:right">162</td>
+			<td style="text-align:right">837</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Southern</th>
+			<td style="text-align:right">5,598</td>
+			<td style="text-align:right">93%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">4,532</td>
+			<td style="text-align:right">75%</td>
+			<td style="text-align:right">896</td>
+			<td style="text-align:right">6,031</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Overseas / Unknown</th>
+			<td style="text-align:right">338</td>
+			<td style="text-align:right">29%</td>
+			<td style="text-align:right">696</td>
+			<td style="text-align:right">296</td>
+			<td style="text-align:right">26%</td>
+			<td style="text-align:right">738</td>
+			<td style="text-align:right">1,149</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total</strong></th>
+			<td style="text-align:right"><strong>244,009</strong></td>
+			<td style="text-align:right"><strong>85%</strong></td>
+			<td style="text-align:right"><strong>14,004</strong></td>
+			<td style="text-align:right"><strong>197,188</strong></td>
+			<td style="text-align:right"><strong>69%</strong></td>
+			<td style="text-align:right"><strong>60,825</strong></td>
+			<td style="text-align:right"><strong>286,681</strong></td>
+		</tr>
+	</tbody>
+</table>
+<!--daily_end-->
+
+<hr/>
+<h2><a id="weekly-updates" name="weekly-updates"></a>COVID-19 vaccinations: weekly updates</h2>
+
+<div class="well well-sm">
+<p style="margin-top: 0"><strong>Data in this section is as at 11:59pm 26 October 2021 and is updated weekly on Wednesdays.</strong></p>
+</div>
+
+<h3><a id="model" model="" name="id="></a>Cumulative vaccinations</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccination doses administered compared to plan doses" class="img-responsive" height="830" src="/web/20211101145759im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/vaccineplanmodel_13.png" width="1780"/></figure>
+
+<p>Production plan figures are the volumes agreed with DHBs and national providers for expected vaccinations. These figures have been matched with expected supply. Detailed plans are available in the Excel file at the bottom of this page.</p>
+
+<p>The Stock received figures are the cumulative supply of doses to date.</p>
+
+<p>DHB capacity plans for the remainder of the year are undergoing review.</p>
+
+<hr/><!--
+<h3><a id="model" model="" name="id="></a>Cumulative vaccinations for last 6 weeks</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccination doses administered compared to plan doses - 6wks" class="img-responsive" height="830" src="/vaccineplanmodel_wks.png" width="1780" /></figure>
+
+<hr />
+-->
+<h3><a id="uptake" name="uptake"></a>Vaccine uptake</h3>
+
+<p>Maps and data related to uptake rates of the COVID-19 vaccine across the country are available on the pages linked below. These show&nbsp;vaccination records aggregated by area of residence for all New Zealand residents, Māori communities, and Pacific communities.</p>
+
+<ul>
+	<li><a href="/web/20211101145759/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-across-nz">COVID-19 Vaccination uptake rates across NZ</a></li>
+	<li><a href="/web/20211101145759/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-maori-communities-across-nz">COVID-19 Vaccination uptake rates within Māori communities across NZ</a></li>
+	<li><a href="/web/20211101145759/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-pacific-communities-across-nz">COVID-19 Vaccination uptake rates within Pacific communities across NZ</a></li>
+</ul>
+
+<h4><a id="uptake" name="uptake"></a>Vaccine uptake per rate ratio (unadjusted) Māori and Pacific compared with Non-Māori non-Pacific</h4>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine Uptake per 1,000 (HSU) Rate Ratio, Showing Prioritised Ethnicity, vs Non-Māori Non-Pacific, By Age Band" class="img-responsive" height="830" src="/web/20211101145759im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_mix_8.png" width="1780"/></figure>
+
+<p>In the Chart above, rate ratios tell us the rate Māori or Pacific People per population are being vaccinated compared with non-Māori non-Pacific. This comparison can be split by age group.</p>
+
+<ul>
+	<li>A rate of one means the groups being compared are being vaccinated at the same rate.</li>
+	<li>A rate over one means Māori (or Pacific) are being vaccinated at a higher rate than non-Māori non-Pacific.</li>
+	<li>A rate under one means Māori (or Pacific) are being vaccinated at a lower rate than non-Māori non-Pacific.</li>
+</ul>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<td colspan="2" style="border-top: 0 !important; border-bottom-color: #FDD6AF !important; border-right: 0 !important;">&nbsp;</td>
+			<th colspan="6" id="ac1">Māori</th>
+			<th colspan="6" id="ac8">Pacific Peoples</th>
+		</tr>
+		<tr>
+			<th id="ar1">DHB</th>
+			<th>Dose number</th>
+			<th headers="ac1" id="ac2">65+</th>
+			<th headers="ac1" id="ac3">50-64</th>
+			<th headers="ac1" id="ac4">35-49</th>
+			<th headers="ac1" id="ac5">20-34</th>
+			<th headers="ac1" id="ac6">12-19</th>
+			<th headers="ac1" id="ac7">All ages</th>
+			<th headers="ac8" id="ac9">65+</th>
+			<th headers="ac8" id="ac10">50-64</th>
+			<th headers="ac8" id="ac11">35-49</th>
+			<th headers="ac8" id="ac12">20-34</th>
+			<th headers="ac8" id="ac13">12-19</th>
+			<th headers="ac8" id="ac14">All ages</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th headers="ar1" id="ar2" rowspan="2">National</th>
+			<th headers="ar1 ar2" id="ar3">Dose 1</th>
+			<td headers="ar1 ar2 ar3 ac1 ac2" style="background-color:green; color: #FFF;"><strong>0.99</strong></td>
+			<td headers="ar1 ar2 ar3 ac1 ac3" style="background-color:mediumseagreen"><strong>0.93</strong></td>
+			<td headers="ar1 ar2 ar3 ac1 ac4" style="background-color:yellow"><strong>0.79</strong></td>
+			<td headers="ar1 ar2 ar3 ac1 ac5" style="background-color:coral"><strong>0.67</strong></td>
+			<td headers="ar1 ar2 ar3 ac1 ac6" style="background-color:orange"><strong>0.71</strong></td>
+			<td headers="ar1 ar2 ar3 ac1 ac7" style="background-color:yellow"><strong>0.77</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac9" style="background-color:mediumseagreen"><strong>0.94</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac10" style="background-color:green; color: #FFF;"><strong>0.99</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac11" style="background-color:green; color: #FFF;"><strong>0.98</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac12" style="background-color:lightgreen"><strong>0.89</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac13" style="background-color:mediumseagreen"><strong>0.90</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac14" style="background-color:mediumseagreen"><strong>0.93</strong></td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar2" id="ar4">Dose 2</th>
+			<td headers="ar1 ar2 ar4 ac1 ac2" style="background-color:green; color: #FFF;"><strong>0.96</strong></td>
+			<td headers="ar1 ar2 ar4 ac1 ac3" style="background-color:lightgreen"><strong>0.87</strong></td>
+			<td headers="ar1 ar2 ar4 ac1 ac4" style="background-color:coral"><strong>0.68</strong></td>
+			<td headers="ar1 ar2 ar4 ac1 ac5" style="background-color:crimson; color: #FFF;"><strong>0.51</strong></td>
+			<td headers="ar1 ar2 ar4 ac1 ac6" style="background-color:crimson; color: #FFF;"><strong>0.57</strong></td>
+			<td headers="ar1 ar2 ar4 ac1 ac7" style="background-color:coral"><strong>0.65</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac9" style="background-color:mediumseagreen"><strong>0.92</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac10" style="background-color:green; color: #FFF;"><strong>0.99</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac11" style="background-color:green; color: #FFF;"><strong>0.97</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac12" style="background-color:palegreen"><strong>0.82</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac13" style="background-color:lightgreen"><strong>0.86</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac14" style="background-color:lightgreen"><strong>0.86</strong></td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar5" rowspan="2">Northland</th>
+			<th headers="ar1 ar5" id="ar6">Dose 1</th>
+			<td headers="ar1 ar5 ar6 ac1 ac2" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar5 ar6 ac1 ac3" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar5 ar6 ac1 ac4" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar5 ar6 ac1 ac5" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar5 ar6 ac1 ac6" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar5 ar6 ac1 ac7" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar5 ar6 ac8 ac9" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar5 ar6 ac8 ac10" style="background-color:green; color: #FFF;">1.06</td>
+			<td headers="ar1 ar5 ar6 ac8 ac11" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar5 ar6 ac8 ac12" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar5 ar6 ac8 ac13" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar5 ar6 ac8 ac14" style="background-color:mediumseagreen">0.94</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar5" id="ar7">Dose 2</th>
+			<td headers="ar1 ar5 ar7 ac1 ac2" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar5 ar7 ac1 ac3" style="background-color:lightgreen">0.87</td>
+			<td headers="ar1 ar5 ar7 ac1 ac4" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar5 ar7 ac1 ac5" style="background-color:crimson; color: #FFF;">0.49</td>
+			<td headers="ar1 ar5 ar7 ac1 ac6" style="background-color:crimson; color: #FFF;">0.59</td>
+			<td headers="ar1 ar5 ar7 ac1 ac7" style="background-color:tomato">0.63</td>
+			<td headers="ar1 ar5 ar7 ac8 ac9" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar5 ar7 ac8 ac10" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar5 ar7 ac8 ac11" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar5 ar7 ac8 ac12" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar5 ar7 ac8 ac13" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar5 ar7 ac8 ac14" style="background-color:palegreen">0.80</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar8" rowspan="2">Auckland Metro</th>
+			<th headers="ar1 ar8" id="ar9">Dose 1</th>
+			<td headers="ar1 ar8 ar9 ac1 ac2" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar8 ar9 ac1 ac3" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar8 ar9 ac1 ac4" style="background-color:palegreen">0.81</td>
+			<td headers="ar1 ar8 ar9 ac1 ac5" style="background-color:orange">0.72</td>
+			<td headers="ar1 ar8 ar9 ac1 ac6" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar8 ar9 ac1 ac7" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar8 ar9 ac8 ac9" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar8 ar9 ac8 ac10" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar8 ar9 ac8 ac11" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar8 ar9 ac8 ac12" style="background-color:palegreen">0.81</td>
+			<td headers="ar1 ar8 ar9 ac8 ac13" style="background-color:palegreen">0.84</td>
+			<td headers="ar1 ar8 ar9 ac8 ac14" style="background-color:lightgreen">0.88</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar8" id="ar10">Dose 2</th>
+			<td headers="ar1 ar8 ar10 ac1 ac2" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar8 ar10 ac1 ac3" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar8 ar10 ac1 ac4" style="background-color:coral">0.69</td>
+			<td headers="ar1 ar8 ar10 ac1 ac5" style="background-color:crimson; color: #FFF;">0.54</td>
+			<td headers="ar1 ar8 ar10 ac1 ac6" style="background-color:crimson; color: #FFF;">0.59</td>
+			<td headers="ar1 ar8 ar10 ac1 ac7" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar8 ar10 ac8 ac9" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar8 ar10 ac8 ac10" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar8 ar10 ac8 ac11" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar8 ar10 ac8 ac12" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar8 ar10 ac8 ac13" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar8 ar10 ac8 ac14" style="background-color:yellow">0.78</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar11" rowspan="2">Waikato</th>
+			<th headers="ar1 ar11" id="ar12">Dose 1</th>
+			<td headers="ar1 ar11 ar12 ac1 ac2" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar11 ar12 ac1 ac3" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar11 ar12 ac1 ac4" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar11 ar12 ac1 ac5" style="background-color:coral">0.69</td>
+			<td headers="ar1 ar11 ar12 ac1 ac6" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar11 ar12 ac1 ac7" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar11 ar12 ac8 ac9" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar11 ar12 ac8 ac10" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar11 ar12 ac8 ac11" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar11 ar12 ac8 ac12" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar11 ar12 ac8 ac13" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar11 ar12 ac8 ac14" style="background-color:mediumseagreen">0.94</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar11" id="ar13">Dose 2</th>
+			<td headers="ar1 ar11 ar13 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar11 ar13 ac1 ac3" style="background-color:lightgreen">0.87</td>
+			<td headers="ar1 ar11 ar13 ac1 ac4" style="background-color:coral">0.68</td>
+			<td headers="ar1 ar11 ar13 ac1 ac5" style="background-color:crimson; color: #FFF;">0.50</td>
+			<td headers="ar1 ar11 ar13 ac1 ac6" style="background-color:crimson; color: #FFF;">0.57</td>
+			<td headers="ar1 ar11 ar13 ac1 ac7" style="background-color:tomato">0.64</td>
+			<td headers="ar1 ar11 ar13 ac8 ac9" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar11 ar13 ac8 ac10" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar11 ar13 ac8 ac11" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar11 ar13 ac8 ac12" style="background-color:palegreen">0.84</td>
+			<td headers="ar1 ar11 ar13 ac8 ac13" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar11 ar13 ac8 ac14" style="background-color:lightgreen">0.87</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar14" rowspan="2">Bay of Plenty</th>
+			<th headers="ar1 ar14" id="ar15">Dose 1</th>
+			<td headers="ar1 ar14 ar15 ac1 ac2" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar14 ar15 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar14 ar15 ac1 ac4" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar14 ar15 ac1 ac5" style="background-color:crimson; color: #FFF;">0.57</td>
+			<td headers="ar1 ar14 ar15 ac1 ac6" style="background-color:tomato">0.64</td>
+			<td headers="ar1 ar14 ar15 ac1 ac7" style="background-color:orange">0.72</td>
+			<td headers="ar1 ar14 ar15 ac8 ac9" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar14 ar15 ac8 ac10" style="background-color:green; color: #FFF;">1.09</td>
+			<td headers="ar1 ar14 ar15 ac8 ac11" style="background-color:green; color: #FFF;">1.47</td>
+			<td headers="ar1 ar14 ar15 ac8 ac12" style="background-color:green; color: #FFF;">1.52</td>
+			<td headers="ar1 ar14 ar15 ac8 ac13" style="background-color:lightgreen">0.87</td>
+			<td headers="ar1 ar14 ar15 ac8 ac14" style="background-color:green; color: #FFF;">1.23</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar14" id="ar16">Dose 2</th>
+			<td headers="ar1 ar14 ar16 ac1 ac2" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar14 ar16 ac1 ac3" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar14 ar16 ac1 ac4" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar14 ar16 ac1 ac5" style="background-color:crimson; color: #FFF;">0.46</td>
+			<td headers="ar1 ar14 ar16 ac1 ac6" style="background-color:crimson; color: #FFF;">0.54</td>
+			<td headers="ar1 ar14 ar16 ac1 ac7" style="background-color:tomato">0.60</td>
+			<td headers="ar1 ar14 ar16 ac8 ac9" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar14 ar16 ac8 ac10" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar14 ar16 ac8 ac11" style="background-color:green; color: #FFF;">1.60</td>
+			<td headers="ar1 ar14 ar16 ac8 ac12" style="background-color:green; color: #FFF;">1.78</td>
+			<td headers="ar1 ar14 ar16 ac8 ac13" style="background-color:yellow">0.77</td>
+			<td headers="ar1 ar14 ar16 ac8 ac14" style="background-color:green; color: #FFF;">1.15</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar17" rowspan="2">Tairawhiti</th>
+			<th headers="ar1 ar17" id="ar18">Dose 1</th>
+			<td headers="ar1 ar17 ar18 ac1 ac2" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar17 ar18 ac1 ac3" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar17 ar18 ac1 ac4" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar17 ar18 ac1 ac5" style="background-color:tomato">0.62</td>
+			<td headers="ar1 ar17 ar18 ac1 ac6" style="background-color:coral">0.69</td>
+			<td headers="ar1 ar17 ar18 ac1 ac7" style="background-color:yellow">0.76</td>
+			<td headers="ar1 ar17 ar18 ac8 ac9" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar17 ar18 ac8 ac10" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar17 ar18 ac8 ac11" style="background-color:green; color: #FFF;">1.10</td>
+			<td headers="ar1 ar17 ar18 ac8 ac12" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar17 ar18 ac8 ac13" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar17 ar18 ac8 ac14" style="background-color:green; color: #FFF;">1.01</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar17" id="ar19">Dose 2</th>
+			<td headers="ar1 ar17 ar19 ac1 ac2" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar17 ar19 ac1 ac3" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar17 ar19 ac1 ac4" style="background-color:coral">0.68</td>
+			<td headers="ar1 ar17 ar19 ac1 ac5" style="background-color:crimson; color: #FFF;">0.49</td>
+			<td headers="ar1 ar17 ar19 ac1 ac6" style="background-color:crimson; color: #FFF;">0.55</td>
+			<td headers="ar1 ar17 ar19 ac1 ac7" style="background-color:tomato">0.64</td>
+			<td headers="ar1 ar17 ar19 ac8 ac9" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar17 ar19 ac8 ac10" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar17 ar19 ac8 ac11" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar17 ar19 ac8 ac12" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar17 ar19 ac8 ac13" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar17 ar19 ac8 ac14" style="background-color:mediumseagreen">0.90</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar20" rowspan="2">Lakes</th>
+			<th headers="ar1 ar20" id="ar21">Dose 1</th>
+			<td headers="ar1 ar20 ar21 ac1 ac2" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar20 ar21 ac1 ac3" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar20 ar21 ac1 ac4" style="background-color:yellow">0.76</td>
+			<td headers="ar1 ar20 ar21 ac1 ac5" style="background-color:crimson; color: #FFF;">0.58</td>
+			<td headers="ar1 ar20 ar21 ac1 ac6" style="background-color:coral">0.65</td>
+			<td headers="ar1 ar20 ar21 ac1 ac7" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar20 ar21 ac8 ac9" style="background-color:green; color: #FFF;">1.06</td>
+			<td headers="ar1 ar20 ar21 ac8 ac10" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar20 ar21 ac8 ac11" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar20 ar21 ac8 ac12" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar20 ar21 ac8 ac13" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar20 ar21 ac8 ac14" style="background-color:mediumseagreen">0.90</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar20" id="ar22">Dose 2</th>
+			<td headers="ar1 ar20 ar22 ac1 ac2" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar20 ar22 ac1 ac3" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar20 ar22 ac1 ac4" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar20 ar22 ac1 ac5" style="background-color:crimson; color: #FFF;">0.44</td>
+			<td headers="ar1 ar20 ar22 ac1 ac6" style="background-color:crimson; color: #FFF;">0.53</td>
+			<td headers="ar1 ar20 ar22 ac1 ac7" style="background-color:tomato">0.61</td>
+			<td headers="ar1 ar20 ar22 ac8 ac9" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar20 ar22 ac8 ac10" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar20 ar22 ac8 ac11" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar20 ar22 ac8 ac12" style="background-color:palegreen">0.83</td>
+			<td headers="ar1 ar20 ar22 ac8 ac13" style="background-color:lightgreen">0.86</td>
+			<td headers="ar1 ar20 ar22 ac8 ac14" style="background-color:palegreen">0.83</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar23" rowspan="2">Taranaki</th>
+			<th headers="ar1 ar23" id="ar24">Dose 1</th>
+			<td headers="ar1 ar23 ar24 ac1 ac2" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar23 ar24 ac1 ac3" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar23 ar24 ac1 ac4" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar23 ar24 ac1 ac5" style="background-color:coral">0.68</td>
+			<td headers="ar1 ar23 ar24 ac1 ac6" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar23 ar24 ac1 ac7" style="background-color:yellow">0.77</td>
+			<td headers="ar1 ar23 ar24 ac8 ac9" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar23 ar24 ac8 ac10" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar23 ar24 ac8 ac11" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar23 ar24 ac8 ac12" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar23 ar24 ac8 ac13" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar23 ar24 ac8 ac14" style="background-color:mediumseagreen">0.94</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar23" id="ar25">Dose 2</th>
+			<td headers="ar1 ar23 ar25 ac1 ac2" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar23 ar25 ac1 ac3" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar23 ar25 ac1 ac4" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar23 ar25 ac1 ac5" style="background-color:crimson; color: #FFF;">0.52</td>
+			<td headers="ar1 ar23 ar25 ac1 ac6" style="background-color:crimson; color: #FFF;">0.56</td>
+			<td headers="ar1 ar23 ar25 ac1 ac7" style="background-color:tomato">0.64</td>
+			<td headers="ar1 ar23 ar25 ac8 ac9" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar23 ar25 ac8 ac10" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar23 ar25 ac8 ac11" style="background-color:green; color: #FFF;">1.21</td>
+			<td headers="ar1 ar23 ar25 ac8 ac12" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar23 ar25 ac8 ac13" style="background-color:lightgreen">0.87</td>
+			<td headers="ar1 ar23 ar25 ac8 ac14" style="background-color:lightgreen">0.89</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar26" rowspan="2">Whanganui</th>
+			<th headers="ar1 ar26" id="ar27">Dose 1</th>
+			<td headers="ar1 ar26 ar27 ac1 ac2" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar26 ar27 ac1 ac3" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar26 ar27 ac1 ac4" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar26 ar27 ac1 ac5" style="background-color:coral">0.65</td>
+			<td headers="ar1 ar26 ar27 ac1 ac6" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar26 ar27 ac1 ac7" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar26 ar27 ac8 ac9" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar26 ar27 ac8 ac10" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar26 ar27 ac8 ac11" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar26 ar27 ac8 ac12" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar26 ar27 ac8 ac13" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar26 ar27 ac8 ac14" style="background-color:lightgreen">0.87</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar26" id="ar28">Dose 2</th>
+			<td headers="ar1 ar26 ar28 ac1 ac2" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar26 ar28 ac1 ac3" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar26 ar28 ac1 ac4" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar26 ar28 ac1 ac5" style="background-color:crimson; color: #FFF;">0.51</td>
+			<td headers="ar1 ar26 ar28 ac1 ac6" style="background-color:tomato">0.60</td>
+			<td headers="ar1 ar26 ar28 ac1 ac7" style="background-color:coral">0.65</td>
+			<td headers="ar1 ar26 ar28 ac8 ac9" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar26 ar28 ac8 ac10" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar26 ar28 ac8 ac11" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar26 ar28 ac8 ac12" style="background-color:palegreen">0.83</td>
+			<td headers="ar1 ar26 ar28 ac8 ac13" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar26 ar28 ac8 ac14" style="background-color:palegreen">0.80</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar29" rowspan="2">Hawke&#39;s Bay</th>
+			<th headers="ar1 ar29" id="ar30">Dose 1</th>
+			<td headers="ar1 ar29 ar30 ac1 ac2" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar29 ar30 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar29 ar30 ac1 ac4" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar29 ar30 ac1 ac5" style="background-color:crimson; color: #FFF;">0.59</td>
+			<td headers="ar1 ar29 ar30 ac1 ac6" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar29 ar30 ac1 ac7" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar29 ar30 ac8 ac9" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar29 ar30 ac8 ac10" style="background-color:green; color: #FFF;">1.05</td>
+			<td headers="ar1 ar29 ar30 ac8 ac11" style="background-color:green; color: #FFF;">1.42</td>
+			<td headers="ar1 ar29 ar30 ac8 ac12" style="background-color:green; color: #FFF;">1.32</td>
+			<td headers="ar1 ar29 ar30 ac8 ac13" style="background-color:lightgreen">0.88</td>
+			<td headers="ar1 ar29 ar30 ac8 ac14" style="background-color:green; color: #FFF;">1.16</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar29" id="ar31">Dose 2</th>
+			<td headers="ar1 ar29 ar31 ac1 ac2" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar29 ar31 ac1 ac3" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar29 ar31 ac1 ac4" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar29 ar31 ac1 ac5" style="background-color:crimson; color: #FFF;">0.47</td>
+			<td headers="ar1 ar29 ar31 ac1 ac6" style="background-color:crimson; color: #FFF;">0.57</td>
+			<td headers="ar1 ar29 ar31 ac1 ac7" style="background-color:tomato">0.61</td>
+			<td headers="ar1 ar29 ar31 ac8 ac9" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar29 ar31 ac8 ac10" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar29 ar31 ac8 ac11" style="background-color:green; color: #FFF;">1.48</td>
+			<td headers="ar1 ar29 ar31 ac8 ac12" style="background-color:green; color: #FFF;">1.48</td>
+			<td headers="ar1 ar29 ar31 ac8 ac13" style="background-color:lightgreen">0.86</td>
+			<td headers="ar1 ar29 ar31 ac8 ac14" style="background-color:green; color: #FFF;">1.10</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar32" rowspan="2">MidCentral</th>
+			<th headers="ar1 ar32" id="ar33">Dose 1</th>
+			<td headers="ar1 ar32 ar33 ac1 ac2" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar32 ar33 ac1 ac3" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar32 ar33 ac1 ac4" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar32 ar33 ac1 ac5" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar32 ar33 ac1 ac6" style="background-color:orange">0.72</td>
+			<td headers="ar1 ar32 ar33 ac1 ac7" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar32 ar33 ac8 ac9" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar32 ar33 ac8 ac10" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar32 ar33 ac8 ac11" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar32 ar33 ac8 ac12" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar32 ar33 ac8 ac13" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar32 ar33 ac8 ac14" style="background-color:mediumseagreen">0.94</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar32" id="ar34">Dose 2</th>
+			<td headers="ar1 ar32 ar34 ac1 ac2" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar32 ar34 ac1 ac3" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar32 ar34 ac1 ac4" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar32 ar34 ac1 ac5" style="background-color:crimson; color: #FFF;">0.58</td>
+			<td headers="ar1 ar32 ar34 ac1 ac6" style="background-color:tomato">0.60</td>
+			<td headers="ar1 ar32 ar34 ac1 ac7" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar32 ar34 ac8 ac9" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar32 ar34 ac8 ac10" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar32 ar34 ac8 ac11" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar32 ar34 ac8 ac12" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar32 ar34 ac8 ac13" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar32 ar34 ac8 ac14" style="background-color:lightgreen">0.85</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar35" rowspan="2">Wairarapa</th>
+			<th headers="ar1 ar35" id="ar36">Dose 1</th>
+			<td headers="ar1 ar35 ar36 ac1 ac2" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar35 ar36 ac1 ac3" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar35 ar36 ac1 ac4" style="background-color:palegreen">0.84</td>
+			<td headers="ar1 ar35 ar36 ac1 ac5" style="background-color:orange">0.72</td>
+			<td headers="ar1 ar35 ar36 ac1 ac6" style="background-color:yellow">0.77</td>
+			<td headers="ar1 ar35 ar36 ac1 ac7" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar35 ar36 ac8 ac9" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar35 ar36 ac8 ac10" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar35 ar36 ac8 ac11" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar35 ar36 ac8 ac12" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar35 ar36 ac8 ac13" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar35 ar36 ac8 ac14" style="background-color:mediumseagreen">0.92</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar35" id="ar37">Dose 2</th>
+			<td headers="ar1 ar35 ar37 ac1 ac2" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar35 ar37 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar35 ar37 ac1 ac4" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar35 ar37 ac1 ac5" style="background-color:crimson; color: #FFF;">0.55</td>
+			<td headers="ar1 ar35 ar37 ac1 ac6" style="background-color:tomato">0.63</td>
+			<td headers="ar1 ar35 ar37 ac1 ac7" style="background-color:tomato">0.64</td>
+			<td headers="ar1 ar35 ar37 ac8 ac9" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar35 ar37 ac8 ac10" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar35 ar37 ac8 ac11" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar35 ar37 ac8 ac12" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar35 ar37 ac8 ac13" style="background-color:palegreen">0.84</td>
+			<td headers="ar1 ar35 ar37 ac8 ac14" style="background-color:lightgreen">0.86</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar38" rowspan="2">Capital &amp; Coast and Hutt Valley</th>
+			<th headers="ar1 ar38" id="ar39">Dose 1</th>
+			<td headers="ar1 ar38 ar39 ac1 ac2" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar38 ar39 ac1 ac3" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar38 ar39 ac1 ac4" style="background-color:palegreen">0.83</td>
+			<td headers="ar1 ar38 ar39 ac1 ac5" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar38 ar39 ac1 ac6" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar38 ar39 ac1 ac7" style="background-color:palegreen">0.81</td>
+			<td headers="ar1 ar38 ar39 ac8 ac9" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar38 ar39 ac8 ac10" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar38 ar39 ac8 ac11" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar38 ar39 ac8 ac12" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar38 ar39 ac8 ac13" style="background-color:palegreen">0.84</td>
+			<td headers="ar1 ar38 ar39 ac8 ac14" style="background-color:lightgreen">0.86</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar38" id="ar40">Dose 2</th>
+			<td headers="ar1 ar38 ar40 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar38 ar40 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar38 ar40 ac1 ac4" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar38 ar40 ac1 ac5" style="background-color:tomato">0.63</td>
+			<td headers="ar1 ar38 ar40 ac1 ac6" style="background-color:tomato">0.62</td>
+			<td headers="ar1 ar38 ar40 ac1 ac7" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar38 ar40 ac8 ac9" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar38 ar40 ac8 ac10" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar38 ar40 ac8 ac11" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar38 ar40 ac8 ac12" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar38 ar40 ac8 ac13" style="background-color:yellow">0.76</td>
+			<td headers="ar1 ar38 ar40 ac8 ac14" style="background-color:palegreen">0.80</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar41" rowspan="2">Nelson Marlborough</th>
+			<th headers="ar1 ar41" id="ar42">Dose 1</th>
+			<td headers="ar1 ar41 ar42 ac1 ac2" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar41 ar42 ac1 ac3" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar41 ar42 ac1 ac4" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar41 ar42 ac1 ac5" style="background-color:coral">0.69</td>
+			<td headers="ar1 ar41 ar42 ac1 ac6" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar41 ar42 ac1 ac7" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar41 ar42 ac8 ac9" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar41 ar42 ac8 ac10" style="background-color:green; color: #FFF;">1.28</td>
+			<td headers="ar1 ar41 ar42 ac8 ac11" style="background-color:green; color: #FFF;">2.45</td>
+			<td headers="ar1 ar41 ar42 ac8 ac12" style="background-color:green; color: #FFF;">2.89</td>
+			<td headers="ar1 ar41 ar42 ac8 ac13" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar41 ar42 ac8 ac14" style="background-color:green; color: #FFF;">1.97</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar41" id="ar43">Dose 2</th>
+			<td headers="ar1 ar41 ar43 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar41 ar43 ac1 ac3" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar41 ar43 ac1 ac4" style="background-color:orange">0.72</td>
+			<td headers="ar1 ar41 ar43 ac1 ac5" style="background-color:crimson; color: #FFF;">0.57</td>
+			<td headers="ar1 ar41 ar43 ac1 ac6" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar41 ar43 ac1 ac7" style="background-color:coral">0.69</td>
+			<td headers="ar1 ar41 ar43 ac8 ac9" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar41 ar43 ac8 ac10" style="background-color:green; color: #FFF;">1.26</td>
+			<td headers="ar1 ar41 ar43 ac8 ac11" style="background-color:green; color: #FFF;">2.57</td>
+			<td headers="ar1 ar41 ar43 ac8 ac12" style="background-color:green; color: #FFF;">3.47</td>
+			<td headers="ar1 ar41 ar43 ac8 ac13" style="background-color:green; color: #FFF;">1.05</td>
+			<td headers="ar1 ar41 ar43 ac8 ac14" style="background-color:green; color: #FFF;">1.95</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar44" rowspan="2">West Coast</th>
+			<th headers="ar1 ar44" id="ar45">Dose 1</th>
+			<td headers="ar1 ar44 ar45 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar44 ar45 ac1 ac3" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar44 ar45 ac1 ac4" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar44 ar45 ac1 ac5" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar44 ar45 ac1 ac6" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar44 ar45 ac1 ac7" style="background-color:lightgreen">0.86</td>
+			<td headers="ar1 ar44 ar45 ac8 ac9" style="background-color:green; color: #FFF;">1.33</td>
+			<td headers="ar1 ar44 ar45 ac8 ac10" style="background-color:green; color: #FFF;">1.06</td>
+			<td headers="ar1 ar44 ar45 ac8 ac11" style="background-color:green; color: #FFF;">1.07</td>
+			<td headers="ar1 ar44 ar45 ac8 ac12" style="background-color:green; color: #FFF;">1.24</td>
+			<td headers="ar1 ar44 ar45 ac8 ac13" style="background-color:palegreen">0.83</td>
+			<td headers="ar1 ar44 ar45 ac8 ac14" style="background-color:green; color: #FFF;">0.99</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar44" id="ar46">Dose 2</th>
+			<td headers="ar1 ar44 ar46 ac1 ac2" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar44 ar46 ac1 ac3" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar44 ar46 ac1 ac4" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar44 ar46 ac1 ac5" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar44 ar46 ac1 ac6" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar44 ar46 ac1 ac7" style="background-color:yellow">0.76</td>
+			<td headers="ar1 ar44 ar46 ac8 ac9" style="background-color:green; color: #FFF;">1.33</td>
+			<td headers="ar1 ar44 ar46 ac8 ac10" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar44 ar46 ac8 ac11" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar44 ar46 ac8 ac12" style="background-color:green; color: #FFF;">1.57</td>
+			<td headers="ar1 ar44 ar46 ac8 ac13" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar44 ar46 ac8 ac14" style="background-color:mediumseagreen">0.91</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar47" rowspan="2">Canterbury</th>
+			<th headers="ar1 ar47" id="ar48">Dose 1</th>
+			<td headers="ar1 ar47 ar48 ac1 ac2" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar47 ar48 ac1 ac3" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar47 ar48 ac1 ac4" style="background-color:palegreen">0.83</td>
+			<td headers="ar1 ar47 ar48 ac1 ac5" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar47 ar48 ac1 ac6" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar47 ar48 ac1 ac7" style="background-color:palegreen">0.81</td>
+			<td headers="ar1 ar47 ar48 ac8 ac9" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar47 ar48 ac8 ac10" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar47 ar48 ac8 ac11" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar47 ar48 ac8 ac12" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar47 ar48 ac8 ac13" style="background-color:lightgreen">0.88</td>
+			<td headers="ar1 ar47 ar48 ac8 ac14" style="background-color:lightgreen">0.89</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar47" id="ar49">Dose 2</th>
+			<td headers="ar1 ar47 ar49 ac1 ac2" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar47 ar49 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar47 ar49 ac1 ac4" style="background-color:yellow">0.77</td>
+			<td headers="ar1 ar47 ar49 ac1 ac5" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar47 ar49 ac1 ac6" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar47 ar49 ac1 ac7" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar47 ar49 ac8 ac9" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar47 ar49 ac8 ac10" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar47 ar49 ac8 ac11" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar47 ar49 ac8 ac12" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar47 ar49 ac8 ac13" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar47 ar49 ac8 ac14" style="background-color:lightgreen">0.85</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar50" rowspan="2">South Canterbury</th>
+			<th headers="ar1 ar50" id="ar51">Dose 1</th>
+			<td headers="ar1 ar50 ar51 ac1 ac2" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar50 ar51 ac1 ac3" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar50 ar51 ac1 ac4" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar50 ar51 ac1 ac5" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar50 ar51 ac1 ac6" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar50 ar51 ac1 ac7" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar50 ar51 ac8 ac9" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar50 ar51 ac8 ac10" style="background-color:green; color: #FFF;">1.09</td>
+			<td headers="ar1 ar50 ar51 ac8 ac11" style="background-color:green; color: #FFF;">1.18</td>
+			<td headers="ar1 ar50 ar51 ac8 ac12" style="background-color:green; color: #FFF;">1.23</td>
+			<td headers="ar1 ar50 ar51 ac8 ac13" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar50 ar51 ac8 ac14" style="background-color:green; color: #FFF;">1.06</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar50" id="ar52">Dose 2</th>
+			<td headers="ar1 ar50 ar52 ac1 ac2" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar50 ar52 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar50 ar52 ac1 ac4" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar50 ar52 ac1 ac5" style="background-color:tomato">0.63</td>
+			<td headers="ar1 ar50 ar52 ac1 ac6" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar50 ar52 ac1 ac7" style="background-color:coral">0.69</td>
+			<td headers="ar1 ar50 ar52 ac8 ac9" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar50 ar52 ac8 ac10" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar50 ar52 ac8 ac11" style="background-color:green; color: #FFF;">1.09</td>
+			<td headers="ar1 ar50 ar52 ac8 ac12" style="background-color:green; color: #FFF;">1.15</td>
+			<td headers="ar1 ar50 ar52 ac8 ac13" style="background-color:green; color: #FFF;">1.05</td>
+			<td headers="ar1 ar50 ar52 ac8 ac14" style="background-color:lightgreen">0.89</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar53" rowspan="2">Southern</th>
+			<th headers="ar1 ar53" id="ar54">Dose 1</th>
+			<td headers="ar1 ar53 ar54 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar53 ar54 ac1 ac3" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar53 ar54 ac1 ac4" style="background-color:palegreen">0.83</td>
+			<td headers="ar1 ar53 ar54 ac1 ac5" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar53 ar54 ac1 ac6" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar53 ar54 ac1 ac7" style="background-color:palegreen">0.81</td>
+			<td headers="ar1 ar53 ar54 ac8 ac9" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar53 ar54 ac8 ac10" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar53 ar54 ac8 ac11" style="background-color:green; color: #FFF;">1.07</td>
+			<td headers="ar1 ar53 ar54 ac8 ac12" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar53 ar54 ac8 ac13" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar53 ar54 ac8 ac14" style="background-color:green; color: #FFF;">1.01</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar53" id="ar55">Dose 2</th>
+			<td headers="ar1 ar53 ar55 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar53 ar55 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar53 ar55 ac1 ac4" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar53 ar55 ac1 ac5" style="background-color:coral">0.66</td>
+			<td headers="ar1 ar53 ar55 ac1 ac6" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar53 ar55 ac1 ac7" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar53 ar55 ac8 ac9" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar53 ar55 ac8 ac10" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar53 ar55 ac8 ac11" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar53 ar55 ac8 ac12" style="background-color:green; color: #FFF;">1.05</td>
+			<td headers="ar1 ar53 ar55 ac8 ac13" style="background-color:lightgreen">0.87</td>
+			<td headers="ar1 ar53 ar55 ac8 ac14" style="background-color:mediumseagreen">0.93</td>
+		</tr>
+	</tbody>
+</table>
+
+<p>This table shows the rate of doses administered (per 1,000 population) to Māori or Pacific Peoples, relative to the rate of doses for Non-Māori and Non-Pacific groups. Less than one means the group is receiving a lower proportion of doses than would be expected if equity is being achieved. More than one means they are receiving a higher proportion of doses than would be expected if equity is being achieved. Exactly one means doses administered are in line with their proportion of population.</p>
+
+<ul>
+	<li><a download="" href="/web/20211101145759/https://www.health.govt.nz/system/files/documents/pages/rateratioexplainer_2.docx">Rate Ratio Explainer (Word, 434 KB)</a></li>
+</ul>
+
+<p>At all ages the size (weightings) of the age groups becomes a major contributing factor to comparative ratios, which is why the all ages (12+) figure may not appear to be in line with the age splits.</p>
+
+<h4><a id="uptake" name="uptake"></a>Vaccine uptake per 1,000 people by ethnicity</h4>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine uptake per 1,000 people by ethnicity" class="img-responsive" height="830" src="/web/20211101145759im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_eth_8.png" width="1780"/></figure>
+
+<h4><a id="uptake" name="uptake"></a>Vaccine uptake per 1,000 people by age band</h4>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine uptake per 1,000 people by age band" class="img-responsive" height="1030" src="/web/20211101145759im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_age_9.png" width="1780"/></figure>
+
+<h4><a id="uptake" name="location"></a>Vaccine uptake per 1,000 people by DHB of residence</h4>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine uptake per 1,000 people by DHB of residence" class="img-responsive" height="1030" src="/web/20211101145759im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_dhb_4.png" width="1780"/></figure>
+<!--
+<hr />
+<h3><a id="by_dhb_plan" name="dhb_plan"></a>Cumulative vaccination plan for DHBs</h3>
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">DHB of service</th>
+			<th scope="col" style="text-align:right">Actuals to Sunday 24 October</th>
+			<th scope="col" style="text-align:right">DHB Plan to Sunday 24 October</th>
+			<th scope="col" style="text-align:right">Variance</th>
+			<th scope="col" style="text-align:right">% of Plan</th>
+			<th scope="col" style="text-align:right">Week to date</th>
+		</tr>
+	</thead>
+	<tbody> --><!--plan--><!--
+<tr><td nowrap="nowrap">Auckland Metro</td><td>190621</td><td>205515</td><td>-14894</td><td>93%</td><td>9913</td></tr>
+<tr><td nowrap="nowrap">Bay of Plenty</td><td>22841</td><td>14255</td><td>8586</td><td>160%</td><td>1843</td></tr>
+<tr><td nowrap="nowrap">Canterbury</td><td>50558</td><td>39266</td><td>11292</td><td>129%</td><td>2769</td></tr>
+<tr><td nowrap="nowrap">Capital & Coast and Hutt Valley</td><td>48758</td><td>39742</td><td>9016</td><td>123%</td><td>1796</td></tr>
+<tr><td nowrap="nowrap">Hawke's Bay</td><td>15319</td><td>18205</td><td>-2886</td><td>84%</td><td>1351</td></tr>
+<tr><td nowrap="nowrap">Lakes</td><td>13437</td><td>12810</td><td>627</td><td>105%</td><td>731</td></tr>
+<tr><td nowrap="nowrap">MidCentral</td><td>10708</td><td>7237</td><td>3471</td><td>148%</td><td>1191</td></tr>
+<tr><td nowrap="nowrap">Nelson Marlborough</td><td>30198</td><td>18574</td><td>11624</td><td>163%</td><td>1285</td></tr>
+<tr><td nowrap="nowrap">Northland</td><td>21469</td><td>24762</td><td>-3293</td><td>87%</td><td>1257</td></tr>
+<tr><td nowrap="nowrap">South Canterbury</td><td>8106</td><td>8033</td><td>73</td><td>101%</td><td>389</td></tr>
+<tr><td nowrap="nowrap">Southern</td><td>35234</td><td>34594</td><td>640</td><td>102%</td><td>1794</td></tr>
+<tr><td nowrap="nowrap">Tairāwhiti</td><td>4579</td><td>4928</td><td>-349</td><td>93%</td><td>290</td></tr>
+<tr><td nowrap="nowrap">Taranaki</td><td>5619</td><td>5297</td><td>322</td><td>106%</td><td>168</td></tr>
+<tr><td nowrap="nowrap">Waikato</td><td>36070</td><td>32842</td><td>3228</td><td>110%</td><td>1905</td></tr>
+<tr><td nowrap="nowrap">Wairarapa</td><td>4516</td><td>4960</td><td>-444</td><td>91%</td><td>468</td></tr>
+<tr><td nowrap="nowrap">West Coast</td><td>3533</td><td>3300</td><td>233</td><td>107%</td><td>336</td></tr>
+<tr><td nowrap="nowrap">Whanganui</td><td>6982</td><td>4711</td><td>2271</td><td>148%</td><td>612</td></tr>
+<tr><td nowrap="nowrap">Other Sites</td><td>24890</td><td>14575</td><td>10315</td><td>171%</td><td>613</td></tr>
+<tr><td nowrap="nowrap">Total</td><td>533438</td><td>493606</td><td>39832</td><td>108%</td><td>28711</td></tr>
+!--plan_end--><!--	</tbody>
+</table>
+
+
+<p>The information provided in this table is based on cumulative DHB plans to the last week ending on Sunday. The final column shows vaccinations administered since Sunday by DHB of service to reconcile total actuals in this table to other total numbers shown.   On-going, and as we roll-out the vaccination programme, we anticipate that there could be a potential variance of up to ten percent (plus or minus) between DHB Plans and actual vaccination numbers. This is on the basis that, for example, an unplanned significant event could affect roll-out implementation or some DHBs might exceed their planned vaccination numbers.
+</p>
+-->
+
+<hr/>
+<h3><a id="by_dhb" name="location"></a>Cumulative vaccinations by DHB</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Cumulative vaccinations for DHBs" class="img-responsive" height="830" src="/web/20211101145759im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/dhbstacked_12.png" width="1780"/></figure>
+
+<hr/>
+<h3><a id="by-day" name="by-day"></a>Vaccinations by day</h3>
+
+<figure class="image-captioned img-responsive"><img alt="Vaccination doses administered per day" class="img-responsive" height="830" src="/web/20211101145759im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/vaccinebyday_12.png" width="1780"/></figure>
+
+<p>This chart shows the count of vaccinations administered on a given day from the COVID-19 Immunisation Register. Note some records are entered in the register at a later date than the immunisation was received. This means that the figures for a given date may move for some time after that date.</p>
+
+<hr/>
+<h3><a id="group" name="group"></a>Vaccinations by group by week</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccinations by group" class="img-responsive" height="830" src="/web/20211101145759im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/vaccinebygroupwk_12.png" width="1780"/></figure>
+
+<hr/>
+<h3><a id="group_d" name="group_d"></a>Cumulative vaccinations by group</h3>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">Priority Group</th>
+			<th scope="col" style="text-align:right">First dose administered</th>
+			<th scope="col" style="text-align:right">Second dose administered</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">Group 1</th>
+			<td style="text-align:right">66,767</td>
+			<td style="text-align:right">65,205</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Group 2</th>
+			<td style="text-align:right">661,231</td>
+			<td style="text-align:right">621,689</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Group 3</th>
+			<td style="text-align:right">793,481</td>
+			<td style="text-align:right">746,741</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Group 4</th>
+			<td style="text-align:right">2,136,491</td>
+			<td style="text-align:right">1,585,195</td>
+		</tr>
+	</tbody>
+</table>
+
+<p>For definitions of the groups and further detail see the downloadable spreadsheet at the bottom of the page.</p>
+
+<hr/>
+<h3><a id="by_soh" name="stockonhand"></a>Vaccine available for distribution at week end</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine available for distribution at week end" class="img-responsive" height="830" src="/web/20211101145759im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/stockonhand_13.png" width="1780"/></figure>
+
+<p>Vaccine available for distribution is stock (in doses) held at central warehouses. It does not include stock in transit or available at sites ready for use.</p>
+
+<hr/>
+<h3><a id="by_eth" name="ethnicity"></a>Total cumulative doses per 1,000 people by ethnicity</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Total cumulative doses per 1,000 people by ethnicity" class="img-responsive" height="830" src="/web/20211101145759im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/ethnicity_12.png" width="1780"/></figure>
+
+<p>This chart shows both first and second doses. As a result this chart may exceed 1,000 doses per 1,000 people.</p>
+
+<p><strong>*</strong> The prioritised ethnicity classification system allocates each person to a single ethnic group, based on the ethnic groups they identify with. Where people identify with more than one group, they are assigned in this order of priority: Māori, Pacific Peoples, Asian, and European/Other. So, if a person identifies as being Māori and New Zealand European, the person is counted as Māori. See <a href="/web/20211101145759/https://www.health.govt.nz/publication/hiso-100012017-ethnicity-data-protocols">Ethnicity Data Protocols</a> for further information.</p>
+
+<p>Ethnicity breakdown by DHB of residence is available in the downloadable spreadsheet at the bottom of the page.</p>
+
+<hr/>
+<h3><a id="by_age" name="age"></a>Cumulative vaccinations by age</h3>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">Age</th>
+			<th scope="col" style="text-align:right">First dose administered</th>
+			<th scope="col" style="text-align:right">First doses per 1,000 people</th>
+			<th scope="col" style="text-align:right">Fully vaccinated</th>
+			<th scope="col" style="text-align:right">Fully vaccinated per 1,000 people</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">12 - 19 years</th>
+			<td style="text-align:right">403,029</td>
+			<td style="text-align:right">802</td>
+			<td style="text-align:right">279,575</td>
+			<td style="text-align:right">557</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">20 - 34 years</th>
+			<td style="text-align:right">845,409</td>
+			<td style="text-align:right">817</td>
+			<td style="text-align:right">604,676</td>
+			<td style="text-align:right">585</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">35 - 49 years</th>
+			<td style="text-align:right">824,175</td>
+			<td style="text-align:right">862</td>
+			<td style="text-align:right">670,851</td>
+			<td style="text-align:right">701</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">50 - 64 years</th>
+			<td style="text-align:right">836,170</td>
+			<td style="text-align:right">901</td>
+			<td style="text-align:right">749,933</td>
+			<td style="text-align:right">809</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">65 and over</th>
+			<td style="text-align:right">749,187</td>
+			<td style="text-align:right">950</td>
+			<td style="text-align:right">713,795</td>
+			<td style="text-align:right">905</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total</strong></th>
+			<td style="text-align:right"><strong>3,657,970</strong></td>
+			<td style="text-align:right"><strong>869</strong></td>
+			<td style="text-align:right"><strong>3,018,830</strong></td>
+			<td style="text-align:right"><strong>717</strong></td>
+		</tr>
+	</tbody>
+</table>
+
+<p>Age breakdown by ethnicity and gender is available in the downloadable spreadsheet at the bottom of the page.</p>
+
+<hr/>
+<h3><a id="workforce" name="workforce"></a>Trained vaccinators and active vaccinators</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Trained vaccinators and active vaccinators" class="img-responsive" height="830" src="/web/20211101145759im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/workforce_12.png" width="1780"/></figure>
+
+<p><strong>Trained vaccinators</strong> are individuals who have completed the COVID-19 training. Many trained people are only able to offer a small number of hours to the COVID-19 vaccination programme.</p>
+
+<p><strong>Active vaccinators</strong> are trained individuals who are actively vaccinating. The number of active vaccinators does not reflect the hours worked vaccinating. For example, one vaccinator may work 40 hours in a week at one DHB and will show as 1 vaccinator in the headcount. In another DHB, 4 vaccinators may work 10 hours each (total 40 hours), but will show as 4 vaccinators in the headcount for that week.</p>
+
+<p>Both counts of trained and active vaccinators are cumulative. The difference between the two is due to a number of factors. This includes: individuals being trained in anticipation of future sites being opened (the largest factor); rostering; leave or non-availability; local health priorities; sites opening and closing.</p>
+
+<hr/>
+<h3><a id="usage" name="usage"></a>Wastage of vaccine stock</h3>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">&nbsp;</th>
+			<th scope="col">Wastage</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">New Zealand</th>
+			<td>0.29%</td>
+		</tr>
+	</tbody>
+</table>
+
+<p>Wastage is vials that have been reported as wasted since 13 July in the Inventory portal by DHBs or central warehouses divided by vials used over the same time frame.</p>
+
+<h3><a id="download" name="download"></a>Details of vaccination data</h3>
+
+<p>Download a spreadsheet containing key vaccination data. This includes HSU based population estimates for calculating vaccine uptake rates.</p>
+
+<p><a download="" href="/web/20211101145759/https://www.health.govt.nz/system/files/documents/pages/covid_vaccinations_26_10_2021.xlsx">COVID-19 vaccination data through 26 Oct 2021 (Excel, 363 KB)</a></p>
+
+<p>This spreadsheet is based on the information made available at the time of publishing and may be subject to changes. Please take note of any notes and caveats on each sheet.</p>
+
+<p>The below attachments provide some analysis on our progress on equity. The two PDF files are high level summaries of overall progress. The Excel documents are interactive and provides the ability to delve further into those overall numbers. NB: These Excel workbooks use features that are non-compatible with versions of MS Office 2016 and earlier.</p>
+
+<ul>
+	<li><a download="" href="/web/20211101145759/https://www.health.govt.nz/system/files/documents/pages/211024_-_cvip_equity_-_rate_ratios_by_ethnicity_ageband_and_dhb.pdf">Covid-19 Vaccine Rate Ratios by Ethnicity, Ageband and DHB (PDF, 642 KB)</a></li>
+	<li><a download="" href="/web/20211101145759/https://www.health.govt.nz/system/files/documents/pages/211024_-_cvip_equity_-_uptake_by_ethnicity_ageband_and_dhb.pdf">Covid-19 Vaccine Uptake by Ethnicity, Ageband and DHB (PDF, 550 KB)</a></li>
+	<li><a download="" href="/web/20211101145759/https://www.health.govt.nz/system/files/documents/pages/211024_-_cvip_equity_-_level_1_ethnicity_uptake_and_rate_ratios.xlsx">Covid-19 Vaccine Equity - Level 1 Ethnicity Uptake and Rate Ratios (Excel, 152 KB)</a></li>
+	<li><a download="" href="/web/20211101145759/https://www.health.govt.nz/system/files/documents/pages/211024_-_cvip_equity_-_level_2_ethnicity_uptake_and_rate_ratios.xlsx">Covid-19 Vaccine Equity - Level 2 Ethnicity Uptake and Rate Ratios (Excel, 378 KB)</a></li>
+	<li><a download="" href="/web/20211101145759/https://www.health.govt.nz/system/files/documents/pages/211024_-_cvip_equity_-_rate_ratios_and_uptake_over_time.xlsx">Rate Ratios and Uptake Over Time (Excel, 996 KB)</a></li>
+</ul>
+
+<hr/>
+<h3><a id="adverse-events" name="adverse-events"></a>Adverse events following&nbsp;immunisations (AEFI)</h3>
+
+<p>Like all medicines, the COVID-19 vaccine may cause side effects in some people. These are common, are usually mild, don&rsquo;t last long and won&rsquo;t stop people from having the second dose or going about daily life. Serious allergic reactions do occur but are extremely rare.</p>
+
+<p>Suspected AEFI to COVID-19 vaccines are reported to the <a href="https://web.archive.org/web/20211101145759/https://nzphvc.otago.ac.nz/">Centre for Adverse Reactions Monitoring</a> (CARM).&nbsp;<a href="https://web.archive.org/web/20211101145759/https://www.medsafe.govt.nz/">Medsafe</a> is closely monitoring the AEFI reported from the use of the COVID-19 vaccine and will report regularly on their findings.&nbsp;</p>
+
+<p><a href="https://web.archive.org/web/20211101145759/https://www.medsafe.govt.nz/COVID-19/vaccine-report-overview.asp">View Medsafe data on COVID-19 vaccine adverse effects following immunisation</a></p>
+</div></div></div>    </article>
+  </div>
+
+
+  </div>
+<div class="panel-pane pane-node-links even">
+
+
+
+  <div class="pane-content">
+          </div>
+
+
+  </div>
+
+<div class="panel-pane pane-views pane-sub-pages even">
+
+        <h2 class="pane-title h3">In this section</h2>
+
+
+  <div class="pane-content">
+        <div class="view view-sub-pages view-id-sub_pages view-display-id-block view-dom-id-0656d6b989e93421406ac57aca4463e3">
+
+
+
+      <div class="view-content">
+      <div class="item-list">    <ul>          <li class="views-row views-row-1 views-row-odd views-row-first">
+  <div class="views-field views-field-title">        <div class="field-content">
+<div class="views-field views-field-title">
+  <h3 class="field-content">
+    <a href="/web/20211101145759/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-across-nz">COVID-19 Vaccination uptake rates across NZ</a>  </h3>
+</div></div>  </div>
+  <span class="views-field views-field-body">        <span class="field-content">This page provides information related to uptake rates of the COVID-19 vaccine across the country.
+</span>  </span>
+  <span class="views-field views-field-view-node">        <span class="field-content"><a href="/web/20211101145759/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-across-nz">Read more</a></span>  </span></li>
+          <li class="views-row views-row-2 views-row-even">
+  <div class="views-field views-field-title">        <div class="field-content">
+<div class="views-field views-field-title">
+  <h3 class="field-content">
+    <a href="/web/20211101145759/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-maori-communities-across-nz">COVID-19 Vaccination uptake rates within Māori communities across NZ</a>  </h3>
+</div></div>  </div>
+  <span class="views-field views-field-body">        <span class="field-content">This page provides information related to uptake rates of the COVID-19 vaccine within Māori communities across New Zealand.
+</span>  </span>
+  <span class="views-field views-field-view-node">        <span class="field-content"><a href="/web/20211101145759/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-maori-communities-across-nz">Read more</a></span>  </span></li>
+          <li class="views-row views-row-3 views-row-odd views-row-last">
+  <div class="views-field views-field-title">        <div class="field-content">
+<div class="views-field views-field-title">
+  <h3 class="field-content">
+    <a href="/web/20211101145759/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-pacific-communities-across-nz">COVID-19 Vaccination uptake rates within Pacific communities across NZ</a>  </h3>
+</div></div>  </div>
+  <span class="views-field views-field-body">        <span class="field-content">This page provides information related to uptake rates of the COVID-19 vaccine within Pacific communities across New Zealand.
+</span>  </span>
+  <span class="views-field views-field-view-node">        <span class="field-content"><a href="/web/20211101145759/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-pacific-communities-across-nz">Read more</a></span>  </span></li>
+      </ul></div>    </div>
+
+
+
+
+
+
+</div>  </div>
+
+
+  </div>
+</div>          </div>
+
+  </div>
+
+</section>
+  </div>
+      </section>
+
+
+    </div>
+    <div id="content-footer-wrapper" class="clearfix">
+      <div id="content-footer" class="clearfix">
+                  <p class="page_updated">Page last updated: <span class="date">01 November 2021</span></p>                  <div class="region region-content-footer">
+    <section id="block-moh-tools-page-tools" class="block block-moh-tools clearfix">
+  <a href="#" data-placement="top" data-title="Share this content." data-html="true" data-content="<p>Share this page on some of the most popular social networking and content sites on the internet.</p><div class='service-links'><ul><li><a href='https://twitter.com/share?url=https%3A//www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data&amp;text=COVID-19%3A%20Vaccine%20data' title='Share this on Twitter' class='service-links-twitter' rel='nofollow'><img typeof='foaf:Image' class='img-responsive' src='https://www.health.govt.nz/sites/all/modules/contrib/service_links/images/twitter.png' alt='Twitter' /> Twitter</a></li>
+<li><a href='https://www.facebook.com/sharer.php?u=https%3A//www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data&amp;t=COVID-19%3A%20Vaccine%20data' title='Share on Facebook' class='service-links-facebook' rel='nofollow'><img typeof='foaf:Image' class='img-responsive' src='https://www.health.govt.nz/sites/all/modules/contrib/service_links/images/facebook.png' alt='Facebook' /> Facebook</a></li>
+</ul></div>" class="share-this-content"><i class="fa fa-share"></i> Share</a><a href="#" title="print this page" class="print"><i class="fa fa-print"></i> Print</a><a href="https://web.archive.org/web/20211101145759/https://www.health.govt.nz/forward?path=node/12052" title="Email this page" class="email"><i class="fa fa-envelope"></i> Email</a><a href="/web/20211101145759/https://www.health.govt.nz/feedback?ref=https%3A//www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="Feedback" class="rss"><i class="fa fa-comment"></i> Feedback</a></section>
+
+  </div>
+      </div>
+    </div>
+
+  </div>
+  <footer class="footer container">
+    <h2 class="hidden">Site Footer</h2>
+    <div class="footer-default">
+      <div class="row">
+        <div class="col-sm-6 col-md-6">
+          <div class="field field-name-field-tax-first-column-links">
+            <ul class="field-items"><li class="field-item"><a href="https://web.archive.org/web/20211101145759/https://www.health.govt.nz/node/492" class="">About this site</a></li><li class="field-item"><a href="https://web.archive.org/web/20211101145759/https://www.health.govt.nz/node/524" class="">Contact us</a></li><li class="field-item"><a href="https://web.archive.org/web/20211101145759/https://www.health.govt.nz/node/488" class="">Other Ministry of Health websites</a></li><li class="field-item"><a href="https://web.archive.org/web/20211101145759/https://www.health.govt.nz/node/7497" class="">Official Information Act requests</a></li><li class="field-item"><a href="https://web.archive.org/web/20211101145759/https://www.health.govt.nz/about-ministry/information-releases" class="">Information releases</a></li><li class="field-item"><a href="https://web.archive.org/web/20211101145759/https://consult.health.govt.nz/" class="">Consultations</a></li></ul>
+          </div>
+        </div>
+        <div class="col-sm-6 col-md-6">
+          <div class="field field-name-field-tax-footer-body field-type-text-long field-label-hidden"><div class="field-items"><div class="field-item even"><h3>Where to go for help</h3>
+
+<table>
+	<tbody>
+		<tr>
+			<th scope="row">Emergencies</th>
+			<td><strong>Dial <a href="tel:111">111</a></strong> (for ambulance, fire or police)</td>
+		</tr>
+		<tr>
+			<th scope="row">Healthline</th>
+			<td><strong>Dial <a href="tel:0800611116">0800 611 116</a></strong></td>
+		</tr>
+		<tr>
+			<th scope="row">Poisons</th>
+			<td><strong>Dial <a href="tel:0800764766">0800 POISON</a> </strong>(<a href="tel:0800764766">0800 764 766</a>)</td>
+		</tr>
+		<tr>
+			<th scope="row">Mental health crisis</th>
+			<td><strong><a href="/web/20211101145759/https://www.health.govt.nz/your-health/services-and-support/health-care-services/mental-health-services/crisis-assessment-teams">Emergency contact numbers</a></strong></td>
+		</tr>
+	</tbody>
+</table>
+</div></div></div>        </div>
+      </div>
+      <div class="row">
+        <div class="sub-footer">
+          <div class="column col-sm-12 col-md-3">
+            <a href="https://web.archive.org/web/20211101145759/https://www.govt.nz/">
+              <img src="/web/20211101145759im_/https://www.health.govt.nz/sites/all/themes/mohpub_bootstrap/images/nzgovtlogo_white.png" width="152" height="16" alt="govt.nz - connecting you to New Zealand central &amp; local government services" title="govt.nz - connecting you to New Zealand central &amp; local government services"/>
+            </a>
+          </div>
+          <div class="column col-sm-12 col-md-9">
+          <span class="bottom-menu-moh with-v-divider">&copy; Ministry of Health – Manatū Hauora</span><ul class="bottom-menu-list"><li class="bottom-menu-list-item with-v-divider"><a href="https://web.archive.org/web/20211101145759/https://www.health.govt.nz/sitemap" class="">Site map</a></li><li class="bottom-menu-list-item with-v-divider"><a href="https://web.archive.org/web/20211101145759/https://www.health.govt.nz/about-site/privacy-and-security" class="">Privacy &amp; security</a></li><li class="bottom-menu-list-item with-v-divider"><a href="https://web.archive.org/web/20211101145759/https://www.health.govt.nz/about-site/copyright" class="">Copyright</a></li></ul>          </div>
+        </div>
+      </div>
+    </div>
+    <div class="footer-print">&copy; Ministry of Health – Manatū Hauora</div>
+  </footer>
+  <a class="scrollToTop">Back to top <i class="fas fa-arrow-up"></i></a>
+</div>
+  <script src="https://web.archive.org/web/20211101145759js_/https://www.health.govt.nz/sites/default/files/js/js_akZOsKtodu3PdnQzY3_ElOfujkLxJcowmaWgHTBBLOE.js"></script>
+</body>
+</html>
+<!--
+     FILE ARCHIVED ON 14:57:59 Nov 01, 2021 AND RETRIEVED FROM THE
+     INTERNET ARCHIVE ON 03:14:30 Nov 07, 2021.
+     JAVASCRIPT APPENDED BY WAYBACK MACHINE, COPYRIGHT INTERNET ARCHIVE.
+
+     ALL OTHER CONTENT MAY ALSO BE PROTECTED BY COPYRIGHT (17 U.S.C.
+     SECTION 108(a)(3)).
+-->
+<!--
+playback timings (ms):
+  captures_list: 133.346
+  exclusion.robots: 0.191
+  exclusion.robots.policy: 0.184
+  RedisCDXSource: 0.465
+  esindex: 0.006
+  LoadShardBlock: 97.797 (3)
+  PetaboxLoader3.datanode: 197.29 (4)
+  CDXLines.iter: 24.953 (3)
+  load_resource: 191.512
+  PetaboxLoader3.resolve: 39.859
+-->

--- a/data/rawSite/2021-11-01.html
+++ b/data/rawSite/2021-11-01.html
@@ -1,0 +1,2523 @@
+
+<!DOCTYPE html>
+<html lang="en" dir="ltr" prefix="" class="no-js">
+<head><script src="//archive.org/includes/analytics.js?v=cf34f82" type="text/javascript"></script>
+<script type="text/javascript">window.addEventListener('DOMContentLoaded',function(){var v=archive_analytics.values;v.service='wb';v.server_name='wwwb-app224.us.archive.org';v.server_ms=276;archive_analytics.send_pageview({});});</script>
+<script type="text/javascript" src="/_static/js/bundle-playback.js?v=UfTkgsKx" charset="utf-8"></script>
+<script type="text/javascript" src="/_static/js/wombat.js?v=UHAOicsW" charset="utf-8"></script>
+<script type="text/javascript">
+  __wm.init("https://web.archive.org/web");
+  __wm.wombat("https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data","20211102161403","https://web.archive.org/","web","/_static/",
+	      "1635869643");
+</script>
+<link rel="stylesheet" type="text/css" href="/_static/css/banner-styles.css?v=omkqRugM" />
+<link rel="stylesheet" type="text/css" href="/_static/css/iconochive.css?v=qtvMKcIJ" />
+<!-- End Wayback Rewrite JS Include -->
+
+  <!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta name="format-detection" content="telephone=no"/>
+  <link rel="profile" href="http://www.w3.org/1999/xhtml/vocab"/>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+<link rel="shortcut icon" href="https://web.archive.org/web/20211102161403im_/https://www.health.govt.nz/sites/all/themes/mohpub_bootstrap/favicon.ico" type="image/vnd.microsoft.icon"/>
+<meta name="description" content="Dashboard of data and statistics about the rollout of COVID-19 vaccines in New Zealand"/>
+<meta name="generator" content="Drupal 7 (https://www.drupal.org)"/>
+<link rel="canonical" href="https://web.archive.org/web/20211102161403/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data"/>
+<link rel="shortlink" href="https://web.archive.org/web/20211102161403/https://www.health.govt.nz/node/12052"/>
+<meta property="og:site_name" content="Ministry of Health NZ"/>
+<meta property="og:type" content="article"/>
+<meta property="og:url" content="https://web.archive.org/web/20211102161403/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data"/>
+<meta property="og:title" content="COVID-19: Vaccine data"/>
+<meta property="og:description" content="Dashboard of data and statistics about the rollout of COVID-19 vaccines in New Zealand"/>
+  <title>COVID-19: Vaccine data | Ministry of Health NZ</title>
+  <link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211102161403cs_/https://www.health.govt.nz/sites/default/files/css/css_lQaZfjVpwP_oGNqdtWCSpJT1EMqXdMiU84ekLLxQnc4.css" media="all"/>
+<link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211102161403cs_/https://www.health.govt.nz/sites/default/files/css/css_jqUBpWfMaxMiP7LismdZVlyVv8azUJSE2yaH58nj0cE.css" media="all"/>
+<link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211102161403cs_/https://www.health.govt.nz/sites/default/files/css/css_Rb1wqFBC8VXCJC-BuNY53cvjjlj6UADGvqzo_f-1yN0.css" media="all"/>
+<link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211102161403cs_/https://www.health.govt.nz/sites/default/files/css/css_38_K1lHKg-98m4KKRfv57JBK0gvlKscexGt9MKoi0DE.css" media="all"/>
+<link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211102161403cs_/https://www.health.govt.nz/sites/default/files/css/css_r7NPyvpdYfAyZmk9zkK8OaFKEFj6er5ZJnam2H644DM.css" media="print"/>
+  <link rel="alternate stylesheet" type="text/css" href="/web/20211102161403cs_/https://www.health.govt.nz/sites/all/themes/mohpub_bootstrap/css/high-contrast.css" media="screen" title="High Contrast"/>
+  <script src="https://web.archive.org/web/20211102161403js_/https://www.health.govt.nz/sites/default/files/js/js_zS-CmNFGyegtLYJmqFRpxQvvQrfPIFrOMq_3T3C8sZE.js"></script>
+<script src="https://web.archive.org/web/20211102161403js_/https://www.health.govt.nz/sites/default/files/js/js_fNgZ4Okisfr70Q0yvAYsATgB0o_jD3-srhQQ-VHmlXE.js"></script>
+<script src="https://web.archive.org/web/20211102161403js_/https://www.health.govt.nz/sites/default/files/js/js_YAdPZfg12M1m7ROp3_gVJPS5sArqL0kYQgNRPoicvHE.js"></script>
+<script>(function(i,s,o,g,r,a,m){i["GoogleAnalyticsObject"]=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,"script","https://web.archive.org/web/20211102161403/https://www.google-analytics.com/analytics.js","ga");ga("create", "UA-3573389-24", {"cookieDomain":".www.health.govt.nz","siteSpeedSampleRate":15});ga("send", "pageview");</script>
+<script src="https://web.archive.org/web/20211102161403js_/https://www.health.govt.nz/sites/default/files/js/js_wauJ-VUoyA1MrZ6ZPFtGhNR7qiKnBdBSKEwQJjdEXIk.js"></script>
+<script src="https://web.archive.org/web/20211102161403js_/https://www.health.govt.nz/sites/default/files/js/js_4VW9edmu3V8VjGJxFfXGAwkXeW2cJIa5h-6y7SgwVrk.js"></script>
+<script>    (function(h,o,t,j,a,r){
+        h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
+        h._hjSettings={hjid:930919,hjsv:6};
+        a=o.getElementsByTagName('head')[0];
+        r=o.createElement('script');r.async=1;
+        r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+        a.appendChild(r);
+    })(window,document,'https://web.archive.org/web/20211102161403/https://static.hotjar.com/c/hotjar-','.js?sv=');
+</script>
+<script>jQuery.extend(Drupal.settings, {"basePath":"\/","pathPrefix":"","ajaxPageState":{"theme":"mohpub_bootstrap","theme_token":"B7Gxkf4wCqe4Y1Gf9ijWA2Begd-5lZAcQUcX1XTeR2E","js":{"sites\/all\/modules\/custom\/table_d3chart\/js\/table_d3chart.js":1,"sites\/all\/modules\/custom\/moh_d3\/moh_d3.js":1,"sites\/all\/modules\/contrib\/jquery_update\/replace\/jquery\/1.7\/jquery.min.js":1,"misc\/jquery-extend-3.4.0.js":1,"misc\/jquery-html-prefilter-3.5.0-backport.js":1,"misc\/jquery.once.js":1,"misc\/drupal.js":1,"sites\/all\/modules\/contrib\/ckeditor_accordion\/js\/ckeditor-accordion.js":1,"sites\/all\/modules\/contrib\/extlink\/extlink.js":1,"modules\/field\/modules\/text\/text.js":1,"sites\/all\/modules\/contrib\/field_group\/field_group.js":1,"sites\/all\/modules\/contrib\/google_analytics\/googleanalytics.js":1,"0":1,"sites\/all\/libraries\/c3\/c3.js":1,"sites\/all\/libraries\/d3\/d3.js":1,"sites\/all\/modules\/contrib\/d3\/js\/d3.js":1,"sites\/all\/libraries\/d3.helpers\/d3.helpers.js":1,"sites\/all\/libraries\/d3.c3\/d3-c3.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/assets\/ios-fix.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/affix.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/alert.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/button.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/carousel.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/collapse.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/dropdown.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/modal.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/tooltip.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/popover.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/scrollspy.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/tab.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/transition.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/jquery.cookie.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/jquery.moh.announcement.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/svgeezy.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/fitvids.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/bootstrap-tabcollapse.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/jquery.scrollTo.min.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/script.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/jquery.google_analytics.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/bootstrap-accessibility.min.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/style-switcher.js":1,"1":1},"css":{"modules\/system\/system.base.css":1,"sites\/all\/modules\/contrib\/calendar\/css\/calendar_multiday.css":1,"sites\/all\/modules\/contrib\/ckeditor_accordion\/css\/ckeditor-accordion.css":1,"modules\/field\/theme\/field.css":1,"modules\/node\/node.css":1,"sites\/all\/modules\/contrib\/extlink\/extlink.css":1,"sites\/all\/modules\/contrib\/views\/css\/views.css":1,"sites\/all\/modules\/contrib\/ckeditor\/css\/ckeditor.css":1,"sites\/all\/modules\/contrib\/ctools\/css\/ctools.css":1,"sites\/all\/modules\/contrib\/panels\/css\/panels.css":1,"sites\/all\/libraries\/c3\/c3.css":1,"sites\/all\/libraries\/d3.c3\/d3-c3.css":1,"sites\/all\/themes\/mohpub_bootstrap\/fontawesome\/css\/fontawesome.min.css":1,"sites\/all\/themes\/mohpub_bootstrap\/fontawesome\/css\/solid.min.css":1,"sites\/all\/themes\/mohpub_bootstrap\/fontawesome\/css\/brands.min.css":1,"sites\/all\/modules\/features\/site_profile\/css\/fix-rubik-multiselect-height.css":1,"sites\/all\/themes\/mohpub_bootstrap\/css\/style.css":1,"sites\/all\/themes\/mohpub_bootstrap\/css\/responsive-tables.css":1,"sites\/all\/themes\/mohpub_bootstrap\/css\/print.css":1}},"field_group":{"div":"full"},"ckeditor_accordion":{"collapseAll":1},"extlink":{"extTarget":0,"extClass":"ext","extLabel":"(link is external)","extImgClass":0,"extIconPlacement":"append","extSubdomains":0,"extExclude":"","extInclude":"","extCssExclude":"","extCssExplicit":"","extAlert":0,"extAlertText":"This link will take you to an external web site. We are not responsible for their content.","mailtoClass":"mailto","mailtoLabel":"(link sends e-mail)"},"googleanalytics":{"trackOutbound":1,"trackMailto":1,"trackDownload":1,"trackDownloadExtensions":"7z|aac|arc|arj|asf|asx|avi|bin|csv|doc|exe|flv|gif|gz|gzip|hqx|jar|jpe?g|js|mp(2|3|4|e?g)|mov(ie)?|msi|msp|pdf|phps|png|ppt|qtm?|ra(m|r)?|sea|sit|tar|tgz|torrent|txt|wav|wma|wmv|wpd|xls|xml|z|zip|docx|xlsx|pptx|pptm|ppsx|ppsm|epub"},"mohD3":{"C3Types":["line","spline","step","area","area-spline","area-step","bar","scatter","pie","donut","gauge"],"graphRender":"line","graphLegend":true,"graphDefaultColors":"#2b8cbe, #abdda4, #7f7f7f, #92cddc, #dc8b0c","graphDefaultGroupedTooltip":0,"graphDefaultGridX":0,"graphDefaultGridY":0,"graphDefaultLegendPosition":"top-right","graphDefaultTooltip":1,"graphDefaultDataLabel":0,"graphLegendStep":"5","graphInteraction":true,"graphTypes":"","graphXaxisShow":true,"graphXaxisLabel":"","graphYaxisLabel":"","graphXaxisType":"category","graphXaxisCentered":false,"graphXaxisRotation":"","graphXaxisHeight":"","graphYaxisShow":true,"graphYaxisMax":"","graphYaxisMin":"","graphYaxisInverted":false,"graphYaxisCenter":"","graphYaxisPrefix":"","graphYaxisSuffix":"","graphYaxisPosition":"","graphY2axisShow":false,"graphY2axisSource":"","graphY2axisMax":"","graphY2axisMin":"","graphGroups":"","graphRotated":false,"graphIgnoreEmpty":false,"graphLineDot":true,"graphBarRatio":"0.9","graphDot":true,"graphDotR":"2.5","graphFocus":false},"tableD3":{"show":"View table data source","hide":"Hide table data source"},"urlIsAjaxTrusted":{"\/our-work\/diseases-and-conditions\/covid-19-novel-coronavirus\/covid-19-data-and-statistics\/covid-19-vaccine-data":true},"bootstrap":{"anchorsFix":1,"anchorsSmoothScrolling":1,"formHasError":1,"popoverEnabled":1,"popoverOptions":{"animation":1,"html":0,"placement":"right","selector":"","trigger":"click","triggerAutoclose":1,"title":"","content":"","delay":0,"container":"body"},"tooltipEnabled":1,"tooltipOptions":{"animation":1,"html":0,"placement":"auto left","selector":"","trigger":"hover focus","delay":0,"container":"body"}}});</script>
+  <!-- HTML5 element support for IE6-8 -->
+  <!--[if lt IE 9]>
+    <script src="/sites/all/themes/mohpub_bootstrap/js/assets/html5shiv.js"></script>
+    <script src="/sites/all/themes/mohpub_bootstrap/js/assets/respond.min.js"></script>
+  <![endif]-->
+</head>
+<body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-12052 node-type-page node-has-intro"><!-- BEGIN WAYBACK TOOLBAR INSERT -->
+<style type="text/css">
+body {
+  margin-top:0 !important;
+  padding-top:0 !important;
+  /*min-width:800px !important;*/
+}
+</style>
+<script>__wm.rw(0);</script>
+<div id="wm-ipp-base" lang="en" style="display:none;direction:ltr;">
+<div id="wm-ipp" style="position:fixed;left:0;top:0;right:0;">
+<div id="wm-ipp-inside">
+  <div style="position:relative;">
+    <div id="wm-logo" style="float:left;width:110px;padding-top:12px;">
+      <a href="/web/" title="Wayback Machine home page"><img src="/_static/images/toolbar/wayback-toolbar-logo-200.png" srcset="/_static/images/toolbar/wayback-toolbar-logo-100.png, /_static/images/toolbar/wayback-toolbar-logo-150.png 1.5x, /_static/images/toolbar/wayback-toolbar-logo-200.png 2x" alt="Wayback Machine" style="width:100px" border="0" /></a>
+    </div>
+    <div class="r" style="float:right;">
+      <div id="wm-btns" style="text-align:right;height:25px;">
+                  <div id="wm-save-snapshot-success">success</div>
+          <div id="wm-save-snapshot-fail">fail</div>
+          <a id="wm-save-snapshot-open" href="#"
+	     title="Share via My Web Archive" >
+            <span class="iconochive-web"></span>
+          </a>
+          <a href="https://archive.org/account/login.php"
+             title="Sign In"
+             id="wm-sign-in"
+          >
+            <span class="iconochive-person"></span>
+          </a>
+          <span id="wm-save-snapshot-in-progress" class="iconochive-web"></span>
+        	<a href="http://faq.web.archive.org/" title="Get some help using the Wayback Machine" style="top:-6px;"><span class="iconochive-question" style="color:rgb(87,186,244);font-size:160%;"></span></a>
+	<a id="wm-tb-close" href="#close" onclick="__wm.h(event);return false;" style="top:-2px;" title="Close the toolbar"><span class="iconochive-remove-circle" style="color:#888888;font-size:240%;"></span></a>
+      </div>
+      <div id="wm-share">
+          <a href="/web/20211102161403/http://web.archive.org/screenshot/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data"
+             id="wm-screenshot"
+             title="screenshot">
+            <span class="wm-icon-screen-shot"></span>
+          </a>
+          <a href="#"
+            id="wm-video"
+            title="video">
+            <span class="iconochive-movies"></span>
+          </a>
+	<a id="wm-share-facebook" href="#" data-url="https://web.archive.org/web/20211102161403/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="Share on Facebook" style="margin-right:5px;" target="_blank"><span class="iconochive-facebook" style="color:#3b5998;font-size:160%;"></span></a>
+	<a id="wm-share-twitter" href="#" data-url="https://web.archive.org/web/20211102161403/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="Share on Twitter" style="margin-right:5px;" target="_blank"><span class="iconochive-twitter" style="color:#1dcaff;font-size:160%;"></span></a>
+      </div>
+    </div>
+    <table class="c" style="">
+      <tbody>
+	<tr>
+	  <td class="u" colspan="2">
+	    <form target="_top" method="get" action="/web/submit" name="wmtb" id="wmtb"><input type="text" name="url" id="wmtbURL" value="https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" onfocus="this.focus();this.select();" /><input type="hidden" name="type" value="replay" /><input type="hidden" name="date" value="20211102161403" /><input type="submit" value="Go" /></form>
+	  </td>
+	  <td class="n" rowspan="2" style="width:110px;">
+	    <table>
+	      <tbody>
+		<!-- NEXT/PREV MONTH NAV AND MONTH INDICATOR -->
+		<tr class="m">
+		  <td class="b" nowrap="nowrap"><a href="https://web.archive.org/web/20211001190759/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="01 Oct 2021"><strong>Oct</strong></a></td>
+		  <td class="c" id="displayMonthEl" title="You are here: 16:14:03 Nov 02, 2021">NOV</td>
+		  <td class="f" nowrap="nowrap">Dec</td>
+		</tr>
+		<!-- NEXT/PREV CAPTURE NAV AND DAY OF MONTH INDICATOR -->
+		<tr class="d">
+		  <td class="b" nowrap="nowrap"><a href="https://web.archive.org/web/20211101145759/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="14:57:59 Nov 01, 2021"><img src="/_static/images/toolbar/wm_tb_prv_on.png" alt="Previous capture" width="14" height="16" border="0" /></a></td>
+		  <td class="c" id="displayDayEl" style="width:34px;font-size:24px;white-space:nowrap;" title="You are here: 16:14:03 Nov 02, 2021">02</td>
+		  <td class="f" nowrap="nowrap"><a href="https://web.archive.org/web/20211103184409/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="18:44:09 Nov 03, 2021"><img src="/_static/images/toolbar/wm_tb_nxt_on.png" alt="Next capture" width="14" height="16" border="0" /></a></td>
+		</tr>
+		<!-- NEXT/PREV YEAR NAV AND YEAR INDICATOR -->
+		<tr class="y">
+		  <td class="b" nowrap="nowrap">2020</td>
+		  <td class="c" id="displayYearEl" title="You are here: 16:14:03 Nov 02, 2021">2021</td>
+		  <td class="f" nowrap="nowrap">2022</td>
+		</tr>
+	      </tbody>
+	    </table>
+	  </td>
+	</tr>
+	<tr>
+	  <td class="s">
+	    	    <div id="wm-nav-captures">
+	      	      <a class="t" href="/web/20211102161403*/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="See a list of every capture for this URL">682 captures</a>
+	      <div class="r" title="Timespan for captures of this URL">07 Apr 2021 - 06 Nov 2021</div>
+	      </div>
+	  </td>
+	  <td class="k">
+	    <a href="" id="wm-graph-anchor">
+	      <div id="wm-ipp-sparkline" title="Explore captures for this URL" style="position: relative">
+		<canvas id="wm-sparkline-canvas" width="650" height="27" border="0"></canvas>
+	      </div>
+	    </a>
+	  </td>
+	</tr>
+      </tbody>
+    </table>
+    <div style="position:absolute;bottom:0;right:2px;text-align:right;">
+      <a id="wm-expand" class="wm-btn wm-closed" href="#expand" onclick="__wm.ex(event);return false;"><span id="wm-expand-icon" class="iconochive-down-solid"></span> <span style="font-size:80%">About this capture</span></a>
+    </div>
+  </div>
+    <div id="wm-capinfo" style="border-top:1px solid #777;display:none; overflow: hidden">
+                    <div id="wm-capinfo-collected-by">
+    <div style="background-color:#666;color:#fff;font-weight:bold;text-align:center">COLLECTED BY</div>
+    <div style="padding:3px;position:relative" id="wm-collected-by-content">
+            <div style="display:inline-block;vertical-align:top;width:50%;">
+			<span class="c-logo" style="background-image:url(https://archive.org/services/img/focused_crawls);"></span>
+		Organization: <a style="color:#33f;" href="https://archive.org/details/focused_crawls" target="_new"><span class="wm-title">Internet Archive</span></a>
+		<div style="max-height:75px;overflow:hidden;position:relative;">
+	  <div style="position:absolute;top:0;left:0;width:100%;height:75px;background:linear-gradient(to bottom,rgba(255,255,255,0) 0%,rgba(255,255,255,0) 90%,rgba(255,255,255,255) 100%);"></div>
+	  Focused crawls are collections of frequently-updated webcrawl data from narrow (as opposed to broad or wide) web crawls, often focused on a single domain or subdomain.<br />
+	</div>
+	      </div>
+      <div style="display:inline-block;vertical-align:top;width:49%;">
+			<span class="c-logo" style="background-image:url(https://archive.org/services/img/abc.net.au-news)"></span>
+		<div>Collection: <a style="color:#33f;" href="https://archive.org/details/abc.net.au-news" target="_new"><span class="wm-title">abc.net.au-news</span></a></div>
+	      </div>
+    </div>
+    </div>
+    <div id="wm-capinfo-timestamps">
+    <div style="background-color:#666;color:#fff;font-weight:bold;text-align:center" title="Timestamps for the elements of this page">TIMESTAMPS</div>
+    <div>
+      <div id="wm-capresources" style="margin:0 5px 5px 5px;max-height:250px;overflow-y:scroll !important"></div>
+      <div id="wm-capresources-loading" style="text-align:left;margin:0 20px 5px 5px;display:none"><img src="/_static/images/loading.gif" alt="loading" /></div>
+    </div>
+    </div>
+  </div></div></div></div><div id="wm-ipp-print">The Wayback Machine - https://web.archive.org/web/20211102161403/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data</div>
+<div id="donato" style="position:relative;width:100%;">
+  <div id="donato-base">
+    <iframe id="donato-if" src="https://archive.org/includes/donate.php?as_page=1&amp;platform=wb&amp;referer=https%3A//web.archive.org/web/20211102161403/https%3A//www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data"
+	    scrolling="no" frameborder="0" style="width:100%; height:100%">
+    </iframe>
+  </div>
+</div><script type="text/javascript">
+__wm.bt(650,27,25,2,"web","https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data","20211102161403",1996,"/_static/",["/_static/css/banner-styles.css?v=omkqRugM","/_static/css/iconochive.css?v=qtvMKcIJ"], "False");
+  __wm.rw(1);
+</script>
+<!-- END WAYBACK TOOLBAR INSERT -->
+<!--googleoff: all-->
+  <div id="skip-link">
+    <a href="#skip-content" id="skipper" class="element-invisible element-focusable">Skip to main content</a>
+  </div>
+    <div id="page">
+  <header id="navbar" role="banner" class="navbar container navbar-default">
+          <ul class="menu nav navbar-nav secondary"><li class="first leaf jobs depth-1"><a href="https://web.archive.org/web/20211102161403/https://careers.health.govt.nz/" title="">Jobs</a></li>
+<li class="leaf news depth-1"><a href="/web/20211102161403/https://www.health.govt.nz/news-media" data-is-top-level="0" title="">News</a></li>
+<li class="leaf contact-us depth-1"><a href="/web/20211102161403/https://www.health.govt.nz/about-ministry/contact-us" title="">Contact us</a></li>
+<li class="leaf facebook depth-1"><a href="https://web.archive.org/web/20211102161403/https://www.facebook.com/minhealthnz/">Facebook</a></li>
+<li class="leaf twitter depth-1"><a href="https://web.archive.org/web/20211102161403/https://twitter.com/minhealthnz" data-is-top-level="0" title="">Twitter</a></li>
+<li class="last leaf youtube depth-1"><a href="https://web.archive.org/web/20211102161403/https://www.youtube.com/user/minhealthnz" data-is-top-level="0" title="">Youtube</a></li>
+</ul>        <div class="container">
+      <div class="navbar-header">
+                <a class="logo navbar-btn pull-left" href="/web/20211102161403/https://www.health.govt.nz/" title="Home">
+          <img src="/web/20211102161403im_/https://www.health.govt.nz/sites/all/themes/mohpub_bootstrap/images/mohlogo.svg" alt="Ministry of Health"/>
+        </a>
+                  <div class="region region-header-top">
+    <section id="block-apachesolr-panels-search-form" class="block block-apachesolr-panels clearfix">
+
+
+  <form action="/web/20211102161403/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" method="post" id="apachesolr-panels-search-block" accept-charset="UTF-8"><div><div class="form-item form-item-apachesolr-panels-search-form form-type-textfield form-group"> <label class="control-label" for="edit-apachesolr-panels-search-form">Search</label>
+<input title="Enter the terms you wish to search for." class="form-control form-text" type="text" id="edit-apachesolr-panels-search-form" name="apachesolr_panels_search_form" value="" size="15" maxlength="128"/></div><input type="hidden" name="form_build_id" value="form-Js6LSPTbAV4RMl7e9cJbPBiU9_1udpe0ZJmlZOhGegg"/>
+<input type="hidden" name="form_id" value="apachesolr_panels_search_block"/>
+<div class="form-actions form-wrapper form-group" id="edit-actions"><button type="submit" id="edit-submit" name="op" value="Search" class="btn btn-primary form-submit">Search</button>
+</div></div></form>
+</section>
+  </div>
+        <!-- .btn-navbar is used as the toggle for collapsed navbar content -->
+        <button aria-expanded="false" aria-controls="megamenu" type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+                    <span class="menu-text">Menu</span><span class="sr-only">Toggle navigation</span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+
+        </button>
+      </div>
+
+              <div class="navbar-collapse collapse">
+          <nav id="megamenu" role="navigation">
+                          <h2 class="element-invisible">Main menu</h2><ul id="main-menu" class="menu nav navbar-nav yamm navbar"><li class="first dropdown"><a href="/web/20211102161403/https://www.health.govt.nz/your-health" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="megamenu-dropdown-780">Your health <b class="caret"></b></a>
+    <div id="megamenu-dropdown-780" class="dropdown-menu">
+    <div class="yamm-content">
+      <div class="row">
+                            <div class="col">
+            <h3><a href="/web/20211102161403/https://www.health.govt.nz/your-health/conditions-and-treatments?mega=Your%20health&amp;title=Conditions%20%26%20treatments" class="menu-header">Conditions &amp; treatments</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211102161403/https://www.health.govt.nz/your-health/conditions-and-treatments/mental-health/depression?mega=Your%20health&amp;title=Depression">Depression</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/diabetes?mega=Your%20health&amp;title=Diabetes">Diabetes</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/influenza?mega=Your%20health&amp;title=Influenza">Influenza</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/measles?mega=Your%20health&amp;title=Measles">Measles</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/meningococcal-disease-including-meningitis?mega=Your%20health&amp;title=Meningococcal%20disease">Meningococcal disease</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/mumps?mega=Your%20health&amp;title=Mumps">Mumps</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/respiratory-syncytial-virus-rsv?mega=Your%20health&amp;title=RSV">RSV</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/sore-throat?mega=Your%20health&amp;title=Sore%20throat">Sore throat</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/your-health/conditions-and-treatments?mega=Your%20health&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211102161403/https://www.health.govt.nz/your-health/healthy-living?mega=Your%20health&amp;title=Healthy%20living" class="menu-header">Healthy living</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211102161403/https://www.health.govt.nz/your-health/healthy-living/drinking-water?mega=Your%20health&amp;title=Drinking-water">Drinking-water</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/your-health/healthy-living/food-activity-and-sleep/green-prescriptions?mega=Your%20health&amp;title=Green%20Prescriptions">Green Prescriptions</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/your-health/healthy-living/food-activity-and-sleep/healthy-eating?mega=Your%20health&amp;title=Healthy%20eating">Healthy eating</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/your-health/healthy-living/immunisation?mega=Your%20health&amp;title=Immunisation">Immunisation</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/your-health/healthy-living/food-activity-and-sleep/physical-activity?mega=Your%20health&amp;title=Physical%20activity">Physical activity</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/your-health/healthy-living/addictions/quitting-smoking?mega=Your%20health&amp;title=Smoking">Smoking</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/your-health/healthy-living/teeth-and-gums?mega=Your%20health&amp;title=Teeth%20and%20gums">Teeth and gums</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/your-health/healthy-living?mega=Your%20health&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211102161403/https://www.health.govt.nz/your-health/pregnancy-and-kids?mega=Your%20health&amp;title=Pregnancy%20and%20kids" class="menu-header">Pregnancy and kids</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211102161403/https://www.health.govt.nz/your-health/pregnancy-and-kids/birth-and-afterwards?mega=Your%20health&amp;title=Birth%20and%20afterwards">Birth and afterwards</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/your-health/pregnancy-and-kids/first-year/helpful-advice-during-first-year/breastfeeding-perfect-you-and-your-baby?mega=Your%20health&amp;title=Breastfeeding">Breastfeeding</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/your-health/pregnancy-and-kids/pregnancy?mega=Your%20health&amp;title=Pregnancy">Pregnancy</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/your-health/pregnancy-and-kids/services-and-support-during-pregnancy?mega=Your%20health&amp;title=Services%20and%20support%20during%20pregnancy">Services and support during pregnancy</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/your-health/pregnancy-and-kids/services-and-support-you-and-your-child?mega=Your%20health&amp;title=Services%20and%20support%20for%20you%20and%20your%20child">Services and support for you and your child</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/your-health/pregnancy-and-kids/first-year?mega=Your%20health&amp;title=The%20first%20year">The first year</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/your-health/pregnancy-and-kids/under-fives?mega=Your%20health&amp;title=Under%20fives">Under fives</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/your-health/pregnancy-and-kids?mega=Your%20health&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211102161403/https://www.health.govt.nz/your-health/services-and-support?mega=Your%20health&amp;title=Services%20and%20support" class="menu-header">Services &amp; support</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211102161403/https://www.health.govt.nz/your-health/services-and-support/health-care-services/help-alcohol-and-drug-problems?mega=Your%20health&amp;title=Alcohol%20and%20drugs">Alcohol and drugs</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/your-health/services-and-support/disability-services?mega=Your%20health&amp;title=Disability%20services">Disability services</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/your-health/services-and-support/health-care-services/earthquake-support-line?mega=Your%20health&amp;title=Earthquake%20Support%20Line">Earthquake Support Line</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/your-health/services-and-support/health-care-services/healthline?mega=Your%20health&amp;title=Healthline">Healthline</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/your-health/services-and-support/health-care-services/mental-health-services?mega=Your%20health&amp;title=Mental%20health%20services">Mental health services</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/your-health/services-and-support/health-care-services/maori-health-provider-directory?mega=Your%20health&amp;title=M%C4%81ori%20health%20providers">Māori health providers</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/your-health/services-and-support/health-care-services/services-older-people/rest-home-certification-and-audits?mega=Your%20health&amp;title=Rest%20home%20certification">Rest home certification</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/your-health/services-and-support/health-care-services/hospitals-and-specialist-services/travel-assistance?mega=Your%20health&amp;title=Travel%20assistance">Travel assistance</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/your-health/services-and-support?mega=Your%20health&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                        </div>
+    </div>
+    <div class="feature-links">
+      <h3 class="sr-only">Other related resources</h3>
+      <a href="/web/20211102161403/https://www.health.govt.nz/your-health/full-a-z?mega=Your%20health&amp;title=A-Z">View the full A-Z</a>    </div>
+  </div>
+</li>
+<li class="dropdown"><a href="/web/20211102161403/https://www.health.govt.nz/new-zealand-health-system" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="megamenu-dropdown-6076">NZ health system <b class="caret"></b></a>
+    <div id="megamenu-dropdown-6076" class="dropdown-menu">
+    <div class="yamm-content">
+      <div class="row">
+                            <div class="col">
+            <h3><a href="/web/20211102161403/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people?mega=NZ%20health%20system&amp;title=Key%20organisations" class="menu-header">Key organisations</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211102161403/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/crown-entities-and-statutory-boards?mega=NZ%20health%20system&amp;title=Crown%20entities%20%26%20agencies">Crown entities &amp; agencies</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/district-health-boards?mega=NZ%20health%20system&amp;title=District%20health%20boards">District health boards</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/non-governmental-organisations?mega=NZ%20health%20system&amp;title=Non-governmental%20organisations">Non-governmental organisations</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/primary-health-organisations?mega=NZ%20health%20system&amp;title=Primary%20health%20organisations">Primary health organisations</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/public-health-units?mega=NZ%20health%20system&amp;title=Public%20health%20units">Public health units</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people?mega=NZ%20health%20system&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211102161403/https://www.health.govt.nz/new-zealand-health-system/health-system-indicators-framework?mega=NZ%20health%20system&amp;title=Health%20System%20Indicators%20framework" class="menu-header">Health System Indicators framework</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211102161403/https://www.health.govt.nz/new-zealand-health-system/health-system-indicators-framework?mega=NZ%20health%20system&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211102161403/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services?mega=NZ%20health%20system&amp;title=Eligibility%20for%20public%20health%20services" class="menu-header">Eligibility for public health services</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211102161403/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services/guide-eligibility-publicly-funded-health-services?mega=NZ%20health%20system&amp;title=Guide%20to%20eligibility">Guide to eligibility</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services/eligibility-questions-and-answers-consumers?mega=NZ%20health%20system&amp;title=Q%26A%20for%20consumers">Q&amp;A for consumers</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services/eligibility-questions-and-answers-service-providers?mega=NZ%20health%20system&amp;title=Q%26A%20for%20service%20providers">Q&amp;A for service providers</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services/reciprocal-health-agreements?mega=NZ%20health%20system&amp;title=Reciprocal%20health%20agreements">Reciprocal health agreements</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services?mega=NZ%20health%20system&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211102161403/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements?mega=NZ%20health%20system&amp;title=Claims%2C%20provider%20payments%20and%20entitlements" class="menu-header">Claims &amp; provider payments</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211102161403/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/carer-support-claims?mega=NZ%20health%20system&amp;title=Carer%20Support">Carer Support</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/high-use-health-card-payments?mega=NZ%20health%20system&amp;title=High%20Use%20Health%20Card%20payments">High Use Health Card payments</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/between-travel-settlement?mega=NZ%20health%20system&amp;title=In-Between%20Travel%20Settlement">In-Between Travel Settlement</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/maternity-claim-forms?mega=NZ%20health%20system&amp;title=Maternity%20claim%20forms">Maternity claim forms</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/national-travel-assistance?mega=NZ%20health%20system&amp;title=National%20travel%20assistance%20claims">National travel assistance claims</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements?mega=NZ%20health%20system&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                        </div>
+    </div>
+    <div class="feature-links">
+      <h3 class="sr-only">Other related resources</h3>
+      <a href="/web/20211102161403/https://www.health.govt.nz/new-zealand-health-system/overview-health-system?mega=NZ%20health%20system&amp;title=Overview">Overview of the health system</a>  <a href="/web/20211102161403/https://www.health.govt.nz/new-zealand-health-system/my-dhb?mega=NZ%20health%20system&amp;title=Mydhb">My DHB</a> <a href="/web/20211102161403/https://www.health.govt.nz/new-zealand-health-system/system-level-measures-framework?mega=NZ%20health%20system&amp;title=SLM">System level measures</a>  <a href="/web/20211102161403/https://www.health.govt.nz/publication/new-zealand-health-strategy-2016?mega=NZ%20health%20system&amp;title=HealthStrategy">NZ Health Strategy</a>    </div>
+  </div>
+</li>
+<li class="dropdown"><a href="/web/20211102161403/https://www.health.govt.nz/our-work" class="dropdown-toggle active-trail" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="megamenu-dropdown-776">Our work <b class="caret"></b></a>
+  <div id="megamenu-dropdown-776" class="dropdown-menu">
+    <div class="yamm-content">
+      <div class="row">
+                            <ul class="col list-unstyled no-menu-header">
+                                                                                <li>
+                <a href="/web/20211102161403/https://www.health.govt.nz/our-work/hospitals-and-specialist-care/acute-care?mega=Our%20work&amp;title=Acute%20care" class="menu-header">Acute care</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211102161403/https://www.health.govt.nz/our-work/diseases-and-conditions/antimicrobial-resistance?mega=Our%20work&amp;title=Antimicrobial%20resistance" class="menu-header">Antimicrobial resistance</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211102161403/https://www.health.govt.nz/our-work/populations/asian-and-migrant-health?mega=Our%20work&amp;title=Asian%20and%20migrant%20health" class="menu-header">Asian and migrant health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211102161403/https://www.health.govt.nz/our-work/border-health?mega=Our%20work&amp;title=Border%20health" class="menu-header">Border health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211102161403/https://www.health.govt.nz/our-work/life-stages/breastfeeding?mega=Our%20work&amp;title=Breastfeeding" class="menu-header">Breastfeeding</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211102161403/https://www.health.govt.nz/our-work/diseases-and-conditions/cancer?mega=Our%20work&amp;title=Cancer" class="menu-header">Cancer</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211102161403/https://www.health.govt.nz/our-work/regulation-health-and-disability-system/certification-health-care-services?mega=Our%20work&amp;title=Certification%20of%20health%20care%20services" class="menu-header">Certification of health care services</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211102161403/https://www.health.govt.nz/our-work/life-stages/child-health?mega=Our%20work&amp;title=Child%20health" class="menu-header">Child health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211102161403/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus?mega=Our%20work&amp;title=COVID-19" class="menu-header">COVID-19 (novel coronavirus)</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211102161403/https://www.health.govt.nz/our-work/diseases-and-conditions/diabetes?mega=Our%20work&amp;title=Diabetes" class="menu-header">Diabetes</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211102161403/https://www.health.govt.nz/our-work/digital-health?mega=Our%20work&amp;title=Digital%20health" class="menu-header">Digital health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211102161403/https://www.health.govt.nz/our-work/disability-services?mega=Our%20work&amp;title=Disability%20services" class="menu-header">Disability services</a>                              </li>
+                                                                </ul>
+                            <ul class="col list-unstyled no-menu-header">
+                                                                                <li>
+                <a href="/web/20211102161403/https://www.health.govt.nz/our-work/diseases-and-conditions?mega=Our%20work&amp;title=Diseases%20and%20conditions" class="menu-header">Diseases and conditions</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211102161403/https://www.health.govt.nz/our-work/hospitals-and-specialist-care/emergency-departments?mega=Our%20work&amp;title=Emergency%20departments" class="menu-header">Emergency departments</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211102161403/https://www.health.govt.nz/our-work/emergency-management?mega=Our%20work&amp;title=Emergency%20management" class="menu-header">Emergency management</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211102161403/https://www.health.govt.nz/our-work/environmental-health?mega=Our%20work&amp;title=Environmental%20health" class="menu-header">Environmental health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211102161403/https://www.health.govt.nz/our-work/preventative-health-wellness/family-violence?mega=Our%20work&amp;title=Family%20violence" class="menu-header">Family violence</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211102161403/https://www.health.govt.nz/our-work/preventative-health-wellness/fluoride-and-oral-health?mega=Our%20work&amp;title=Fluoride%20and%20oral%20health" class="menu-header">Fluoride and oral health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211102161403/https://www.health.govt.nz/our-work/health-identity?mega=Our%20work&amp;title=Health%20identity" class="menu-header">Health identity</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211102161403/https://www.health.govt.nz/our-work/digital-health/digital-health-sector-architecture-standards-and-governance/health-information-standards-0?mega=Our%20work&amp;title=Health%20information%20standards" class="menu-header">Health information standards</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211102161403/https://www.health.govt.nz/our-work/health-infrastructure-unit-hiu?mega=Our%20work&amp;title=Health%20Infrastructure%20Unit" class="menu-header">Health Infrastructure Unit</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211102161403/https://www.health.govt.nz/our-work/life-stages/health-older-people?mega=Our%20work&amp;title=Health%20of%20older%20people" class="menu-header">Health of older people</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211102161403/https://www.health.govt.nz/our-work/health-workforce?mega=Our%20work&amp;title=Health%20workforce" class="menu-header">Health workforce</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211102161403/https://www.health.govt.nz/our-work/hospitals-and-specialist-care?mega=Our%20work&amp;title=Hospitals%20and%20specialist%20care" class="menu-header">Hospitals and specialist care</a>                              </li>
+                                                                </ul>
+                            <ul class="col list-unstyled no-menu-header">
+                                                                                <li>
+                <a href="/web/20211102161403/https://www.health.govt.nz/our-work/preventative-health-wellness/immunisation?mega=Our%20work&amp;title=Immunisation" class="menu-header">Immunisation</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211102161403/https://www.health.govt.nz/our-work/ionising-radiation-safety?mega=Our%20work&amp;title=Ionising%20radiation%20safety" class="menu-header">Ionising radiation safety</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211102161403/https://www.health.govt.nz/our-work/populations/maori-health?mega=Our%20work&amp;title=M%C4%81ori%20health" class="menu-header">Māori health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211102161403/https://www.health.govt.nz/our-work/life-stages/maternity-services?mega=Our%20work&amp;title=Maternity" class="menu-header">Maternity</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211102161403/https://www.health.govt.nz/our-work/regulation-health-and-disability-system/medicinal-cannabis-agency?mega=Our%20work&amp;title=Medicinal%20Cannabis%20Agency" class="menu-header">Medicinal cannabis</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211102161403/https://www.health.govt.nz/our-work/regulation-health-and-disability-system/medicines-control?mega=Our%20work&amp;title=Medicines%20control" class="menu-header">Medicines control</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211102161403/https://www.health.govt.nz/our-work/mental-health-and-addiction?mega=Our%20work&amp;title=Mental%20health%20and%20addiction" class="menu-header">Mental health and addiction</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211102161403/https://www.health.govt.nz/our-work/nursing?mega=Our%20work&amp;title=Nursing" class="menu-header">Nursing</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211102161403/https://www.health.govt.nz/our-work/preventative-health-wellness/nutrition?mega=Our%20work&amp;title=Nutrition" class="menu-header">Nutrition</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211102161403/https://www.health.govt.nz/our-work/preventative-health-wellness/oral-health?mega=Our%20work&amp;title=Oral%20health" class="menu-header">Oral health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211102161403/https://www.health.govt.nz/our-work/hospitals-and-specialist-care/organ-donation-and-transplantation?mega=Our%20work&amp;title=Organ%20donation%20and%20transplantation" class="menu-header">Organ donation and transplantation</a>                              </li>
+                                                                </ul>
+                            <ul class="col list-unstyled no-menu-header">
+                                                                                <li>
+                <a href="/web/20211102161403/https://www.health.govt.nz/our-work/populations/pacific-health?mega=Our%20work&amp;title=Pacific%20health" class="menu-header">Pacific health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211102161403/https://www.health.govt.nz/new-zealand-health-system/pay-equity-settlements?mega=Our%20work&amp;title=Pay%20equity%20settlements" class="menu-header">Pay equity</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211102161403/https://www.health.govt.nz/our-work/preventative-health-wellness/physical-activity?mega=Our%20work&amp;title=Physical%20activity" class="menu-header">Physical activity</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211102161403/https://www.health.govt.nz/our-work/hospitals-and-specialist-care/planned-care-services?mega=Our%20work&amp;title=Planned%20Care%20services" class="menu-header">Planned Care services</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211102161403/https://www.health.govt.nz/our-work/preventative-health-wellness?mega=Our%20work&amp;title=Preventative%20health/wellness" class="menu-header">Preventative health/wellness</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211102161403/https://www.health.govt.nz/our-work/primary-health-care?mega=Our%20work&amp;title=Primary%20health%20care" class="menu-header">Primary health care</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211102161403/https://www.health.govt.nz/our-work/public-health-workforce-development?mega=Our%20work&amp;title=Public%20health%20workforce%20development" class="menu-header">Public health workforce</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211102161403/https://www.health.govt.nz/our-work/regulation-health-and-disability-system?mega=Our%20work&amp;title=Regulation" class="menu-header">Regulation</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211102161403/https://www.health.govt.nz/our-work/preventative-health-wellness/tobacco-control?mega=Our%20work&amp;title=Tobacco%20control" class="menu-header">Tobacco control</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211102161403/https://www.health.govt.nz/our-work/regulation-health-and-disability-system/regulation-vaping-and-smokeless-tobacco-products?mega=Our%20work&amp;title=Vaping%20and%20smokeless%20tobacco%20products" class="menu-header">Vaping &amp; smokeless tobacco</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211102161403/https://www.health.govt.nz/our-work/who-code-nz?mega=Our%20work&amp;title=WHO%20Code%20in%20NZ" class="menu-header">WHO Code in NZ</a>                              </li>
+                      </ul>
+              </div>
+    </div>
+    <div class="feature-links">
+      <a href="/web/20211102161403/https://www.health.govt.nz/our-work?mega=Our%20work&amp;title=A-Z">View the full A-Z</a>    </div>
+  </div>
+</li>
+<li class="dropdown"><a href="/web/20211102161403/https://www.health.govt.nz/nz-health-statistics" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="megamenu-dropdown-778">Health statistics <b class="caret"></b></a>
+    <div id="megamenu-dropdown-778" class="dropdown-menu">
+    <div class="yamm-content">
+      <div class="row">
+                            <div class="col">
+            <h3><a href="/web/20211102161403/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets?mega=Health%20statistics&amp;title=Health%20statistics%20and%20data%20sets" class="menu-header">Statistics by topic</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211102161403/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/cancer-data-and-stats?mega=Health%20statistics&amp;title=Cancer">Cancer</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/diabetes-data-and-stats?mega=Health%20statistics&amp;title=Diabetes">Diabetes</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/mental-health-data-and-stats?mega=Health%20statistics&amp;title=Mental%20health">Mental health</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/maori-health-data-and-stats?mega=Health%20statistics&amp;title=M%C4%81ori%20health">Māori health</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/obesity-statistics?mega=Health%20statistics&amp;title=Obesity">Obesity</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/suicide-data-and-stats?mega=Health%20statistics&amp;title=Suicide">Suicide</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/tobacco-data-and-stats?mega=Health%20statistics&amp;title=Tobacco">Tobacco</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets?mega=Health%20statistics&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211102161403/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys?mega=Health%20statistics&amp;title=National%20collections%20and%20surveys" class="menu-header">About our surveys &amp; data collections</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211102161403/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/surveys/past-surveys/alcohol-and-drug-use-survey?mega=Health%20statistics&amp;title=Alcohol%20%26%20Drug%20Use%20Survey">Alcohol &amp; Drug Use Survey</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/national-collections-annual-maintenance-project?mega=Health%20statistics&amp;title=NCAMP">NCAMP</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/collections/new-zealand-cancer-registry-nzcr?mega=Health%20statistics&amp;title=NZ%20Cancer%20Registry">NZ Cancer Registry</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/surveys/new-zealand-health-survey?mega=Health%20statistics&amp;title=NZ%20Health%20Survey">NZ Health Survey</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/surveys/past-surveys/nutrition-survey?mega=Health%20statistics&amp;title=Nutrition%20Survey">Nutrition Survey</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/collections/primhd-mental-health-data?mega=Health%20statistics&amp;title=PRIMHD">PRIMHD</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys?mega=Health%20statistics&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211102161403/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology?mega=Health%20statistics&amp;title=Classification%20and%20Terminology" class="menu-header">Classification &amp; terminology</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211102161403/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology/using-icd-10-am-achi-acs/coding-queries/coding-query-database?mega=Health%20statistics&amp;title=Coding%20query%20database">Coding query database</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology/using-icd-10-am-achi-acs/courses-clinical-coding?mega=Health%20statistics&amp;title=Courses%20on%20clinical%20coding">Courses on clinical coding</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology/new-zealand-snomed-ct-national-release-centre?mega=Health%20statistics&amp;title=SNOMED%20CT">SNOMED CT</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology/using-icd-10-am-achi-acs?mega=Health%20statistics&amp;title=Using%20ICD-10-AM/ACHI/ACS">Using ICD-10-AM/ACHI/ACS</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology?mega=Health%20statistics&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211102161403/https://www.health.govt.nz/nz-health-statistics/data-references?mega=Health%20statistics&amp;title=Data%20references" class="menu-header">Data references</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211102161403/https://www.health.govt.nz/nz-health-statistics/data-references/code-tables?mega=Health%20statistics&amp;title=Code%20tables">Code tables</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/nz-health-statistics/data-references/data-dictionaries?mega=Health%20statistics&amp;title=Data%20dictionaries">Data dictionaries</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/nz-health-statistics/data-references/diagnosis-related-groups?mega=Health%20statistics&amp;title=Diagnosis-related%20groups">Diagnosis-related groups</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/nz-health-statistics/data-references/code-tables/common-code-tables/domicile-code-table?mega=Health%20statistics&amp;title=Domicile%20code%20table">Domicile code table</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/nz-health-statistics/data-references/mapping-tools?mega=Health%20statistics&amp;title=ICD%20mapping%20tools">ICD mapping tools</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/nz-health-statistics/data-references/weighted-inlier-equivalent-separations?mega=Health%20statistics&amp;title=Weighted%20Inlier%20Equivalent%20Separations">Weighted Inlier Equivalent Separations</a></li>
+                                  <li><a href="/web/20211102161403/https://www.health.govt.nz/nz-health-statistics/data-references?mega=Health%20statistics&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                        </div>
+    </div>
+    <div class="feature-links">
+      <h3 class="sr-only">Other related resources</h3>
+      <a href="/web/20211102161403/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/tier-1-health-statistics-release-calendar?mega=Health%20statistics&amp;title=Tier%201%20calendar">Release calendar for our Tier 1 statistics</a> <a href="/web/20211102161403/https://www.health.govt.nz/nz-health-statistics/about-data-collection?mega=Health%20statistics&amp;title=Enquiries">Data and survey enquiries</a>    </div>
+  </div>
+</li>
+<li class=""><a href="/web/20211102161403/https://www.health.govt.nz/publications" aria-haspopup="false">Publications</a></li>
+<li class=""><a href="/web/20211102161403/https://www.health.govt.nz/about-ministry" aria-haspopup="false">About us</a></li>
+<li class="visible-xs"><a href="/web/20211102161403/https://www.health.govt.nz/contactus" aria-haspopup="false">Contact us</a></li>
+</ul>
+                                  </nav>
+        </div>
+          </div>
+  </header>
+
+  <div class="main-container container">
+    <!-- announcement -->
+        <!-- /announcement -->
+
+    <header role="banner" id="page-header">
+
+          </header> <!-- /#page-header -->
+
+    <div class="row">
+
+      <section class="col-sm-12">
+                        <a id="main-content"></a>
+                                                                            <div class="breadcrumbs">
+            <ul><li><a href="/web/20211102161403/https://www.health.govt.nz/">Home</a></li><li><a href="/web/20211102161403/https://www.health.govt.nz/our-work">Our work</a></li><li><a href="/web/20211102161403/https://www.health.govt.nz/our-work/diseases-and-conditions">Diseases and conditions</a></li><li><a href="/web/20211102161403/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished" data-is-top-level="1" title="">COVID-19</a></li><li><a href="/web/20211102161403/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics" class="menu-node-unpublished menu-node-unpublished">Data and statistics</a></li><li><span class="current-breadcrumb">Vaccine data</span></li></ul>          </div>
+
+
+
+          <div class="region region-content">
+    <section id="block-system-main" class="block block-system clearfix">
+
+
+  <div class="bootstrap-threecol-stacked">
+
+      <div class="row"> <!-- @TODO: Add extra classes -->
+      <div class="panel-panel left col-xs-12 col-md-3 col-lg-3"><div class="panel-pane pane-block pane-menu-block-1 odd pane-top-link">
+
+        <span class="top-link"><a href="/web/20211102161403/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished active-trail" data-is-top-level="1">COVID-19</a></span>
+
+
+  <div class="pane-content">
+        <div class="menu-block-wrapper menu-block-1 menu-name-main-menu parent-mlid-1445 menu-level-2">
+  <ul class="menu nav"><li class="first collapsed menu-mlid-10163 health-advice depth-4"><a href="/web/20211102161403/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-health-advice-public" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished">Health advice</a></li>
+<li class="collapsed menu-mlid-10630 covid-19-vaccines- depth-4 section-overview hide-children"><a href="/web/20211102161403/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-vaccines" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished" data-is-top-level="1" title="">COVID-19 vaccines </a></li>
+<li class="collapsed menu-mlid-9997 health-professionals depth-4"><a href="/web/20211102161403/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-information-health-professionals" class="menu-node-unpublished menu-node-unpublished">Health professionals</a></li>
+<li class="collapsed menu-mlid-10019 specific-audiences depth-4"><a href="/web/20211102161403/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-information-specific-audiences" class="menu-node-unpublished">Specific audiences</a></li>
+<li class="expanded active-trail menu-mlid-10096 data-and-statistics depth-4"><a href="/web/20211102161403/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics" class="menu-node-unpublished menu-node-unpublished active-trail">Data and statistics</a><ul class="menu nav"><li class="first leaf menu-mlid-10062 current-cases depth-5 same-level-as-node"><a href="/web/20211102161403/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-current-cases" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Current cases</a></li>
+<li class="leaf menu-mlid-10146 case-demographics depth-5 same-level-as-node"><a href="/web/20211102161403/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-case-demographics">Case demographics</a></li>
+<li class="leaf menu-mlid-10097 source-of-cases depth-5 same-level-as-node"><a href="/web/20211102161403/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-source-cases" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Source of cases</a></li>
+<li class="leaf menu-mlid-10119 testing-for-covid-19 depth-5 same-level-as-node"><a href="/web/20211102161403/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/testing-covid-19" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Testing for COVID-19</a></li>
+<li class="leaf menu-mlid-10371 nz-covid-tracer-app-data depth-5 same-level-as-node"><a href="/web/20211102161403/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-nz-covid-tracer-app-data" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">NZ COVID Tracer app data</a></li>
+<li class="expanded active-trail active menu-mlid-10584 active vaccine-data depth-5 same-level-as-node"><a href="/web/20211102161403/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished active-trail active">Vaccine data</a><ul class="menu nav"><li class="first leaf menu-mlid-10867 covid-19-vaccination-uptake-rates-across-nz depth-6"><a href="/web/20211102161403/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-across-nz" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">COVID-19 Vaccination uptake rates across NZ</a></li>
+<li class="leaf menu-mlid-10868 covid-19-vaccination-uptake-rates---māori depth-6"><a href="/web/20211102161403/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-maori-communities-across-nz" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">COVID-19 Vaccination uptake rates - Māori</a></li>
+<li class="last leaf menu-mlid-10869 covid-19-vaccination-uptake-rates---pacific depth-6"><a href="/web/20211102161403/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-pacific-communities-across-nz" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">COVID-19 Vaccination uptake rates - Pacific</a></li>
+</ul></li>
+<li class="last leaf menu-mlid-10404 data-resources depth-5 same-level-as-node"><a href="/web/20211102161403/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-data-resources" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Data resources</a></li>
+</ul></li>
+<li class="collapsed menu-mlid-10369 response-planning depth-4"><a href="/web/20211102161403/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-response-planning" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished" data-is-top-level="1" title="">Response planning</a></li>
+<li class="collapsed menu-mlid-10015 resources-and-tools depth-4"><a href="/web/20211102161403/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-resources-and-tools" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Resources and tools</a></li>
+<li class="last leaf menu-mlid-10004 news-and-media depth-4 section-overview hide-children"><a href="/web/20211102161403/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-news-and-media-updates" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">News and media</a></li>
+</ul></div>
+  </div>
+
+
+  </div>
+</div>      <div class="panel-panel middle col-xs-12 col-md-9 col-lg-9"><div class="panel-pane pane-page-title even">
+
+
+
+  <div class="pane-content">
+    <span id="skip-content" tabindex="-1"></span>    <h1>COVID-19: Vaccine data</h1>
+  </div>
+
+
+  </div>
+<div class="panel-pane pane-node-content odd">
+
+
+
+  <div class="pane-content">
+        <article id="node-12052" class="node node-page node-sticky view-mode-full clearfix" about="/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" typeof="sioc:Item foaf:Document">
+    <header>
+            <span property="dc:title" content="COVID-19: Vaccine data" class="rdf-meta element-hidden"></span>      </header>
+    <div class="field field-name-field-intro-text field-type-text-long field-label-hidden"><div class="field-items"><div class="field-item even"><p class="intro-text">Data and statistics about the rollout of COVID-19 vaccines in New Zealand.</p></div></div></div><div class="field field-name-body field-type-text-with-summary field-label-hidden"><div class="field-items"><div class="field-item even" property="content:encoded"><p>On this page:</p>
+
+<ul>
+	<li><a href="#daily">Daily updates</a>
+
+	<ul>
+		<li><a href="#total-vaccinations">Total vaccinations</a></li>
+		<li><a href="#ethnicity">Vaccinations by ethnicity</a></li>
+		<li><a href="#90pct">Vaccinations to 90% by DHB</a></li>
+	</ul>
+	</li>
+	<li><a href="#weekly-updates">Weekly updates</a>
+	<ul>
+		<li><a href="#model">Vaccinations against plan</a></li>
+		<li><a href="#uptake">Vaccinations uptake</a></li>
+		<li><a href="#by-day">Vaccinations by day</a></li>
+		<li><a href="#location">Vaccinations by DHB</a></li>
+		<li><a href="#group">Vaccinations by group</a></li>
+		<li><a href="#by_soh">Stock on hand</a></li>
+		<li><a href="#age">Vaccinations by age</a></li>
+		<li><a href="#workforce">Trained vaccinator and active vaccinator</a></li>
+		<li><a href="#group">Vaccinations by group</a></li>
+		<li><a href="#download">Details of vaccination&nbsp;data</a></li>
+	</ul>
+	</li>
+	<li><a href="#adverse-events">Adverse events from immunisations</a></li>
+</ul>
+
+<hr/><!--daily-->
+<h2><a id="daily" name="daily"></a>COVID-19 vaccinations: daily updates</h2>
+
+<div class="well well-sm">
+<p style="margin-top: 0"><strong>Data in this section is as at 11:59pm 01 November 2021 and is updated daily.</strong></p>
+</div>
+
+<h3><a id="total-vaccinations" name="total-vaccinations"></a>Total Vaccinations</h3>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">&nbsp;</th>
+			<th scope="col" style="text-align:right">Vaccinations yesterday</th>
+			<th scope="col" style="text-align:right">Cumulative total</th>
+			<th scope="col" style="text-align:right">Eligible population vaccinated %</th>
+			<th scope="col" style="text-align:right">Total population vaccinated %</th>
+			<th scope="col" style="text-align:right">Vaccinated or booked</th>
+			<th scope="col" style="text-align:right">Eligible vaccinated or booked %</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">First dose</th>
+			<td style="text-align:right">7,187</td>
+			<td style="text-align:right">3,716,740</td>
+			<td style="text-align:right">88%</td>
+			<td style="text-align:right">74%</td>
+			<td style="text-align:right">3,727,996</td>
+			<td style="text-align:right">89%</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Second dose</th>
+			<td style="text-align:right">20,286</td>
+			<td style="text-align:right">3,179,817</td>
+			<td style="text-align:right">76%</td>
+			<td style="text-align:right">64%</td>
+			<td style="text-align:right">3,389,251</td>
+			<td style="text-align:right">81%</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total doses</strong></th>
+			<td style="text-align:right"><strong>27,473</strong></td>
+			<td style="text-align:right"><strong>6,896,557</strong></td>
+		</tr>
+	</tbody>
+</table>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Total vaccinations" class="img-responsive" height="900" src="/web/20211102161403im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake-summary.png" width="5340"/></figure>
+
+<h5>Definitions</h5>
+
+<ul>
+	<li><strong>Cumulative total:</strong>&nbsp;All vaccinations that have been administered and entered into the COVID-19 Immunisation Register up until midnight of the night before the data is published.</li>
+	<li><strong>Eligible population vaccinated %:</strong>&nbsp;Vaccinations administered divided by HSU population estimates for the eligible population (12+).</li>
+	<li><strong>Total population vaccinated %:</strong>&nbsp;Vaccinations administered divided by HSU population estimates for the total population (0+).</li>
+	<li><strong>Vaccinated or booked:</strong>&nbsp;Count of individuals who have either received their vaccination or have booked via Book My Vaccine to receive a vaccination.</li>
+	<li><strong>Eligible vaccinated or booked %:</strong>&nbsp;Count of individuals who have either received their vaccination or have booked via Book My Vaccine to receive a vaccination divided by HSU population estimates for the eligible population (12+).</li>
+</ul>
+
+<p>HSU population estimates are available in the downloadable spreadsheet at the bottom of the page. Throughout the rest of this sheet doses per 1,000 are based on eligible (12+) population.</p>
+
+<p>Bookings are only counted if the site is using Book My Vaccine. Bookings made through other Patient Management Systems are not counted.</p>
+
+<hr/>
+<h3><a id="by_eth" name="ethnicity"></a>Cumulative vaccinations by ethnicity</h3>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">Ethnicity *</th>
+			<th scope="col" style="text-align:right">First dose administered</th>
+			<th scope="col" style="text-align:right">First doses per 1,000 people</th>
+			<th scope="col" style="text-align:right">Second dose administered</th>
+			<th scope="col" style="text-align:right">Second doses per 1,000 people</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">Māori</th>
+			<td style="text-align:right">412,747</td>
+			<td style="text-align:right">723</td>
+			<td style="text-align:right">303,845</td>
+			<td style="text-align:right">532</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Pacific Peoples</th>
+			<td style="text-align:right">244,702</td>
+			<td style="text-align:right">854</td>
+			<td style="text-align:right">198,665</td>
+			<td style="text-align:right">693</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Asian</th>
+			<td style="text-align:right">608,411</td>
+			<td style="text-align:right">&gt;950</td>
+			<td style="text-align:right">546,028</td>
+			<td style="text-align:right">912</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">European / Other</th>
+			<td style="text-align:right">2,416,830</td>
+			<td style="text-align:right">885</td>
+			<td style="text-align:right">2,102,592</td>
+			<td style="text-align:right">770</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Unknown</th>
+			<td style="text-align:right">34,050</td>
+			<td style="text-align:right">-</td>
+			<td style="text-align:right">28,687</td>
+			<td style="text-align:right">-</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total</strong></th>
+			<td style="text-align:right"><strong>3,716,740</strong></td>
+			<td style="text-align:right"><strong>883</strong></td>
+			<td style="text-align:right"><strong>3,179,817</strong></td>
+			<td style="text-align:right"><strong>755</strong></td>
+		</tr>
+	</tbody>
+</table>
+
+<p><strong>*</strong> The prioritised ethnicity classification system allocates each person to a single ethnic group, based on the ethnic groups they identify with. Where people identify with more than one group, they are assigned in this order of priority: Māori, Pacific Peoples, Asian, and European/Other. So, if a person identifies as being Māori and New Zealand European, the person is counted as Māori. See <a href="/web/20211102161403/https://www.health.govt.nz/publication/hiso-100012017-ethnicity-data-protocols">Ethnicity Data Protocols</a> for further information.</p>
+
+<p>Ethnicity breakdown by DHB of residence is available in the downloadable spreadsheet at the bottom of the page.</p>
+
+<hr/>
+<h3><a id="90pct" name="90pct"></a>Vaccinations to 90% by DHB</h3>
+
+<h4><a id="90pct all ethnicities" name="90pct all ethnicities"></a>All Ethnicities</h4>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">&nbsp;</th>
+			<th scope="col" style="text-align:right">First doses</th>
+			<th scope="col" style="text-align:right">First doses %</th>
+			<th scope="col" style="text-align:right">First doses to 90%</th>
+			<th scope="col" style="text-align:right">Second doses</th>
+			<th scope="col" style="text-align:right">Second doses %</th>
+			<th scope="col" style="text-align:right">Second doses to 90%</th>
+			<th scope="col" style="text-align:right">Population</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">Northland</th>
+			<td style="text-align:right">128,068</td>
+			<td style="text-align:right">79%</td>
+			<td style="text-align:right">17,120</td>
+			<td style="text-align:right">104,560</td>
+			<td style="text-align:right">65%</td>
+			<td style="text-align:right">40,628</td>
+			<td style="text-align:right">161,320</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waitemata</th>
+			<td style="text-align:right">480,711</td>
+			<td style="text-align:right">91%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">426,209</td>
+			<td style="text-align:right">81%</td>
+			<td style="text-align:right">47,269</td>
+			<td style="text-align:right">526,087</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Auckland</th>
+			<td style="text-align:right">399,036</td>
+			<td style="text-align:right">94%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">360,143</td>
+			<td style="text-align:right">85%</td>
+			<td style="text-align:right">21,419</td>
+			<td style="text-align:right">423,958</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Counties Manukau</th>
+			<td style="text-align:right">430,545</td>
+			<td style="text-align:right">89%</td>
+			<td style="text-align:right">3,951</td>
+			<td style="text-align:right">374,881</td>
+			<td style="text-align:right">78%</td>
+			<td style="text-align:right">59,615</td>
+			<td style="text-align:right">482,773</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waikato</th>
+			<td style="text-align:right">310,407</td>
+			<td style="text-align:right">87%</td>
+			<td style="text-align:right">11,051</td>
+			<td style="text-align:right">259,826</td>
+			<td style="text-align:right">73%</td>
+			<td style="text-align:right">61,632</td>
+			<td style="text-align:right">357,176</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Lakes</th>
+			<td style="text-align:right">76,421</td>
+			<td style="text-align:right">81%</td>
+			<td style="text-align:right">8,556</td>
+			<td style="text-align:right">62,426</td>
+			<td style="text-align:right">66%</td>
+			<td style="text-align:right">22,551</td>
+			<td style="text-align:right">94,419</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Bay of Plenty</th>
+			<td style="text-align:right">180,801</td>
+			<td style="text-align:right">83%</td>
+			<td style="text-align:right">14,446</td>
+			<td style="text-align:right">148,017</td>
+			<td style="text-align:right">68%</td>
+			<td style="text-align:right">47,230</td>
+			<td style="text-align:right">216,941</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Tairawhiti</th>
+			<td style="text-align:right">32,971</td>
+			<td style="text-align:right">79%</td>
+			<td style="text-align:right">4,798</td>
+			<td style="text-align:right">26,826</td>
+			<td style="text-align:right">64%</td>
+			<td style="text-align:right">10,942</td>
+			<td style="text-align:right">41,965</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Taranaki</th>
+			<td style="text-align:right">86,191</td>
+			<td style="text-align:right">84%</td>
+			<td style="text-align:right">5,741</td>
+			<td style="text-align:right">68,071</td>
+			<td style="text-align:right">67%</td>
+			<td style="text-align:right">23,861</td>
+			<td style="text-align:right">102,147</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hawkes Bay</th>
+			<td style="text-align:right">123,446</td>
+			<td style="text-align:right">85%</td>
+			<td style="text-align:right">7,568</td>
+			<td style="text-align:right">104,470</td>
+			<td style="text-align:right">72%</td>
+			<td style="text-align:right">26,544</td>
+			<td style="text-align:right">145,571</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">MidCentral</th>
+			<td style="text-align:right">131,740</td>
+			<td style="text-align:right">86%</td>
+			<td style="text-align:right">5,332</td>
+			<td style="text-align:right">110,879</td>
+			<td style="text-align:right">73%</td>
+			<td style="text-align:right">26,193</td>
+			<td style="text-align:right">152,302</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Whanganui</th>
+			<td style="text-align:right">46,207</td>
+			<td style="text-align:right">81%</td>
+			<td style="text-align:right">5,315</td>
+			<td style="text-align:right">39,038</td>
+			<td style="text-align:right">68%</td>
+			<td style="text-align:right">12,484</td>
+			<td style="text-align:right">57,247</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Capital and Coast</th>
+			<td style="text-align:right">250,231</td>
+			<td style="text-align:right">92%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">219,122</td>
+			<td style="text-align:right">81%</td>
+			<td style="text-align:right">24,935</td>
+			<td style="text-align:right">271,174</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hutt Valley</th>
+			<td style="text-align:right">114,892</td>
+			<td style="text-align:right">88%</td>
+			<td style="text-align:right">2,323</td>
+			<td style="text-align:right">97,676</td>
+			<td style="text-align:right">75%</td>
+			<td style="text-align:right">19,539</td>
+			<td style="text-align:right">130,239</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Wairarapa</th>
+			<td style="text-align:right">35,511</td>
+			<td style="text-align:right">86%</td>
+			<td style="text-align:right">1,773</td>
+			<td style="text-align:right">30,174</td>
+			<td style="text-align:right">73%</td>
+			<td style="text-align:right">7,110</td>
+			<td style="text-align:right">41,427</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Nelson Marlborough</th>
+			<td style="text-align:right">118,070</td>
+			<td style="text-align:right">87%</td>
+			<td style="text-align:right">4,099</td>
+			<td style="text-align:right">103,539</td>
+			<td style="text-align:right">76%</td>
+			<td style="text-align:right">18,630</td>
+			<td style="text-align:right">135,743</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">West Coast</th>
+			<td style="text-align:right">22,822</td>
+			<td style="text-align:right">82%</td>
+			<td style="text-align:right">2,293</td>
+			<td style="text-align:right">18,817</td>
+			<td style="text-align:right">67%</td>
+			<td style="text-align:right">6,298</td>
+			<td style="text-align:right">27,906</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Canterbury</th>
+			<td style="text-align:right">441,511</td>
+			<td style="text-align:right">91%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">359,535</td>
+			<td style="text-align:right">74%</td>
+			<td style="text-align:right">75,066</td>
+			<td style="text-align:right">482,890</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">South Canterbury</th>
+			<td style="text-align:right">45,654</td>
+			<td style="text-align:right">87%</td>
+			<td style="text-align:right">1,672</td>
+			<td style="text-align:right">39,525</td>
+			<td style="text-align:right">75%</td>
+			<td style="text-align:right">7,801</td>
+			<td style="text-align:right">52,584</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Southern</th>
+			<td style="text-align:right">259,459</td>
+			<td style="text-align:right">90%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">224,409</td>
+			<td style="text-align:right">78%</td>
+			<td style="text-align:right">34,804</td>
+			<td style="text-align:right">288,015</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Overseas / Unknown</th>
+			<td style="text-align:right">2,046</td>
+			<td style="text-align:right">12%</td>
+			<td style="text-align:right">13,410</td>
+			<td style="text-align:right">1,674</td>
+			<td style="text-align:right">10%</td>
+			<td style="text-align:right">13,782</td>
+			<td style="text-align:right">17,173</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total</strong></th>
+			<td style="text-align:right"><strong>3,716,740</strong></td>
+			<td style="text-align:right"><strong>88%</strong></td>
+			<td style="text-align:right"><strong>71,411</strong></td>
+			<td style="text-align:right"><strong>3,179,817</strong></td>
+			<td style="text-align:right"><strong>76%</strong></td>
+			<td style="text-align:right"><strong>608,334</strong></td>
+			<td style="text-align:right"><strong>4,209,057</strong></td>
+		</tr>
+	</tbody>
+</table>
+
+<p>First/second doses % are the number of first/second doses administered divided by the eligible population. First/second doses to 90% are the number of doses required to reach 90% of the eligible population. For these two measures, the national total may not be the sum of DHB measures.</p>
+
+<h4><a id="90pct Māori" name="90pct Māori">Māori</a></h4>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">&nbsp;</th>
+			<th scope="col" style="text-align:right">First doses</th>
+			<th scope="col" style="text-align:right">First doses %</th>
+			<th scope="col" style="text-align:right">First doses to 90%</th>
+			<th scope="col" style="text-align:right">Second doses</th>
+			<th scope="col" style="text-align:right">Second doses %</th>
+			<th scope="col" style="text-align:right">Second doses to 90%</th>
+			<th scope="col" style="text-align:right">Population</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">Northland</th>
+			<td style="text-align:right">34,064</td>
+			<td style="text-align:right">67%</td>
+			<td style="text-align:right">11,375</td>
+			<td style="text-align:right">24,006</td>
+			<td style="text-align:right">48%</td>
+			<td style="text-align:right">21,433</td>
+			<td style="text-align:right">50,488</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waitemata</th>
+			<td style="text-align:right">33,056</td>
+			<td style="text-align:right">80%</td>
+			<td style="text-align:right">3,946</td>
+			<td style="text-align:right">25,842</td>
+			<td style="text-align:right">63%</td>
+			<td style="text-align:right">11,160</td>
+			<td style="text-align:right">41,113</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Auckland</th>
+			<td style="text-align:right">23,065</td>
+			<td style="text-align:right">83%</td>
+			<td style="text-align:right">1,948</td>
+			<td style="text-align:right">18,433</td>
+			<td style="text-align:right">66%</td>
+			<td style="text-align:right">6,580</td>
+			<td style="text-align:right">27,792</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Counties Manukau</th>
+			<td style="text-align:right">47,018</td>
+			<td style="text-align:right">74%</td>
+			<td style="text-align:right">10,126</td>
+			<td style="text-align:right">34,549</td>
+			<td style="text-align:right">54%</td>
+			<td style="text-align:right">22,595</td>
+			<td style="text-align:right">63,493</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waikato</th>
+			<td style="text-align:right">51,119</td>
+			<td style="text-align:right">73%</td>
+			<td style="text-align:right">11,617</td>
+			<td style="text-align:right">36,412</td>
+			<td style="text-align:right">52%</td>
+			<td style="text-align:right">26,324</td>
+			<td style="text-align:right">69,707</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Lakes</th>
+			<td style="text-align:right">19,919</td>
+			<td style="text-align:right">66%</td>
+			<td style="text-align:right">7,158</td>
+			<td style="text-align:right">14,278</td>
+			<td style="text-align:right">47%</td>
+			<td style="text-align:right">12,798</td>
+			<td style="text-align:right">30,085</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Bay of Plenty</th>
+			<td style="text-align:right">30,864</td>
+			<td style="text-align:right">65%</td>
+			<td style="text-align:right">12,097</td>
+			<td style="text-align:right">21,992</td>
+			<td style="text-align:right">46%</td>
+			<td style="text-align:right">20,969</td>
+			<td style="text-align:right">47,734</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Tairawhiti</th>
+			<td style="text-align:right">13,586</td>
+			<td style="text-align:right">68%</td>
+			<td style="text-align:right">4,269</td>
+			<td style="text-align:right">10,031</td>
+			<td style="text-align:right">51%</td>
+			<td style="text-align:right">7,824</td>
+			<td style="text-align:right">19,839</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Taranaki</th>
+			<td style="text-align:right">10,937</td>
+			<td style="text-align:right">69%</td>
+			<td style="text-align:right">3,377</td>
+			<td style="text-align:right">7,388</td>
+			<td style="text-align:right">46%</td>
+			<td style="text-align:right">6,926</td>
+			<td style="text-align:right">15,904</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hawkes Bay</th>
+			<td style="text-align:right">23,102</td>
+			<td style="text-align:right">68%</td>
+			<td style="text-align:right">7,551</td>
+			<td style="text-align:right">16,756</td>
+			<td style="text-align:right">49%</td>
+			<td style="text-align:right">13,897</td>
+			<td style="text-align:right">34,059</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">MidCentral</th>
+			<td style="text-align:right">17,470</td>
+			<td style="text-align:right">72%</td>
+			<td style="text-align:right">4,332</td>
+			<td style="text-align:right">12,745</td>
+			<td style="text-align:right">53%</td>
+			<td style="text-align:right">9,058</td>
+			<td style="text-align:right">24,225</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Whanganui</th>
+			<td style="text-align:right">8,855</td>
+			<td style="text-align:right">66%</td>
+			<td style="text-align:right">3,306</td>
+			<td style="text-align:right">6,651</td>
+			<td style="text-align:right">49%</td>
+			<td style="text-align:right">5,510</td>
+			<td style="text-align:right">13,512</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Capital and Coast</th>
+			<td style="text-align:right">21,633</td>
+			<td style="text-align:right">80%</td>
+			<td style="text-align:right">2,637</td>
+			<td style="text-align:right">17,011</td>
+			<td style="text-align:right">63%</td>
+			<td style="text-align:right">7,259</td>
+			<td style="text-align:right">26,967</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hutt Valley</th>
+			<td style="text-align:right">14,101</td>
+			<td style="text-align:right">74%</td>
+			<td style="text-align:right">3,110</td>
+			<td style="text-align:right">10,596</td>
+			<td style="text-align:right">55%</td>
+			<td style="text-align:right">6,615</td>
+			<td style="text-align:right">19,123</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Wairarapa</th>
+			<td style="text-align:right">4,461</td>
+			<td style="text-align:right">71%</td>
+			<td style="text-align:right">1,211</td>
+			<td style="text-align:right">3,217</td>
+			<td style="text-align:right">51%</td>
+			<td style="text-align:right">2,455</td>
+			<td style="text-align:right">6,302</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Nelson Marlborough</th>
+			<td style="text-align:right">7,990</td>
+			<td style="text-align:right">71%</td>
+			<td style="text-align:right">2,133</td>
+			<td style="text-align:right">6,081</td>
+			<td style="text-align:right">54%</td>
+			<td style="text-align:right">4,042</td>
+			<td style="text-align:right">11,248</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">West Coast</th>
+			<td style="text-align:right">2,023</td>
+			<td style="text-align:right">73%</td>
+			<td style="text-align:right">466</td>
+			<td style="text-align:right">1,490</td>
+			<td style="text-align:right">54%</td>
+			<td style="text-align:right">998</td>
+			<td style="text-align:right">2,765</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Canterbury</th>
+			<td style="text-align:right">28,761</td>
+			<td style="text-align:right">78%</td>
+			<td style="text-align:right">4,511</td>
+			<td style="text-align:right">20,408</td>
+			<td style="text-align:right">55%</td>
+			<td style="text-align:right">12,864</td>
+			<td style="text-align:right">36,969</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">South Canterbury</th>
+			<td style="text-align:right">2,475</td>
+			<td style="text-align:right">72%</td>
+			<td style="text-align:right">610</td>
+			<td style="text-align:right">1,853</td>
+			<td style="text-align:right">54%</td>
+			<td style="text-align:right">1,232</td>
+			<td style="text-align:right">3,428</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Southern</th>
+			<td style="text-align:right">18,059</td>
+			<td style="text-align:right">76%</td>
+			<td style="text-align:right">3,222</td>
+			<td style="text-align:right">13,968</td>
+			<td style="text-align:right">59%</td>
+			<td style="text-align:right">7,313</td>
+			<td style="text-align:right">23,646</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Overseas / Unknown</th>
+			<td style="text-align:right">189</td>
+			<td style="text-align:right">7%</td>
+			<td style="text-align:right">2,199</td>
+			<td style="text-align:right">138</td>
+			<td style="text-align:right">5%</td>
+			<td style="text-align:right">2,250</td>
+			<td style="text-align:right">2,653</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total</strong></th>
+			<td style="text-align:right"><strong>412,747</strong></td>
+			<td style="text-align:right"><strong>72%</strong></td>
+			<td style="text-align:right"><strong>101,200</strong></td>
+			<td style="text-align:right"><strong>303,845</strong></td>
+			<td style="text-align:right"><strong>53%</strong></td>
+			<td style="text-align:right"><strong>210,102</strong></td>
+			<td style="text-align:right"><strong>571,052</strong></td>
+		</tr>
+	</tbody>
+</table>
+
+<h4><a id="90pct Pacific Peoples" name="90pct Pacific Peoples"></a>Pacific Peoples</h4>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">&nbsp;</th>
+			<th scope="col" style="text-align:right">First doses</th>
+			<th scope="col" style="text-align:right">First doses %</th>
+			<th scope="col" style="text-align:right">First doses to 90%</th>
+			<th scope="col" style="text-align:right">Second doses</th>
+			<th scope="col" style="text-align:right">Second doses %</th>
+			<th scope="col" style="text-align:right">Second doses to 90%</th>
+			<th scope="col" style="text-align:right">Population</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">Northland</th>
+			<td style="text-align:right">2,379</td>
+			<td style="text-align:right">81%</td>
+			<td style="text-align:right">262</td>
+			<td style="text-align:right">1,767</td>
+			<td style="text-align:right">60%</td>
+			<td style="text-align:right">874</td>
+			<td style="text-align:right">2,934</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waitemata</th>
+			<td style="text-align:right">32,225</td>
+			<td style="text-align:right">86%</td>
+			<td style="text-align:right">1,591</td>
+			<td style="text-align:right">26,382</td>
+			<td style="text-align:right">70%</td>
+			<td style="text-align:right">7,434</td>
+			<td style="text-align:right">37,573</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Auckland</th>
+			<td style="text-align:right">39,737</td>
+			<td style="text-align:right">85%</td>
+			<td style="text-align:right">2,442</td>
+			<td style="text-align:right">32,629</td>
+			<td style="text-align:right">70%</td>
+			<td style="text-align:right">9,550</td>
+			<td style="text-align:right">46,866</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Counties Manukau</th>
+			<td style="text-align:right">97,480</td>
+			<td style="text-align:right">84%</td>
+			<td style="text-align:right">7,368</td>
+			<td style="text-align:right">79,490</td>
+			<td style="text-align:right">68%</td>
+			<td style="text-align:right">25,358</td>
+			<td style="text-align:right">116,498</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waikato</th>
+			<td style="text-align:right">9,181</td>
+			<td style="text-align:right">86%</td>
+			<td style="text-align:right">433</td>
+			<td style="text-align:right">7,380</td>
+			<td style="text-align:right">69%</td>
+			<td style="text-align:right">2,234</td>
+			<td style="text-align:right">10,682</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Lakes</th>
+			<td style="text-align:right">1,829</td>
+			<td style="text-align:right">80%</td>
+			<td style="text-align:right">228</td>
+			<td style="text-align:right">1,457</td>
+			<td style="text-align:right">64%</td>
+			<td style="text-align:right">600</td>
+			<td style="text-align:right">2,286</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Bay of Plenty</th>
+			<td style="text-align:right">4,054</td>
+			<td style="text-align:right">&gt;95%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">3,188</td>
+			<td style="text-align:right">87%</td>
+			<td style="text-align:right">123</td>
+			<td style="text-align:right">3,679</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Tairawhiti</th>
+			<td style="text-align:right">879</td>
+			<td style="text-align:right">91%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">686</td>
+			<td style="text-align:right">71%</td>
+			<td style="text-align:right">182</td>
+			<td style="text-align:right">965</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Taranaki</th>
+			<td style="text-align:right">1,063</td>
+			<td style="text-align:right">84%</td>
+			<td style="text-align:right">80</td>
+			<td style="text-align:right">805</td>
+			<td style="text-align:right">63%</td>
+			<td style="text-align:right">338</td>
+			<td style="text-align:right">1,270</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hawkes Bay</th>
+			<td style="text-align:right">5,136</td>
+			<td style="text-align:right">&gt;95%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">4,227</td>
+			<td style="text-align:right">84%</td>
+			<td style="text-align:right">291</td>
+			<td style="text-align:right">5,020</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">MidCentral</th>
+			<td style="text-align:right">3,794</td>
+			<td style="text-align:right">85%</td>
+			<td style="text-align:right">227</td>
+			<td style="text-align:right">2,963</td>
+			<td style="text-align:right">66%</td>
+			<td style="text-align:right">1,058</td>
+			<td style="text-align:right">4,468</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Whanganui</th>
+			<td style="text-align:right">1,050</td>
+			<td style="text-align:right">76%</td>
+			<td style="text-align:right">193</td>
+			<td style="text-align:right">841</td>
+			<td style="text-align:right">61%</td>
+			<td style="text-align:right">402</td>
+			<td style="text-align:right">1,381</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Capital and Coast</th>
+			<td style="text-align:right">15,714</td>
+			<td style="text-align:right">82%</td>
+			<td style="text-align:right">1,545</td>
+			<td style="text-align:right">12,716</td>
+			<td style="text-align:right">66%</td>
+			<td style="text-align:right">4,543</td>
+			<td style="text-align:right">19,177</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hutt Valley</th>
+			<td style="text-align:right">7,996</td>
+			<td style="text-align:right">81%</td>
+			<td style="text-align:right">909</td>
+			<td style="text-align:right">6,444</td>
+			<td style="text-align:right">65%</td>
+			<td style="text-align:right">2,461</td>
+			<td style="text-align:right">9,894</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Wairarapa</th>
+			<td style="text-align:right">694</td>
+			<td style="text-align:right">83%</td>
+			<td style="text-align:right">59</td>
+			<td style="text-align:right">569</td>
+			<td style="text-align:right">68%</td>
+			<td style="text-align:right">184</td>
+			<td style="text-align:right">837</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Nelson Marlborough</th>
+			<td style="text-align:right">3,630</td>
+			<td style="text-align:right">&gt;95%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">3,178</td>
+			<td style="text-align:right">&gt;95%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">2,115</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">West Coast</th>
+			<td style="text-align:right">232</td>
+			<td style="text-align:right">82%</td>
+			<td style="text-align:right">22</td>
+			<td style="text-align:right">181</td>
+			<td style="text-align:right">64%</td>
+			<td style="text-align:right">73</td>
+			<td style="text-align:right">282</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Canterbury</th>
+			<td style="text-align:right">10,870</td>
+			<td style="text-align:right">85%</td>
+			<td style="text-align:right">593</td>
+			<td style="text-align:right">8,254</td>
+			<td style="text-align:right">65%</td>
+			<td style="text-align:right">3,209</td>
+			<td style="text-align:right">12,737</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">South Canterbury</th>
+			<td style="text-align:right">798</td>
+			<td style="text-align:right">&gt;95%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">639</td>
+			<td style="text-align:right">76%</td>
+			<td style="text-align:right">114</td>
+			<td style="text-align:right">837</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Southern</th>
+			<td style="text-align:right">5,622</td>
+			<td style="text-align:right">93%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">4,572</td>
+			<td style="text-align:right">76%</td>
+			<td style="text-align:right">856</td>
+			<td style="text-align:right">6,031</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Overseas / Unknown</th>
+			<td style="text-align:right">339</td>
+			<td style="text-align:right">30%</td>
+			<td style="text-align:right">695</td>
+			<td style="text-align:right">297</td>
+			<td style="text-align:right">26%</td>
+			<td style="text-align:right">737</td>
+			<td style="text-align:right">1,149</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total</strong></th>
+			<td style="text-align:right"><strong>244,702</strong></td>
+			<td style="text-align:right"><strong>85%</strong></td>
+			<td style="text-align:right"><strong>13,311</strong></td>
+			<td style="text-align:right"><strong>198,665</strong></td>
+			<td style="text-align:right"><strong>69%</strong></td>
+			<td style="text-align:right"><strong>59,348</strong></td>
+			<td style="text-align:right"><strong>286,681</strong></td>
+		</tr>
+	</tbody>
+</table>
+<!--daily_end-->
+
+<hr/>
+<h2><a id="weekly-updates" name="weekly-updates"></a>COVID-19 vaccinations: weekly updates</h2>
+
+<div class="well well-sm">
+<p style="margin-top: 0"><strong>Data in this section is as at 11:59pm 26 October 2021 and is updated weekly on Wednesdays.</strong></p>
+</div>
+
+<h3><a id="model" model="" name="id="></a>Cumulative vaccinations</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccination doses administered compared to plan doses" class="img-responsive" height="830" src="/web/20211102161403im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/vaccineplanmodel_13.png" width="1780"/></figure>
+
+<p>Production plan figures are the volumes agreed with DHBs and national providers for expected vaccinations. These figures have been matched with expected supply. Detailed plans are available in the Excel file at the bottom of this page.</p>
+
+<p>The Stock received figures are the cumulative supply of doses to date.</p>
+
+<p>DHB capacity plans for the remainder of the year are undergoing review.</p>
+
+<hr/><!--
+<h3><a id="model" model="" name="id="></a>Cumulative vaccinations for last 6 weeks</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccination doses administered compared to plan doses - 6wks" class="img-responsive" height="830" src="/vaccineplanmodel_wks.png" width="1780" /></figure>
+
+<hr />
+-->
+<h3><a id="uptake" name="uptake"></a>Vaccine uptake</h3>
+
+<p>Maps and data related to uptake rates of the COVID-19 vaccine across the country are available on the pages linked below. These show&nbsp;vaccination records aggregated by area of residence for all New Zealand residents, Māori communities, and Pacific communities.</p>
+
+<ul>
+	<li><a href="/web/20211102161403/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-across-nz">COVID-19 Vaccination uptake rates across NZ</a></li>
+	<li><a href="/web/20211102161403/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-maori-communities-across-nz">COVID-19 Vaccination uptake rates within Māori communities across NZ</a></li>
+	<li><a href="/web/20211102161403/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-pacific-communities-across-nz">COVID-19 Vaccination uptake rates within Pacific communities across NZ</a></li>
+</ul>
+
+<h4><a id="uptake" name="uptake"></a>Vaccine uptake per rate ratio (unadjusted) Māori and Pacific compared with Non-Māori non-Pacific</h4>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine Uptake per 1,000 (HSU) Rate Ratio, Showing Prioritised Ethnicity, vs Non-Māori Non-Pacific, By Age Band" class="img-responsive" height="830" src="/web/20211102161403im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_mix_8.png" width="1780"/></figure>
+
+<p>In the Chart above, rate ratios tell us the rate Māori or Pacific People per population are being vaccinated compared with non-Māori non-Pacific. This comparison can be split by age group.</p>
+
+<ul>
+	<li>A rate of one means the groups being compared are being vaccinated at the same rate.</li>
+	<li>A rate over one means Māori (or Pacific) are being vaccinated at a higher rate than non-Māori non-Pacific.</li>
+	<li>A rate under one means Māori (or Pacific) are being vaccinated at a lower rate than non-Māori non-Pacific.</li>
+</ul>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<td colspan="2" style="border-top: 0 !important; border-bottom-color: #FDD6AF !important; border-right: 0 !important;">&nbsp;</td>
+			<th colspan="6" id="ac1">Māori</th>
+			<th colspan="6" id="ac8">Pacific Peoples</th>
+		</tr>
+		<tr>
+			<th id="ar1">DHB</th>
+			<th>Dose number</th>
+			<th headers="ac1" id="ac2">65+</th>
+			<th headers="ac1" id="ac3">50-64</th>
+			<th headers="ac1" id="ac4">35-49</th>
+			<th headers="ac1" id="ac5">20-34</th>
+			<th headers="ac1" id="ac6">12-19</th>
+			<th headers="ac1" id="ac7">All ages</th>
+			<th headers="ac8" id="ac9">65+</th>
+			<th headers="ac8" id="ac10">50-64</th>
+			<th headers="ac8" id="ac11">35-49</th>
+			<th headers="ac8" id="ac12">20-34</th>
+			<th headers="ac8" id="ac13">12-19</th>
+			<th headers="ac8" id="ac14">All ages</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th headers="ar1" id="ar2" rowspan="2">National</th>
+			<th headers="ar1 ar2" id="ar3">Dose 1</th>
+			<td headers="ar1 ar2 ar3 ac1 ac2" style="background-color:green; color: #FFF;"><strong>0.99</strong></td>
+			<td headers="ar1 ar2 ar3 ac1 ac3" style="background-color:mediumseagreen"><strong>0.93</strong></td>
+			<td headers="ar1 ar2 ar3 ac1 ac4" style="background-color:yellow"><strong>0.79</strong></td>
+			<td headers="ar1 ar2 ar3 ac1 ac5" style="background-color:coral"><strong>0.67</strong></td>
+			<td headers="ar1 ar2 ar3 ac1 ac6" style="background-color:orange"><strong>0.71</strong></td>
+			<td headers="ar1 ar2 ar3 ac1 ac7" style="background-color:yellow"><strong>0.77</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac9" style="background-color:mediumseagreen"><strong>0.94</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac10" style="background-color:green; color: #FFF;"><strong>0.99</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac11" style="background-color:green; color: #FFF;"><strong>0.98</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac12" style="background-color:lightgreen"><strong>0.89</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac13" style="background-color:mediumseagreen"><strong>0.90</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac14" style="background-color:mediumseagreen"><strong>0.93</strong></td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar2" id="ar4">Dose 2</th>
+			<td headers="ar1 ar2 ar4 ac1 ac2" style="background-color:green; color: #FFF;"><strong>0.96</strong></td>
+			<td headers="ar1 ar2 ar4 ac1 ac3" style="background-color:lightgreen"><strong>0.87</strong></td>
+			<td headers="ar1 ar2 ar4 ac1 ac4" style="background-color:coral"><strong>0.68</strong></td>
+			<td headers="ar1 ar2 ar4 ac1 ac5" style="background-color:crimson; color: #FFF;"><strong>0.51</strong></td>
+			<td headers="ar1 ar2 ar4 ac1 ac6" style="background-color:crimson; color: #FFF;"><strong>0.57</strong></td>
+			<td headers="ar1 ar2 ar4 ac1 ac7" style="background-color:coral"><strong>0.65</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac9" style="background-color:mediumseagreen"><strong>0.92</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac10" style="background-color:green; color: #FFF;"><strong>0.99</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac11" style="background-color:green; color: #FFF;"><strong>0.97</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac12" style="background-color:palegreen"><strong>0.82</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac13" style="background-color:lightgreen"><strong>0.86</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac14" style="background-color:lightgreen"><strong>0.86</strong></td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar5" rowspan="2">Northland</th>
+			<th headers="ar1 ar5" id="ar6">Dose 1</th>
+			<td headers="ar1 ar5 ar6 ac1 ac2" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar5 ar6 ac1 ac3" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar5 ar6 ac1 ac4" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar5 ar6 ac1 ac5" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar5 ar6 ac1 ac6" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar5 ar6 ac1 ac7" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar5 ar6 ac8 ac9" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar5 ar6 ac8 ac10" style="background-color:green; color: #FFF;">1.06</td>
+			<td headers="ar1 ar5 ar6 ac8 ac11" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar5 ar6 ac8 ac12" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar5 ar6 ac8 ac13" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar5 ar6 ac8 ac14" style="background-color:mediumseagreen">0.94</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar5" id="ar7">Dose 2</th>
+			<td headers="ar1 ar5 ar7 ac1 ac2" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar5 ar7 ac1 ac3" style="background-color:lightgreen">0.87</td>
+			<td headers="ar1 ar5 ar7 ac1 ac4" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar5 ar7 ac1 ac5" style="background-color:crimson; color: #FFF;">0.49</td>
+			<td headers="ar1 ar5 ar7 ac1 ac6" style="background-color:crimson; color: #FFF;">0.59</td>
+			<td headers="ar1 ar5 ar7 ac1 ac7" style="background-color:tomato">0.63</td>
+			<td headers="ar1 ar5 ar7 ac8 ac9" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar5 ar7 ac8 ac10" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar5 ar7 ac8 ac11" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar5 ar7 ac8 ac12" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar5 ar7 ac8 ac13" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar5 ar7 ac8 ac14" style="background-color:palegreen">0.80</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar8" rowspan="2">Auckland Metro</th>
+			<th headers="ar1 ar8" id="ar9">Dose 1</th>
+			<td headers="ar1 ar8 ar9 ac1 ac2" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar8 ar9 ac1 ac3" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar8 ar9 ac1 ac4" style="background-color:palegreen">0.81</td>
+			<td headers="ar1 ar8 ar9 ac1 ac5" style="background-color:orange">0.72</td>
+			<td headers="ar1 ar8 ar9 ac1 ac6" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar8 ar9 ac1 ac7" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar8 ar9 ac8 ac9" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar8 ar9 ac8 ac10" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar8 ar9 ac8 ac11" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar8 ar9 ac8 ac12" style="background-color:palegreen">0.81</td>
+			<td headers="ar1 ar8 ar9 ac8 ac13" style="background-color:palegreen">0.84</td>
+			<td headers="ar1 ar8 ar9 ac8 ac14" style="background-color:lightgreen">0.88</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar8" id="ar10">Dose 2</th>
+			<td headers="ar1 ar8 ar10 ac1 ac2" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar8 ar10 ac1 ac3" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar8 ar10 ac1 ac4" style="background-color:coral">0.69</td>
+			<td headers="ar1 ar8 ar10 ac1 ac5" style="background-color:crimson; color: #FFF;">0.54</td>
+			<td headers="ar1 ar8 ar10 ac1 ac6" style="background-color:crimson; color: #FFF;">0.59</td>
+			<td headers="ar1 ar8 ar10 ac1 ac7" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar8 ar10 ac8 ac9" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar8 ar10 ac8 ac10" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar8 ar10 ac8 ac11" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar8 ar10 ac8 ac12" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar8 ar10 ac8 ac13" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar8 ar10 ac8 ac14" style="background-color:yellow">0.78</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar11" rowspan="2">Waikato</th>
+			<th headers="ar1 ar11" id="ar12">Dose 1</th>
+			<td headers="ar1 ar11 ar12 ac1 ac2" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar11 ar12 ac1 ac3" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar11 ar12 ac1 ac4" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar11 ar12 ac1 ac5" style="background-color:coral">0.69</td>
+			<td headers="ar1 ar11 ar12 ac1 ac6" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar11 ar12 ac1 ac7" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar11 ar12 ac8 ac9" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar11 ar12 ac8 ac10" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar11 ar12 ac8 ac11" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar11 ar12 ac8 ac12" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar11 ar12 ac8 ac13" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar11 ar12 ac8 ac14" style="background-color:mediumseagreen">0.94</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar11" id="ar13">Dose 2</th>
+			<td headers="ar1 ar11 ar13 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar11 ar13 ac1 ac3" style="background-color:lightgreen">0.87</td>
+			<td headers="ar1 ar11 ar13 ac1 ac4" style="background-color:coral">0.68</td>
+			<td headers="ar1 ar11 ar13 ac1 ac5" style="background-color:crimson; color: #FFF;">0.50</td>
+			<td headers="ar1 ar11 ar13 ac1 ac6" style="background-color:crimson; color: #FFF;">0.57</td>
+			<td headers="ar1 ar11 ar13 ac1 ac7" style="background-color:tomato">0.64</td>
+			<td headers="ar1 ar11 ar13 ac8 ac9" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar11 ar13 ac8 ac10" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar11 ar13 ac8 ac11" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar11 ar13 ac8 ac12" style="background-color:palegreen">0.84</td>
+			<td headers="ar1 ar11 ar13 ac8 ac13" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar11 ar13 ac8 ac14" style="background-color:lightgreen">0.87</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar14" rowspan="2">Bay of Plenty</th>
+			<th headers="ar1 ar14" id="ar15">Dose 1</th>
+			<td headers="ar1 ar14 ar15 ac1 ac2" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar14 ar15 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar14 ar15 ac1 ac4" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar14 ar15 ac1 ac5" style="background-color:crimson; color: #FFF;">0.57</td>
+			<td headers="ar1 ar14 ar15 ac1 ac6" style="background-color:tomato">0.64</td>
+			<td headers="ar1 ar14 ar15 ac1 ac7" style="background-color:orange">0.72</td>
+			<td headers="ar1 ar14 ar15 ac8 ac9" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar14 ar15 ac8 ac10" style="background-color:green; color: #FFF;">1.09</td>
+			<td headers="ar1 ar14 ar15 ac8 ac11" style="background-color:green; color: #FFF;">1.47</td>
+			<td headers="ar1 ar14 ar15 ac8 ac12" style="background-color:green; color: #FFF;">1.52</td>
+			<td headers="ar1 ar14 ar15 ac8 ac13" style="background-color:lightgreen">0.87</td>
+			<td headers="ar1 ar14 ar15 ac8 ac14" style="background-color:green; color: #FFF;">1.23</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar14" id="ar16">Dose 2</th>
+			<td headers="ar1 ar14 ar16 ac1 ac2" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar14 ar16 ac1 ac3" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar14 ar16 ac1 ac4" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar14 ar16 ac1 ac5" style="background-color:crimson; color: #FFF;">0.46</td>
+			<td headers="ar1 ar14 ar16 ac1 ac6" style="background-color:crimson; color: #FFF;">0.54</td>
+			<td headers="ar1 ar14 ar16 ac1 ac7" style="background-color:tomato">0.60</td>
+			<td headers="ar1 ar14 ar16 ac8 ac9" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar14 ar16 ac8 ac10" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar14 ar16 ac8 ac11" style="background-color:green; color: #FFF;">1.60</td>
+			<td headers="ar1 ar14 ar16 ac8 ac12" style="background-color:green; color: #FFF;">1.78</td>
+			<td headers="ar1 ar14 ar16 ac8 ac13" style="background-color:yellow">0.77</td>
+			<td headers="ar1 ar14 ar16 ac8 ac14" style="background-color:green; color: #FFF;">1.15</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar17" rowspan="2">Tairawhiti</th>
+			<th headers="ar1 ar17" id="ar18">Dose 1</th>
+			<td headers="ar1 ar17 ar18 ac1 ac2" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar17 ar18 ac1 ac3" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar17 ar18 ac1 ac4" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar17 ar18 ac1 ac5" style="background-color:tomato">0.62</td>
+			<td headers="ar1 ar17 ar18 ac1 ac6" style="background-color:coral">0.69</td>
+			<td headers="ar1 ar17 ar18 ac1 ac7" style="background-color:yellow">0.76</td>
+			<td headers="ar1 ar17 ar18 ac8 ac9" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar17 ar18 ac8 ac10" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar17 ar18 ac8 ac11" style="background-color:green; color: #FFF;">1.10</td>
+			<td headers="ar1 ar17 ar18 ac8 ac12" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar17 ar18 ac8 ac13" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar17 ar18 ac8 ac14" style="background-color:green; color: #FFF;">1.01</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar17" id="ar19">Dose 2</th>
+			<td headers="ar1 ar17 ar19 ac1 ac2" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar17 ar19 ac1 ac3" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar17 ar19 ac1 ac4" style="background-color:coral">0.68</td>
+			<td headers="ar1 ar17 ar19 ac1 ac5" style="background-color:crimson; color: #FFF;">0.49</td>
+			<td headers="ar1 ar17 ar19 ac1 ac6" style="background-color:crimson; color: #FFF;">0.55</td>
+			<td headers="ar1 ar17 ar19 ac1 ac7" style="background-color:tomato">0.64</td>
+			<td headers="ar1 ar17 ar19 ac8 ac9" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar17 ar19 ac8 ac10" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar17 ar19 ac8 ac11" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar17 ar19 ac8 ac12" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar17 ar19 ac8 ac13" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar17 ar19 ac8 ac14" style="background-color:mediumseagreen">0.90</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar20" rowspan="2">Lakes</th>
+			<th headers="ar1 ar20" id="ar21">Dose 1</th>
+			<td headers="ar1 ar20 ar21 ac1 ac2" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar20 ar21 ac1 ac3" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar20 ar21 ac1 ac4" style="background-color:yellow">0.76</td>
+			<td headers="ar1 ar20 ar21 ac1 ac5" style="background-color:crimson; color: #FFF;">0.58</td>
+			<td headers="ar1 ar20 ar21 ac1 ac6" style="background-color:coral">0.65</td>
+			<td headers="ar1 ar20 ar21 ac1 ac7" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar20 ar21 ac8 ac9" style="background-color:green; color: #FFF;">1.06</td>
+			<td headers="ar1 ar20 ar21 ac8 ac10" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar20 ar21 ac8 ac11" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar20 ar21 ac8 ac12" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar20 ar21 ac8 ac13" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar20 ar21 ac8 ac14" style="background-color:mediumseagreen">0.90</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar20" id="ar22">Dose 2</th>
+			<td headers="ar1 ar20 ar22 ac1 ac2" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar20 ar22 ac1 ac3" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar20 ar22 ac1 ac4" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar20 ar22 ac1 ac5" style="background-color:crimson; color: #FFF;">0.44</td>
+			<td headers="ar1 ar20 ar22 ac1 ac6" style="background-color:crimson; color: #FFF;">0.53</td>
+			<td headers="ar1 ar20 ar22 ac1 ac7" style="background-color:tomato">0.61</td>
+			<td headers="ar1 ar20 ar22 ac8 ac9" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar20 ar22 ac8 ac10" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar20 ar22 ac8 ac11" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar20 ar22 ac8 ac12" style="background-color:palegreen">0.83</td>
+			<td headers="ar1 ar20 ar22 ac8 ac13" style="background-color:lightgreen">0.86</td>
+			<td headers="ar1 ar20 ar22 ac8 ac14" style="background-color:palegreen">0.83</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar23" rowspan="2">Taranaki</th>
+			<th headers="ar1 ar23" id="ar24">Dose 1</th>
+			<td headers="ar1 ar23 ar24 ac1 ac2" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar23 ar24 ac1 ac3" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar23 ar24 ac1 ac4" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar23 ar24 ac1 ac5" style="background-color:coral">0.68</td>
+			<td headers="ar1 ar23 ar24 ac1 ac6" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar23 ar24 ac1 ac7" style="background-color:yellow">0.77</td>
+			<td headers="ar1 ar23 ar24 ac8 ac9" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar23 ar24 ac8 ac10" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar23 ar24 ac8 ac11" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar23 ar24 ac8 ac12" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar23 ar24 ac8 ac13" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar23 ar24 ac8 ac14" style="background-color:mediumseagreen">0.94</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar23" id="ar25">Dose 2</th>
+			<td headers="ar1 ar23 ar25 ac1 ac2" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar23 ar25 ac1 ac3" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar23 ar25 ac1 ac4" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar23 ar25 ac1 ac5" style="background-color:crimson; color: #FFF;">0.52</td>
+			<td headers="ar1 ar23 ar25 ac1 ac6" style="background-color:crimson; color: #FFF;">0.56</td>
+			<td headers="ar1 ar23 ar25 ac1 ac7" style="background-color:tomato">0.64</td>
+			<td headers="ar1 ar23 ar25 ac8 ac9" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar23 ar25 ac8 ac10" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar23 ar25 ac8 ac11" style="background-color:green; color: #FFF;">1.21</td>
+			<td headers="ar1 ar23 ar25 ac8 ac12" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar23 ar25 ac8 ac13" style="background-color:lightgreen">0.87</td>
+			<td headers="ar1 ar23 ar25 ac8 ac14" style="background-color:lightgreen">0.89</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar26" rowspan="2">Whanganui</th>
+			<th headers="ar1 ar26" id="ar27">Dose 1</th>
+			<td headers="ar1 ar26 ar27 ac1 ac2" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar26 ar27 ac1 ac3" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar26 ar27 ac1 ac4" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar26 ar27 ac1 ac5" style="background-color:coral">0.65</td>
+			<td headers="ar1 ar26 ar27 ac1 ac6" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar26 ar27 ac1 ac7" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar26 ar27 ac8 ac9" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar26 ar27 ac8 ac10" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar26 ar27 ac8 ac11" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar26 ar27 ac8 ac12" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar26 ar27 ac8 ac13" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar26 ar27 ac8 ac14" style="background-color:lightgreen">0.87</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar26" id="ar28">Dose 2</th>
+			<td headers="ar1 ar26 ar28 ac1 ac2" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar26 ar28 ac1 ac3" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar26 ar28 ac1 ac4" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar26 ar28 ac1 ac5" style="background-color:crimson; color: #FFF;">0.51</td>
+			<td headers="ar1 ar26 ar28 ac1 ac6" style="background-color:tomato">0.60</td>
+			<td headers="ar1 ar26 ar28 ac1 ac7" style="background-color:coral">0.65</td>
+			<td headers="ar1 ar26 ar28 ac8 ac9" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar26 ar28 ac8 ac10" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar26 ar28 ac8 ac11" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar26 ar28 ac8 ac12" style="background-color:palegreen">0.83</td>
+			<td headers="ar1 ar26 ar28 ac8 ac13" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar26 ar28 ac8 ac14" style="background-color:palegreen">0.80</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar29" rowspan="2">Hawke&#39;s Bay</th>
+			<th headers="ar1 ar29" id="ar30">Dose 1</th>
+			<td headers="ar1 ar29 ar30 ac1 ac2" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar29 ar30 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar29 ar30 ac1 ac4" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar29 ar30 ac1 ac5" style="background-color:crimson; color: #FFF;">0.59</td>
+			<td headers="ar1 ar29 ar30 ac1 ac6" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar29 ar30 ac1 ac7" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar29 ar30 ac8 ac9" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar29 ar30 ac8 ac10" style="background-color:green; color: #FFF;">1.05</td>
+			<td headers="ar1 ar29 ar30 ac8 ac11" style="background-color:green; color: #FFF;">1.42</td>
+			<td headers="ar1 ar29 ar30 ac8 ac12" style="background-color:green; color: #FFF;">1.32</td>
+			<td headers="ar1 ar29 ar30 ac8 ac13" style="background-color:lightgreen">0.88</td>
+			<td headers="ar1 ar29 ar30 ac8 ac14" style="background-color:green; color: #FFF;">1.16</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar29" id="ar31">Dose 2</th>
+			<td headers="ar1 ar29 ar31 ac1 ac2" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar29 ar31 ac1 ac3" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar29 ar31 ac1 ac4" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar29 ar31 ac1 ac5" style="background-color:crimson; color: #FFF;">0.47</td>
+			<td headers="ar1 ar29 ar31 ac1 ac6" style="background-color:crimson; color: #FFF;">0.57</td>
+			<td headers="ar1 ar29 ar31 ac1 ac7" style="background-color:tomato">0.61</td>
+			<td headers="ar1 ar29 ar31 ac8 ac9" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar29 ar31 ac8 ac10" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar29 ar31 ac8 ac11" style="background-color:green; color: #FFF;">1.48</td>
+			<td headers="ar1 ar29 ar31 ac8 ac12" style="background-color:green; color: #FFF;">1.48</td>
+			<td headers="ar1 ar29 ar31 ac8 ac13" style="background-color:lightgreen">0.86</td>
+			<td headers="ar1 ar29 ar31 ac8 ac14" style="background-color:green; color: #FFF;">1.10</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar32" rowspan="2">MidCentral</th>
+			<th headers="ar1 ar32" id="ar33">Dose 1</th>
+			<td headers="ar1 ar32 ar33 ac1 ac2" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar32 ar33 ac1 ac3" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar32 ar33 ac1 ac4" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar32 ar33 ac1 ac5" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar32 ar33 ac1 ac6" style="background-color:orange">0.72</td>
+			<td headers="ar1 ar32 ar33 ac1 ac7" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar32 ar33 ac8 ac9" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar32 ar33 ac8 ac10" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar32 ar33 ac8 ac11" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar32 ar33 ac8 ac12" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar32 ar33 ac8 ac13" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar32 ar33 ac8 ac14" style="background-color:mediumseagreen">0.94</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar32" id="ar34">Dose 2</th>
+			<td headers="ar1 ar32 ar34 ac1 ac2" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar32 ar34 ac1 ac3" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar32 ar34 ac1 ac4" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar32 ar34 ac1 ac5" style="background-color:crimson; color: #FFF;">0.58</td>
+			<td headers="ar1 ar32 ar34 ac1 ac6" style="background-color:tomato">0.60</td>
+			<td headers="ar1 ar32 ar34 ac1 ac7" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar32 ar34 ac8 ac9" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar32 ar34 ac8 ac10" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar32 ar34 ac8 ac11" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar32 ar34 ac8 ac12" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar32 ar34 ac8 ac13" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar32 ar34 ac8 ac14" style="background-color:lightgreen">0.85</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar35" rowspan="2">Wairarapa</th>
+			<th headers="ar1 ar35" id="ar36">Dose 1</th>
+			<td headers="ar1 ar35 ar36 ac1 ac2" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar35 ar36 ac1 ac3" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar35 ar36 ac1 ac4" style="background-color:palegreen">0.84</td>
+			<td headers="ar1 ar35 ar36 ac1 ac5" style="background-color:orange">0.72</td>
+			<td headers="ar1 ar35 ar36 ac1 ac6" style="background-color:yellow">0.77</td>
+			<td headers="ar1 ar35 ar36 ac1 ac7" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar35 ar36 ac8 ac9" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar35 ar36 ac8 ac10" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar35 ar36 ac8 ac11" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar35 ar36 ac8 ac12" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar35 ar36 ac8 ac13" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar35 ar36 ac8 ac14" style="background-color:mediumseagreen">0.92</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar35" id="ar37">Dose 2</th>
+			<td headers="ar1 ar35 ar37 ac1 ac2" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar35 ar37 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar35 ar37 ac1 ac4" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar35 ar37 ac1 ac5" style="background-color:crimson; color: #FFF;">0.55</td>
+			<td headers="ar1 ar35 ar37 ac1 ac6" style="background-color:tomato">0.63</td>
+			<td headers="ar1 ar35 ar37 ac1 ac7" style="background-color:tomato">0.64</td>
+			<td headers="ar1 ar35 ar37 ac8 ac9" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar35 ar37 ac8 ac10" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar35 ar37 ac8 ac11" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar35 ar37 ac8 ac12" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar35 ar37 ac8 ac13" style="background-color:palegreen">0.84</td>
+			<td headers="ar1 ar35 ar37 ac8 ac14" style="background-color:lightgreen">0.86</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar38" rowspan="2">Capital &amp; Coast and Hutt Valley</th>
+			<th headers="ar1 ar38" id="ar39">Dose 1</th>
+			<td headers="ar1 ar38 ar39 ac1 ac2" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar38 ar39 ac1 ac3" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar38 ar39 ac1 ac4" style="background-color:palegreen">0.83</td>
+			<td headers="ar1 ar38 ar39 ac1 ac5" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar38 ar39 ac1 ac6" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar38 ar39 ac1 ac7" style="background-color:palegreen">0.81</td>
+			<td headers="ar1 ar38 ar39 ac8 ac9" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar38 ar39 ac8 ac10" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar38 ar39 ac8 ac11" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar38 ar39 ac8 ac12" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar38 ar39 ac8 ac13" style="background-color:palegreen">0.84</td>
+			<td headers="ar1 ar38 ar39 ac8 ac14" style="background-color:lightgreen">0.86</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar38" id="ar40">Dose 2</th>
+			<td headers="ar1 ar38 ar40 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar38 ar40 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar38 ar40 ac1 ac4" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar38 ar40 ac1 ac5" style="background-color:tomato">0.63</td>
+			<td headers="ar1 ar38 ar40 ac1 ac6" style="background-color:tomato">0.62</td>
+			<td headers="ar1 ar38 ar40 ac1 ac7" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar38 ar40 ac8 ac9" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar38 ar40 ac8 ac10" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar38 ar40 ac8 ac11" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar38 ar40 ac8 ac12" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar38 ar40 ac8 ac13" style="background-color:yellow">0.76</td>
+			<td headers="ar1 ar38 ar40 ac8 ac14" style="background-color:palegreen">0.80</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar41" rowspan="2">Nelson Marlborough</th>
+			<th headers="ar1 ar41" id="ar42">Dose 1</th>
+			<td headers="ar1 ar41 ar42 ac1 ac2" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar41 ar42 ac1 ac3" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar41 ar42 ac1 ac4" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar41 ar42 ac1 ac5" style="background-color:coral">0.69</td>
+			<td headers="ar1 ar41 ar42 ac1 ac6" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar41 ar42 ac1 ac7" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar41 ar42 ac8 ac9" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar41 ar42 ac8 ac10" style="background-color:green; color: #FFF;">1.28</td>
+			<td headers="ar1 ar41 ar42 ac8 ac11" style="background-color:green; color: #FFF;">2.45</td>
+			<td headers="ar1 ar41 ar42 ac8 ac12" style="background-color:green; color: #FFF;">2.89</td>
+			<td headers="ar1 ar41 ar42 ac8 ac13" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar41 ar42 ac8 ac14" style="background-color:green; color: #FFF;">1.97</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar41" id="ar43">Dose 2</th>
+			<td headers="ar1 ar41 ar43 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar41 ar43 ac1 ac3" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar41 ar43 ac1 ac4" style="background-color:orange">0.72</td>
+			<td headers="ar1 ar41 ar43 ac1 ac5" style="background-color:crimson; color: #FFF;">0.57</td>
+			<td headers="ar1 ar41 ar43 ac1 ac6" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar41 ar43 ac1 ac7" style="background-color:coral">0.69</td>
+			<td headers="ar1 ar41 ar43 ac8 ac9" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar41 ar43 ac8 ac10" style="background-color:green; color: #FFF;">1.26</td>
+			<td headers="ar1 ar41 ar43 ac8 ac11" style="background-color:green; color: #FFF;">2.57</td>
+			<td headers="ar1 ar41 ar43 ac8 ac12" style="background-color:green; color: #FFF;">3.47</td>
+			<td headers="ar1 ar41 ar43 ac8 ac13" style="background-color:green; color: #FFF;">1.05</td>
+			<td headers="ar1 ar41 ar43 ac8 ac14" style="background-color:green; color: #FFF;">1.95</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar44" rowspan="2">West Coast</th>
+			<th headers="ar1 ar44" id="ar45">Dose 1</th>
+			<td headers="ar1 ar44 ar45 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar44 ar45 ac1 ac3" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar44 ar45 ac1 ac4" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar44 ar45 ac1 ac5" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar44 ar45 ac1 ac6" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar44 ar45 ac1 ac7" style="background-color:lightgreen">0.86</td>
+			<td headers="ar1 ar44 ar45 ac8 ac9" style="background-color:green; color: #FFF;">1.33</td>
+			<td headers="ar1 ar44 ar45 ac8 ac10" style="background-color:green; color: #FFF;">1.06</td>
+			<td headers="ar1 ar44 ar45 ac8 ac11" style="background-color:green; color: #FFF;">1.07</td>
+			<td headers="ar1 ar44 ar45 ac8 ac12" style="background-color:green; color: #FFF;">1.24</td>
+			<td headers="ar1 ar44 ar45 ac8 ac13" style="background-color:palegreen">0.83</td>
+			<td headers="ar1 ar44 ar45 ac8 ac14" style="background-color:green; color: #FFF;">0.99</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar44" id="ar46">Dose 2</th>
+			<td headers="ar1 ar44 ar46 ac1 ac2" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar44 ar46 ac1 ac3" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar44 ar46 ac1 ac4" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar44 ar46 ac1 ac5" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar44 ar46 ac1 ac6" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar44 ar46 ac1 ac7" style="background-color:yellow">0.76</td>
+			<td headers="ar1 ar44 ar46 ac8 ac9" style="background-color:green; color: #FFF;">1.33</td>
+			<td headers="ar1 ar44 ar46 ac8 ac10" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar44 ar46 ac8 ac11" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar44 ar46 ac8 ac12" style="background-color:green; color: #FFF;">1.57</td>
+			<td headers="ar1 ar44 ar46 ac8 ac13" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar44 ar46 ac8 ac14" style="background-color:mediumseagreen">0.91</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar47" rowspan="2">Canterbury</th>
+			<th headers="ar1 ar47" id="ar48">Dose 1</th>
+			<td headers="ar1 ar47 ar48 ac1 ac2" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar47 ar48 ac1 ac3" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar47 ar48 ac1 ac4" style="background-color:palegreen">0.83</td>
+			<td headers="ar1 ar47 ar48 ac1 ac5" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar47 ar48 ac1 ac6" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar47 ar48 ac1 ac7" style="background-color:palegreen">0.81</td>
+			<td headers="ar1 ar47 ar48 ac8 ac9" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar47 ar48 ac8 ac10" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar47 ar48 ac8 ac11" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar47 ar48 ac8 ac12" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar47 ar48 ac8 ac13" style="background-color:lightgreen">0.88</td>
+			<td headers="ar1 ar47 ar48 ac8 ac14" style="background-color:lightgreen">0.89</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar47" id="ar49">Dose 2</th>
+			<td headers="ar1 ar47 ar49 ac1 ac2" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar47 ar49 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar47 ar49 ac1 ac4" style="background-color:yellow">0.77</td>
+			<td headers="ar1 ar47 ar49 ac1 ac5" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar47 ar49 ac1 ac6" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar47 ar49 ac1 ac7" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar47 ar49 ac8 ac9" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar47 ar49 ac8 ac10" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar47 ar49 ac8 ac11" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar47 ar49 ac8 ac12" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar47 ar49 ac8 ac13" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar47 ar49 ac8 ac14" style="background-color:lightgreen">0.85</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar50" rowspan="2">South Canterbury</th>
+			<th headers="ar1 ar50" id="ar51">Dose 1</th>
+			<td headers="ar1 ar50 ar51 ac1 ac2" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar50 ar51 ac1 ac3" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar50 ar51 ac1 ac4" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar50 ar51 ac1 ac5" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar50 ar51 ac1 ac6" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar50 ar51 ac1 ac7" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar50 ar51 ac8 ac9" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar50 ar51 ac8 ac10" style="background-color:green; color: #FFF;">1.09</td>
+			<td headers="ar1 ar50 ar51 ac8 ac11" style="background-color:green; color: #FFF;">1.18</td>
+			<td headers="ar1 ar50 ar51 ac8 ac12" style="background-color:green; color: #FFF;">1.23</td>
+			<td headers="ar1 ar50 ar51 ac8 ac13" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar50 ar51 ac8 ac14" style="background-color:green; color: #FFF;">1.06</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar50" id="ar52">Dose 2</th>
+			<td headers="ar1 ar50 ar52 ac1 ac2" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar50 ar52 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar50 ar52 ac1 ac4" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar50 ar52 ac1 ac5" style="background-color:tomato">0.63</td>
+			<td headers="ar1 ar50 ar52 ac1 ac6" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar50 ar52 ac1 ac7" style="background-color:coral">0.69</td>
+			<td headers="ar1 ar50 ar52 ac8 ac9" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar50 ar52 ac8 ac10" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar50 ar52 ac8 ac11" style="background-color:green; color: #FFF;">1.09</td>
+			<td headers="ar1 ar50 ar52 ac8 ac12" style="background-color:green; color: #FFF;">1.15</td>
+			<td headers="ar1 ar50 ar52 ac8 ac13" style="background-color:green; color: #FFF;">1.05</td>
+			<td headers="ar1 ar50 ar52 ac8 ac14" style="background-color:lightgreen">0.89</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar53" rowspan="2">Southern</th>
+			<th headers="ar1 ar53" id="ar54">Dose 1</th>
+			<td headers="ar1 ar53 ar54 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar53 ar54 ac1 ac3" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar53 ar54 ac1 ac4" style="background-color:palegreen">0.83</td>
+			<td headers="ar1 ar53 ar54 ac1 ac5" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar53 ar54 ac1 ac6" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar53 ar54 ac1 ac7" style="background-color:palegreen">0.81</td>
+			<td headers="ar1 ar53 ar54 ac8 ac9" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar53 ar54 ac8 ac10" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar53 ar54 ac8 ac11" style="background-color:green; color: #FFF;">1.07</td>
+			<td headers="ar1 ar53 ar54 ac8 ac12" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar53 ar54 ac8 ac13" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar53 ar54 ac8 ac14" style="background-color:green; color: #FFF;">1.01</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar53" id="ar55">Dose 2</th>
+			<td headers="ar1 ar53 ar55 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar53 ar55 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar53 ar55 ac1 ac4" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar53 ar55 ac1 ac5" style="background-color:coral">0.66</td>
+			<td headers="ar1 ar53 ar55 ac1 ac6" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar53 ar55 ac1 ac7" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar53 ar55 ac8 ac9" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar53 ar55 ac8 ac10" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar53 ar55 ac8 ac11" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar53 ar55 ac8 ac12" style="background-color:green; color: #FFF;">1.05</td>
+			<td headers="ar1 ar53 ar55 ac8 ac13" style="background-color:lightgreen">0.87</td>
+			<td headers="ar1 ar53 ar55 ac8 ac14" style="background-color:mediumseagreen">0.93</td>
+		</tr>
+	</tbody>
+</table>
+
+<p>This table shows the rate of doses administered (per 1,000 population) to Māori or Pacific Peoples, relative to the rate of doses for Non-Māori and Non-Pacific groups. Less than one means the group is receiving a lower proportion of doses than would be expected if equity is being achieved. More than one means they are receiving a higher proportion of doses than would be expected if equity is being achieved. Exactly one means doses administered are in line with their proportion of population.</p>
+
+<ul>
+	<li><a download="" href="/web/20211102161403/https://www.health.govt.nz/system/files/documents/pages/rateratioexplainer_2.docx">Rate Ratio Explainer (Word, 434 KB)</a></li>
+</ul>
+
+<p>At all ages the size (weightings) of the age groups becomes a major contributing factor to comparative ratios, which is why the all ages (12+) figure may not appear to be in line with the age splits.</p>
+
+<h4><a id="uptake" name="uptake"></a>Vaccine uptake per 1,000 people by ethnicity</h4>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine uptake per 1,000 people by ethnicity" class="img-responsive" height="830" src="/web/20211102161403im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_eth_8.png" width="1780"/></figure>
+
+<h4><a id="uptake" name="uptake"></a>Vaccine uptake per 1,000 people by age band</h4>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine uptake per 1,000 people by age band" class="img-responsive" height="1030" src="/web/20211102161403im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_age_9.png" width="1780"/></figure>
+
+<h4><a id="uptake" name="location"></a>Vaccine uptake per 1,000 people by DHB of residence</h4>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine uptake per 1,000 people by DHB of residence" class="img-responsive" height="1030" src="/web/20211102161403im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_dhb_4.png" width="1780"/></figure>
+<!--
+<hr />
+<h3><a id="by_dhb_plan" name="dhb_plan"></a>Cumulative vaccination plan for DHBs</h3>
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">DHB of service</th>
+			<th scope="col" style="text-align:right">Actuals to Sunday 24 October</th>
+			<th scope="col" style="text-align:right">DHB Plan to Sunday 24 October</th>
+			<th scope="col" style="text-align:right">Variance</th>
+			<th scope="col" style="text-align:right">% of Plan</th>
+			<th scope="col" style="text-align:right">Week to date</th>
+		</tr>
+	</thead>
+	<tbody> --><!--plan--><!--
+<tr><td nowrap="nowrap">Auckland Metro</td><td>190621</td><td>205515</td><td>-14894</td><td>93%</td><td>9913</td></tr>
+<tr><td nowrap="nowrap">Bay of Plenty</td><td>22841</td><td>14255</td><td>8586</td><td>160%</td><td>1843</td></tr>
+<tr><td nowrap="nowrap">Canterbury</td><td>50558</td><td>39266</td><td>11292</td><td>129%</td><td>2769</td></tr>
+<tr><td nowrap="nowrap">Capital & Coast and Hutt Valley</td><td>48758</td><td>39742</td><td>9016</td><td>123%</td><td>1796</td></tr>
+<tr><td nowrap="nowrap">Hawke's Bay</td><td>15319</td><td>18205</td><td>-2886</td><td>84%</td><td>1351</td></tr>
+<tr><td nowrap="nowrap">Lakes</td><td>13437</td><td>12810</td><td>627</td><td>105%</td><td>731</td></tr>
+<tr><td nowrap="nowrap">MidCentral</td><td>10708</td><td>7237</td><td>3471</td><td>148%</td><td>1191</td></tr>
+<tr><td nowrap="nowrap">Nelson Marlborough</td><td>30198</td><td>18574</td><td>11624</td><td>163%</td><td>1285</td></tr>
+<tr><td nowrap="nowrap">Northland</td><td>21469</td><td>24762</td><td>-3293</td><td>87%</td><td>1257</td></tr>
+<tr><td nowrap="nowrap">South Canterbury</td><td>8106</td><td>8033</td><td>73</td><td>101%</td><td>389</td></tr>
+<tr><td nowrap="nowrap">Southern</td><td>35234</td><td>34594</td><td>640</td><td>102%</td><td>1794</td></tr>
+<tr><td nowrap="nowrap">Tairāwhiti</td><td>4579</td><td>4928</td><td>-349</td><td>93%</td><td>290</td></tr>
+<tr><td nowrap="nowrap">Taranaki</td><td>5619</td><td>5297</td><td>322</td><td>106%</td><td>168</td></tr>
+<tr><td nowrap="nowrap">Waikato</td><td>36070</td><td>32842</td><td>3228</td><td>110%</td><td>1905</td></tr>
+<tr><td nowrap="nowrap">Wairarapa</td><td>4516</td><td>4960</td><td>-444</td><td>91%</td><td>468</td></tr>
+<tr><td nowrap="nowrap">West Coast</td><td>3533</td><td>3300</td><td>233</td><td>107%</td><td>336</td></tr>
+<tr><td nowrap="nowrap">Whanganui</td><td>6982</td><td>4711</td><td>2271</td><td>148%</td><td>612</td></tr>
+<tr><td nowrap="nowrap">Other Sites</td><td>24890</td><td>14575</td><td>10315</td><td>171%</td><td>613</td></tr>
+<tr><td nowrap="nowrap">Total</td><td>533438</td><td>493606</td><td>39832</td><td>108%</td><td>28711</td></tr>
+!--plan_end--><!--	</tbody>
+</table>
+
+
+<p>The information provided in this table is based on cumulative DHB plans to the last week ending on Sunday. The final column shows vaccinations administered since Sunday by DHB of service to reconcile total actuals in this table to other total numbers shown.   On-going, and as we roll-out the vaccination programme, we anticipate that there could be a potential variance of up to ten percent (plus or minus) between DHB Plans and actual vaccination numbers. This is on the basis that, for example, an unplanned significant event could affect roll-out implementation or some DHBs might exceed their planned vaccination numbers.
+</p>
+-->
+
+<hr/>
+<h3><a id="by_dhb" name="location"></a>Cumulative vaccinations by DHB</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Cumulative vaccinations for DHBs" class="img-responsive" height="830" src="/web/20211102161403im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/dhbstacked_12.png" width="1780"/></figure>
+
+<hr/>
+<h3><a id="by-day" name="by-day"></a>Vaccinations by day</h3>
+
+<figure class="image-captioned img-responsive"><img alt="Vaccination doses administered per day" class="img-responsive" height="830" src="/web/20211102161403im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/vaccinebyday_12.png" width="1780"/></figure>
+
+<p>This chart shows the count of vaccinations administered on a given day from the COVID-19 Immunisation Register. Note some records are entered in the register at a later date than the immunisation was received. This means that the figures for a given date may move for some time after that date.</p>
+
+<hr/>
+<h3><a id="group" name="group"></a>Vaccinations by group by week</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccinations by group" class="img-responsive" height="830" src="/web/20211102161403im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/vaccinebygroupwk_12.png" width="1780"/></figure>
+
+<hr/>
+<h3><a id="group_d" name="group_d"></a>Cumulative vaccinations by group</h3>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">Priority Group</th>
+			<th scope="col" style="text-align:right">First dose administered</th>
+			<th scope="col" style="text-align:right">Second dose administered</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">Group 1</th>
+			<td style="text-align:right">66,767</td>
+			<td style="text-align:right">65,205</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Group 2</th>
+			<td style="text-align:right">661,231</td>
+			<td style="text-align:right">621,689</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Group 3</th>
+			<td style="text-align:right">793,481</td>
+			<td style="text-align:right">746,741</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Group 4</th>
+			<td style="text-align:right">2,136,491</td>
+			<td style="text-align:right">1,585,195</td>
+		</tr>
+	</tbody>
+</table>
+
+<p>For definitions of the groups and further detail see the downloadable spreadsheet at the bottom of the page.</p>
+
+<hr/>
+<h3><a id="by_soh" name="stockonhand"></a>Vaccine available for distribution at week end</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine available for distribution at week end" class="img-responsive" height="830" src="/web/20211102161403im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/stockonhand_13.png" width="1780"/></figure>
+
+<p>Vaccine available for distribution is stock (in doses) held at central warehouses. It does not include stock in transit or available at sites ready for use.</p>
+
+<hr/>
+<h3><a id="by_eth" name="ethnicity"></a>Total cumulative doses per 1,000 people by ethnicity</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Total cumulative doses per 1,000 people by ethnicity" class="img-responsive" height="830" src="/web/20211102161403im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/ethnicity_12.png" width="1780"/></figure>
+
+<p>This chart shows both first and second doses. As a result this chart may exceed 1,000 doses per 1,000 people.</p>
+
+<p><strong>*</strong> The prioritised ethnicity classification system allocates each person to a single ethnic group, based on the ethnic groups they identify with. Where people identify with more than one group, they are assigned in this order of priority: Māori, Pacific Peoples, Asian, and European/Other. So, if a person identifies as being Māori and New Zealand European, the person is counted as Māori. See <a href="/web/20211102161403/https://www.health.govt.nz/publication/hiso-100012017-ethnicity-data-protocols">Ethnicity Data Protocols</a> for further information.</p>
+
+<p>Ethnicity breakdown by DHB of residence is available in the downloadable spreadsheet at the bottom of the page.</p>
+
+<hr/>
+<h3><a id="by_age" name="age"></a>Cumulative vaccinations by age</h3>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">Age</th>
+			<th scope="col" style="text-align:right">First dose administered</th>
+			<th scope="col" style="text-align:right">First doses per 1,000 people</th>
+			<th scope="col" style="text-align:right">Fully vaccinated</th>
+			<th scope="col" style="text-align:right">Fully vaccinated per 1,000 people</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">12 - 19 years</th>
+			<td style="text-align:right">403,029</td>
+			<td style="text-align:right">802</td>
+			<td style="text-align:right">279,575</td>
+			<td style="text-align:right">557</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">20 - 34 years</th>
+			<td style="text-align:right">845,409</td>
+			<td style="text-align:right">817</td>
+			<td style="text-align:right">604,676</td>
+			<td style="text-align:right">585</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">35 - 49 years</th>
+			<td style="text-align:right">824,175</td>
+			<td style="text-align:right">862</td>
+			<td style="text-align:right">670,851</td>
+			<td style="text-align:right">701</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">50 - 64 years</th>
+			<td style="text-align:right">836,170</td>
+			<td style="text-align:right">901</td>
+			<td style="text-align:right">749,933</td>
+			<td style="text-align:right">809</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">65 and over</th>
+			<td style="text-align:right">749,187</td>
+			<td style="text-align:right">950</td>
+			<td style="text-align:right">713,795</td>
+			<td style="text-align:right">905</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total</strong></th>
+			<td style="text-align:right"><strong>3,657,970</strong></td>
+			<td style="text-align:right"><strong>869</strong></td>
+			<td style="text-align:right"><strong>3,018,830</strong></td>
+			<td style="text-align:right"><strong>717</strong></td>
+		</tr>
+	</tbody>
+</table>
+
+<p>Age breakdown by ethnicity and gender is available in the downloadable spreadsheet at the bottom of the page.</p>
+
+<hr/>
+<h3><a id="workforce" name="workforce"></a>Trained vaccinators and active vaccinators</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Trained vaccinators and active vaccinators" class="img-responsive" height="830" src="/web/20211102161403im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/workforce_12.png" width="1780"/></figure>
+
+<p><strong>Trained vaccinators</strong> are individuals who have completed the COVID-19 training. Many trained people are only able to offer a small number of hours to the COVID-19 vaccination programme.</p>
+
+<p><strong>Active vaccinators</strong> are trained individuals who are actively vaccinating. The number of active vaccinators does not reflect the hours worked vaccinating. For example, one vaccinator may work 40 hours in a week at one DHB and will show as 1 vaccinator in the headcount. In another DHB, 4 vaccinators may work 10 hours each (total 40 hours), but will show as 4 vaccinators in the headcount for that week.</p>
+
+<p>Both counts of trained and active vaccinators are cumulative. The difference between the two is due to a number of factors. This includes: individuals being trained in anticipation of future sites being opened (the largest factor); rostering; leave or non-availability; local health priorities; sites opening and closing.</p>
+
+<hr/>
+<h3><a id="usage" name="usage"></a>Wastage of vaccine stock</h3>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">&nbsp;</th>
+			<th scope="col">Wastage</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">New Zealand</th>
+			<td>0.29%</td>
+		</tr>
+	</tbody>
+</table>
+
+<p>Wastage is vials that have been reported as wasted since 13 July in the Inventory portal by DHBs or central warehouses divided by vials used over the same time frame.</p>
+
+<h3><a id="download" name="download"></a>Details of vaccination data</h3>
+
+<p>Download a spreadsheet containing key vaccination data. This includes HSU based population estimates for calculating vaccine uptake rates.</p>
+
+<p><a download="" href="/web/20211102161403/https://www.health.govt.nz/system/files/documents/pages/covid_vaccinations_26_10_2021.xlsx">COVID-19 vaccination data through 26 Oct 2021 (Excel, 363 KB)</a></p>
+
+<p>This spreadsheet is based on the information made available at the time of publishing and may be subject to changes. Please take note of any notes and caveats on each sheet.</p>
+
+<p>The below attachments provide some analysis on our progress on equity. The two PDF files are high level summaries of overall progress. The Excel documents are interactive and provides the ability to delve further into those overall numbers. NB: These Excel workbooks use features that are non-compatible with versions of MS Office 2016 and earlier.</p>
+
+<ul>
+	<li><a download="" href="/web/20211102161403/https://www.health.govt.nz/system/files/documents/pages/211024_-_cvip_equity_-_rate_ratios_by_ethnicity_ageband_and_dhb.pdf">Covid-19 Vaccine Rate Ratios by Ethnicity, Ageband and DHB (PDF, 642 KB)</a></li>
+	<li><a download="" href="/web/20211102161403/https://www.health.govt.nz/system/files/documents/pages/211024_-_cvip_equity_-_uptake_by_ethnicity_ageband_and_dhb.pdf">Covid-19 Vaccine Uptake by Ethnicity, Ageband and DHB (PDF, 550 KB)</a></li>
+	<li><a download="" href="/web/20211102161403/https://www.health.govt.nz/system/files/documents/pages/211024_-_cvip_equity_-_level_1_ethnicity_uptake_and_rate_ratios.xlsx">Covid-19 Vaccine Equity - Level 1 Ethnicity Uptake and Rate Ratios (Excel, 152 KB)</a></li>
+	<li><a download="" href="/web/20211102161403/https://www.health.govt.nz/system/files/documents/pages/211024_-_cvip_equity_-_level_2_ethnicity_uptake_and_rate_ratios.xlsx">Covid-19 Vaccine Equity - Level 2 Ethnicity Uptake and Rate Ratios (Excel, 378 KB)</a></li>
+	<li><a download="" href="/web/20211102161403/https://www.health.govt.nz/system/files/documents/pages/211024_-_cvip_equity_-_rate_ratios_and_uptake_over_time.xlsx">Rate Ratios and Uptake Over Time (Excel, 996 KB)</a></li>
+</ul>
+
+<hr/>
+<h3><a id="adverse-events" name="adverse-events"></a>Adverse events following&nbsp;immunisations (AEFI)</h3>
+
+<p>Like all medicines, the COVID-19 vaccine may cause side effects in some people. These are common, are usually mild, don&rsquo;t last long and won&rsquo;t stop people from having the second dose or going about daily life. Serious allergic reactions do occur but are extremely rare.</p>
+
+<p>Suspected AEFI to COVID-19 vaccines are reported to the <a href="https://web.archive.org/web/20211102161403/https://nzphvc.otago.ac.nz/">Centre for Adverse Reactions Monitoring</a> (CARM).&nbsp;<a href="https://web.archive.org/web/20211102161403/https://www.medsafe.govt.nz/">Medsafe</a> is closely monitoring the AEFI reported from the use of the COVID-19 vaccine and will report regularly on their findings.&nbsp;</p>
+
+<p><a href="https://web.archive.org/web/20211102161403/https://www.medsafe.govt.nz/COVID-19/vaccine-report-overview.asp">View Medsafe data on COVID-19 vaccine adverse effects following immunisation</a></p>
+</div></div></div>    </article>
+  </div>
+
+
+  </div>
+<div class="panel-pane pane-node-links even">
+
+
+
+  <div class="pane-content">
+          </div>
+
+
+  </div>
+
+<div class="panel-pane pane-views pane-sub-pages even">
+
+        <h2 class="pane-title h3">In this section</h2>
+
+
+  <div class="pane-content">
+        <div class="view view-sub-pages view-id-sub_pages view-display-id-block view-dom-id-124b2693ccc9edc6c37a98d9cde27295">
+
+
+
+      <div class="view-content">
+      <div class="item-list">    <ul>          <li class="views-row views-row-1 views-row-odd views-row-first">
+  <div class="views-field views-field-title">        <div class="field-content">
+<div class="views-field views-field-title">
+  <h3 class="field-content">
+    <a href="/web/20211102161403/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-across-nz">COVID-19 Vaccination uptake rates across NZ</a>  </h3>
+</div></div>  </div>
+  <span class="views-field views-field-body">        <span class="field-content">This page provides information related to uptake rates of the COVID-19 vaccine across the country.
+</span>  </span>
+  <span class="views-field views-field-view-node">        <span class="field-content"><a href="/web/20211102161403/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-across-nz">Read more</a></span>  </span></li>
+          <li class="views-row views-row-2 views-row-even">
+  <div class="views-field views-field-title">        <div class="field-content">
+<div class="views-field views-field-title">
+  <h3 class="field-content">
+    <a href="/web/20211102161403/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-maori-communities-across-nz">COVID-19 Vaccination uptake rates within Māori communities across NZ</a>  </h3>
+</div></div>  </div>
+  <span class="views-field views-field-body">        <span class="field-content">This page provides information related to uptake rates of the COVID-19 vaccine within Māori communities across New Zealand.
+</span>  </span>
+  <span class="views-field views-field-view-node">        <span class="field-content"><a href="/web/20211102161403/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-maori-communities-across-nz">Read more</a></span>  </span></li>
+          <li class="views-row views-row-3 views-row-odd views-row-last">
+  <div class="views-field views-field-title">        <div class="field-content">
+<div class="views-field views-field-title">
+  <h3 class="field-content">
+    <a href="/web/20211102161403/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-pacific-communities-across-nz">COVID-19 Vaccination uptake rates within Pacific communities across NZ</a>  </h3>
+</div></div>  </div>
+  <span class="views-field views-field-body">        <span class="field-content">This page provides information related to uptake rates of the COVID-19 vaccine within Pacific communities across New Zealand.
+</span>  </span>
+  <span class="views-field views-field-view-node">        <span class="field-content"><a href="/web/20211102161403/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-pacific-communities-across-nz">Read more</a></span>  </span></li>
+      </ul></div>    </div>
+
+
+
+
+
+
+</div>  </div>
+
+
+  </div>
+</div>          </div>
+
+  </div>
+
+</section>
+  </div>
+      </section>
+
+
+    </div>
+    <div id="content-footer-wrapper" class="clearfix">
+      <div id="content-footer" class="clearfix">
+                  <p class="page_updated">Page last updated: <span class="date">02 November 2021</span></p>                  <div class="region region-content-footer">
+    <section id="block-moh-tools-page-tools" class="block block-moh-tools clearfix">
+  <a href="#" data-placement="top" data-title="Share this content." data-html="true" data-content="<p>Share this page on some of the most popular social networking and content sites on the internet.</p><div class='service-links'><ul><li><a href='https://twitter.com/share?url=https%3A//www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data&amp;text=COVID-19%3A%20Vaccine%20data' title='Share this on Twitter' class='service-links-twitter' rel='nofollow'><img typeof='foaf:Image' class='img-responsive' src='https://www.health.govt.nz/sites/all/modules/contrib/service_links/images/twitter.png' alt='Twitter' /> Twitter</a></li>
+<li><a href='https://www.facebook.com/sharer.php?u=https%3A//www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data&amp;t=COVID-19%3A%20Vaccine%20data' title='Share on Facebook' class='service-links-facebook' rel='nofollow'><img typeof='foaf:Image' class='img-responsive' src='https://www.health.govt.nz/sites/all/modules/contrib/service_links/images/facebook.png' alt='Facebook' /> Facebook</a></li>
+</ul></div>" class="share-this-content"><i class="fa fa-share"></i> Share</a><a href="#" title="print this page" class="print"><i class="fa fa-print"></i> Print</a><a href="https://web.archive.org/web/20211102161403/https://www.health.govt.nz/forward?path=node/12052" title="Email this page" class="email"><i class="fa fa-envelope"></i> Email</a><a href="/web/20211102161403/https://www.health.govt.nz/feedback?ref=https%3A//www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="Feedback" class="rss"><i class="fa fa-comment"></i> Feedback</a></section>
+
+  </div>
+      </div>
+    </div>
+
+  </div>
+  <footer class="footer container">
+    <h2 class="hidden">Site Footer</h2>
+    <div class="footer-default">
+      <div class="row">
+        <div class="col-sm-6 col-md-6">
+          <div class="field field-name-field-tax-first-column-links">
+            <ul class="field-items"><li class="field-item"><a href="https://web.archive.org/web/20211102161403/https://www.health.govt.nz/node/492" class="">About this site</a></li><li class="field-item"><a href="https://web.archive.org/web/20211102161403/https://www.health.govt.nz/node/524" class="">Contact us</a></li><li class="field-item"><a href="https://web.archive.org/web/20211102161403/https://www.health.govt.nz/node/488" class="">Other Ministry of Health websites</a></li><li class="field-item"><a href="https://web.archive.org/web/20211102161403/https://www.health.govt.nz/node/7497" class="">Official Information Act requests</a></li><li class="field-item"><a href="https://web.archive.org/web/20211102161403/https://www.health.govt.nz/about-ministry/information-releases" class="">Information releases</a></li><li class="field-item"><a href="https://web.archive.org/web/20211102161403/https://consult.health.govt.nz/" class="">Consultations</a></li></ul>
+          </div>
+        </div>
+        <div class="col-sm-6 col-md-6">
+          <div class="field field-name-field-tax-footer-body field-type-text-long field-label-hidden"><div class="field-items"><div class="field-item even"><h3>Where to go for help</h3>
+
+<table>
+	<tbody>
+		<tr>
+			<th scope="row">Emergencies</th>
+			<td><strong>Dial <a href="tel:111">111</a></strong> (for ambulance, fire or police)</td>
+		</tr>
+		<tr>
+			<th scope="row">Healthline</th>
+			<td><strong>Dial <a href="tel:0800611116">0800 611 116</a></strong></td>
+		</tr>
+		<tr>
+			<th scope="row">Poisons</th>
+			<td><strong>Dial <a href="tel:0800764766">0800 POISON</a> </strong>(<a href="tel:0800764766">0800 764 766</a>)</td>
+		</tr>
+		<tr>
+			<th scope="row">Mental health crisis</th>
+			<td><strong><a href="/web/20211102161403/https://www.health.govt.nz/your-health/services-and-support/health-care-services/mental-health-services/crisis-assessment-teams">Emergency contact numbers</a></strong></td>
+		</tr>
+	</tbody>
+</table>
+</div></div></div>        </div>
+      </div>
+      <div class="row">
+        <div class="sub-footer">
+          <div class="column col-sm-12 col-md-3">
+            <a href="https://web.archive.org/web/20211102161403/https://www.govt.nz/">
+              <img src="/web/20211102161403im_/https://www.health.govt.nz/sites/all/themes/mohpub_bootstrap/images/nzgovtlogo-te-kawanatanga-white.png" width="230" height="52" alt="govt.nz - connecting you to New Zealand central &amp; local government services" title="govt.nz - connecting you to New Zealand central &amp; local government services"/>
+            </a>
+          </div>
+          <div class="column col-sm-12 col-md-9">
+          <span class="bottom-menu-moh with-v-divider">&copy; Ministry of Health – Manatū Hauora</span><ul class="bottom-menu-list"><li class="bottom-menu-list-item with-v-divider"><a href="https://web.archive.org/web/20211102161403/https://www.health.govt.nz/sitemap" class="">Site map</a></li><li class="bottom-menu-list-item with-v-divider"><a href="https://web.archive.org/web/20211102161403/https://www.health.govt.nz/about-site/privacy-and-security" class="">Privacy &amp; security</a></li><li class="bottom-menu-list-item with-v-divider"><a href="https://web.archive.org/web/20211102161403/https://www.health.govt.nz/about-site/copyright" class="">Copyright</a></li></ul>          </div>
+        </div>
+      </div>
+    </div>
+    <div class="footer-print">&copy; Ministry of Health – Manatū Hauora</div>
+  </footer>
+  <a class="scrollToTop">Back to top <i class="fas fa-arrow-up"></i></a>
+</div>
+  <script src="https://web.archive.org/web/20211102161403js_/https://www.health.govt.nz/sites/default/files/js/js_akZOsKtodu3PdnQzY3_ElOfujkLxJcowmaWgHTBBLOE.js"></script>
+</body>
+</html>
+<!--
+     FILE ARCHIVED ON 16:14:03 Nov 02, 2021 AND RETRIEVED FROM THE
+     INTERNET ARCHIVE ON 03:13:55 Nov 07, 2021.
+     JAVASCRIPT APPENDED BY WAYBACK MACHINE, COPYRIGHT INTERNET ARCHIVE.
+
+     ALL OTHER CONTENT MAY ALSO BE PROTECTED BY COPYRIGHT (17 U.S.C.
+     SECTION 108(a)(3)).
+-->
+<!--
+playback timings (ms):
+  captures_list: 102.255
+  exclusion.robots: 0.209
+  exclusion.robots.policy: 0.201
+  RedisCDXSource: 2.021
+  esindex: 0.008
+  LoadShardBlock: 55.833 (3)
+  PetaboxLoader3.datanode: 69.226 (4)
+  CDXLines.iter: 32.756 (3)
+  load_resource: 156.891
+  PetaboxLoader3.resolve: 76.317
+-->

--- a/data/rawSite/2021-11-02.html
+++ b/data/rawSite/2021-11-02.html
@@ -1,0 +1,2483 @@
+
+<!DOCTYPE html>
+<html lang="en" dir="ltr" prefix="" class="no-js">
+<head><script src="//archive.org/includes/analytics.js?v=cf34f82" type="text/javascript"></script>
+<script type="text/javascript">window.addEventListener('DOMContentLoaded',function(){var v=archive_analytics.values;v.service='wb';v.server_name='wwwb-app201.us.archive.org';v.server_ms=300;archive_analytics.send_pageview({});});</script>
+<script type="text/javascript" src="/_static/js/bundle-playback.js?v=UfTkgsKx" charset="utf-8"></script>
+<script type="text/javascript" src="/_static/js/wombat.js?v=UHAOicsW" charset="utf-8"></script>
+<script type="text/javascript">
+  __wm.init("https://web.archive.org/web");
+  __wm.wombat("https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data","20211103184409","https://web.archive.org/","web","/_static/",
+	      "1635965049");
+</script>
+<link rel="stylesheet" type="text/css" href="/_static/css/banner-styles.css?v=omkqRugM" />
+<link rel="stylesheet" type="text/css" href="/_static/css/iconochive.css?v=qtvMKcIJ" />
+<!-- End Wayback Rewrite JS Include -->
+
+  <!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta name="format-detection" content="telephone=no"/>
+  <link rel="profile" href="http://www.w3.org/1999/xhtml/vocab"/>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+<link rel="shortcut icon" href="https://web.archive.org/web/20211103184409im_/https://www.health.govt.nz/sites/all/themes/mohpub_bootstrap/favicon.ico" type="image/vnd.microsoft.icon"/>
+<meta name="description" content="Dashboard of data and statistics about the rollout of COVID-19 vaccines in New Zealand"/>
+<meta name="generator" content="Drupal 7 (https://www.drupal.org)"/>
+<link rel="canonical" href="https://web.archive.org/web/20211103184409/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data"/>
+<link rel="shortlink" href="https://web.archive.org/web/20211103184409/https://www.health.govt.nz/node/12052"/>
+<meta property="og:site_name" content="Ministry of Health NZ"/>
+<meta property="og:type" content="article"/>
+<meta property="og:url" content="https://web.archive.org/web/20211103184409/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data"/>
+<meta property="og:title" content="COVID-19: Vaccine data"/>
+<meta property="og:description" content="Dashboard of data and statistics about the rollout of COVID-19 vaccines in New Zealand"/>
+  <title>COVID-19: Vaccine data | Ministry of Health NZ</title>
+  <link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211103184409cs_/https://www.health.govt.nz/sites/default/files/css/css_lQaZfjVpwP_oGNqdtWCSpJT1EMqXdMiU84ekLLxQnc4.css" media="all"/>
+<link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211103184409cs_/https://www.health.govt.nz/sites/default/files/css/css_jqUBpWfMaxMiP7LismdZVlyVv8azUJSE2yaH58nj0cE.css" media="all"/>
+<link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211103184409cs_/https://www.health.govt.nz/sites/default/files/css/css_Rb1wqFBC8VXCJC-BuNY53cvjjlj6UADGvqzo_f-1yN0.css" media="all"/>
+<link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211103184409cs_/https://www.health.govt.nz/sites/default/files/css/css_38_K1lHKg-98m4KKRfv57JBK0gvlKscexGt9MKoi0DE.css" media="all"/>
+<link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211103184409cs_/https://www.health.govt.nz/sites/default/files/css/css_r7NPyvpdYfAyZmk9zkK8OaFKEFj6er5ZJnam2H644DM.css" media="print"/>
+  <link rel="alternate stylesheet" type="text/css" href="/web/20211103184409cs_/https://www.health.govt.nz/sites/all/themes/mohpub_bootstrap/css/high-contrast.css" media="screen" title="High Contrast"/>
+  <script src="https://web.archive.org/web/20211103184409js_/https://www.health.govt.nz/sites/default/files/js/js_zS-CmNFGyegtLYJmqFRpxQvvQrfPIFrOMq_3T3C8sZE.js"></script>
+<script src="https://web.archive.org/web/20211103184409js_/https://www.health.govt.nz/sites/default/files/js/js_fNgZ4Okisfr70Q0yvAYsATgB0o_jD3-srhQQ-VHmlXE.js"></script>
+<script src="https://web.archive.org/web/20211103184409js_/https://www.health.govt.nz/sites/default/files/js/js_YAdPZfg12M1m7ROp3_gVJPS5sArqL0kYQgNRPoicvHE.js"></script>
+<script>(function(i,s,o,g,r,a,m){i["GoogleAnalyticsObject"]=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,"script","https://web.archive.org/web/20211103184409/https://www.google-analytics.com/analytics.js","ga");ga("create", "UA-3573389-24", {"cookieDomain":".www.health.govt.nz","siteSpeedSampleRate":15});ga("send", "pageview");</script>
+<script src="https://web.archive.org/web/20211103184409js_/https://www.health.govt.nz/sites/default/files/js/js_wauJ-VUoyA1MrZ6ZPFtGhNR7qiKnBdBSKEwQJjdEXIk.js"></script>
+<script src="https://web.archive.org/web/20211103184409js_/https://www.health.govt.nz/sites/default/files/js/js_4VW9edmu3V8VjGJxFfXGAwkXeW2cJIa5h-6y7SgwVrk.js"></script>
+<script>    (function(h,o,t,j,a,r){
+        h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
+        h._hjSettings={hjid:930919,hjsv:6};
+        a=o.getElementsByTagName('head')[0];
+        r=o.createElement('script');r.async=1;
+        r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+        a.appendChild(r);
+    })(window,document,'https://web.archive.org/web/20211103184409/https://static.hotjar.com/c/hotjar-','.js?sv=');
+</script>
+<script>jQuery.extend(Drupal.settings, {"basePath":"\/","pathPrefix":"","ajaxPageState":{"theme":"mohpub_bootstrap","theme_token":"Zq_eOBh_9X5hIziaTrm_O_g-n3bQEmKCnrh-8RuNdaU","js":{"sites\/all\/modules\/custom\/table_d3chart\/js\/table_d3chart.js":1,"sites\/all\/modules\/custom\/moh_d3\/moh_d3.js":1,"sites\/all\/modules\/contrib\/jquery_update\/replace\/jquery\/1.7\/jquery.min.js":1,"misc\/jquery-extend-3.4.0.js":1,"misc\/jquery-html-prefilter-3.5.0-backport.js":1,"misc\/jquery.once.js":1,"misc\/drupal.js":1,"sites\/all\/modules\/contrib\/ckeditor_accordion\/js\/ckeditor-accordion.js":1,"sites\/all\/modules\/contrib\/extlink\/extlink.js":1,"modules\/field\/modules\/text\/text.js":1,"sites\/all\/modules\/contrib\/field_group\/field_group.js":1,"sites\/all\/modules\/contrib\/google_analytics\/googleanalytics.js":1,"0":1,"sites\/all\/libraries\/c3\/c3.js":1,"sites\/all\/libraries\/d3\/d3.js":1,"sites\/all\/modules\/contrib\/d3\/js\/d3.js":1,"sites\/all\/libraries\/d3.helpers\/d3.helpers.js":1,"sites\/all\/libraries\/d3.c3\/d3-c3.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/assets\/ios-fix.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/affix.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/alert.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/button.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/carousel.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/collapse.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/dropdown.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/modal.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/tooltip.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/popover.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/scrollspy.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/tab.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/transition.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/jquery.cookie.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/jquery.moh.announcement.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/svgeezy.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/fitvids.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/bootstrap-tabcollapse.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/jquery.scrollTo.min.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/script.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/jquery.google_analytics.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/bootstrap-accessibility.min.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/style-switcher.js":1,"1":1},"css":{"modules\/system\/system.base.css":1,"sites\/all\/modules\/contrib\/calendar\/css\/calendar_multiday.css":1,"sites\/all\/modules\/contrib\/ckeditor_accordion\/css\/ckeditor-accordion.css":1,"modules\/field\/theme\/field.css":1,"modules\/node\/node.css":1,"sites\/all\/modules\/contrib\/extlink\/extlink.css":1,"sites\/all\/modules\/contrib\/views\/css\/views.css":1,"sites\/all\/modules\/contrib\/ckeditor\/css\/ckeditor.css":1,"sites\/all\/modules\/contrib\/ctools\/css\/ctools.css":1,"sites\/all\/modules\/contrib\/panels\/css\/panels.css":1,"sites\/all\/libraries\/c3\/c3.css":1,"sites\/all\/libraries\/d3.c3\/d3-c3.css":1,"sites\/all\/themes\/mohpub_bootstrap\/fontawesome\/css\/fontawesome.min.css":1,"sites\/all\/themes\/mohpub_bootstrap\/fontawesome\/css\/solid.min.css":1,"sites\/all\/themes\/mohpub_bootstrap\/fontawesome\/css\/brands.min.css":1,"sites\/all\/modules\/features\/site_profile\/css\/fix-rubik-multiselect-height.css":1,"sites\/all\/themes\/mohpub_bootstrap\/css\/style.css":1,"sites\/all\/themes\/mohpub_bootstrap\/css\/responsive-tables.css":1,"sites\/all\/themes\/mohpub_bootstrap\/css\/print.css":1}},"field_group":{"div":"full"},"ckeditor_accordion":{"collapseAll":1},"extlink":{"extTarget":0,"extClass":"ext","extLabel":"(link is external)","extImgClass":0,"extIconPlacement":"append","extSubdomains":0,"extExclude":"","extInclude":"","extCssExclude":"","extCssExplicit":"","extAlert":0,"extAlertText":"This link will take you to an external web site. We are not responsible for their content.","mailtoClass":"mailto","mailtoLabel":"(link sends e-mail)"},"googleanalytics":{"trackOutbound":1,"trackMailto":1,"trackDownload":1,"trackDownloadExtensions":"7z|aac|arc|arj|asf|asx|avi|bin|csv|doc|exe|flv|gif|gz|gzip|hqx|jar|jpe?g|js|mp(2|3|4|e?g)|mov(ie)?|msi|msp|pdf|phps|png|ppt|qtm?|ra(m|r)?|sea|sit|tar|tgz|torrent|txt|wav|wma|wmv|wpd|xls|xml|z|zip|docx|xlsx|pptx|pptm|ppsx|ppsm|epub"},"mohD3":{"C3Types":["line","spline","step","area","area-spline","area-step","bar","scatter","pie","donut","gauge"],"graphRender":"line","graphLegend":true,"graphDefaultColors":"#2b8cbe, #abdda4, #7f7f7f, #92cddc, #dc8b0c","graphDefaultGroupedTooltip":0,"graphDefaultGridX":0,"graphDefaultGridY":0,"graphDefaultLegendPosition":"top-right","graphDefaultTooltip":1,"graphDefaultDataLabel":0,"graphLegendStep":"5","graphInteraction":true,"graphTypes":"","graphXaxisShow":true,"graphXaxisLabel":"","graphYaxisLabel":"","graphXaxisType":"category","graphXaxisCentered":false,"graphXaxisRotation":"","graphXaxisHeight":"","graphYaxisShow":true,"graphYaxisMax":"","graphYaxisMin":"","graphYaxisInverted":false,"graphYaxisCenter":"","graphYaxisPrefix":"","graphYaxisSuffix":"","graphYaxisPosition":"","graphY2axisShow":false,"graphY2axisSource":"","graphY2axisMax":"","graphY2axisMin":"","graphGroups":"","graphRotated":false,"graphIgnoreEmpty":false,"graphLineDot":true,"graphBarRatio":"0.9","graphDot":true,"graphDotR":"2.5","graphFocus":false},"tableD3":{"show":"View table data source","hide":"Hide table data source"},"urlIsAjaxTrusted":{"\/our-work\/diseases-and-conditions\/covid-19-novel-coronavirus\/covid-19-data-and-statistics\/covid-19-vaccine-data":true},"bootstrap":{"anchorsFix":1,"anchorsSmoothScrolling":1,"formHasError":1,"popoverEnabled":1,"popoverOptions":{"animation":1,"html":0,"placement":"right","selector":"","trigger":"click","triggerAutoclose":1,"title":"","content":"","delay":0,"container":"body"},"tooltipEnabled":1,"tooltipOptions":{"animation":1,"html":0,"placement":"auto left","selector":"","trigger":"hover focus","delay":0,"container":"body"}}});</script>
+  <!-- HTML5 element support for IE6-8 -->
+  <!--[if lt IE 9]>
+    <script src="/sites/all/themes/mohpub_bootstrap/js/assets/html5shiv.js"></script>
+    <script src="/sites/all/themes/mohpub_bootstrap/js/assets/respond.min.js"></script>
+  <![endif]-->
+</head>
+<body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-12052 node-type-page node-has-intro"><!-- BEGIN WAYBACK TOOLBAR INSERT -->
+<style type="text/css">
+body {
+  margin-top:0 !important;
+  padding-top:0 !important;
+  /*min-width:800px !important;*/
+}
+</style>
+<script>__wm.rw(0);</script>
+<div id="wm-ipp-base" lang="en" style="display:none;direction:ltr;">
+<div id="wm-ipp" style="position:fixed;left:0;top:0;right:0;">
+<div id="wm-ipp-inside">
+  <div style="position:relative;">
+    <div id="wm-logo" style="float:left;width:110px;padding-top:12px;">
+      <a href="/web/" title="Wayback Machine home page"><img src="/_static/images/toolbar/wayback-toolbar-logo-200.png" srcset="/_static/images/toolbar/wayback-toolbar-logo-100.png, /_static/images/toolbar/wayback-toolbar-logo-150.png 1.5x, /_static/images/toolbar/wayback-toolbar-logo-200.png 2x" alt="Wayback Machine" style="width:100px" border="0" /></a>
+    </div>
+    <div class="r" style="float:right;">
+      <div id="wm-btns" style="text-align:right;height:25px;">
+                  <div id="wm-save-snapshot-success">success</div>
+          <div id="wm-save-snapshot-fail">fail</div>
+          <a id="wm-save-snapshot-open" href="#"
+	     title="Share via My Web Archive" >
+            <span class="iconochive-web"></span>
+          </a>
+          <a href="https://archive.org/account/login.php"
+             title="Sign In"
+             id="wm-sign-in"
+          >
+            <span class="iconochive-person"></span>
+          </a>
+          <span id="wm-save-snapshot-in-progress" class="iconochive-web"></span>
+        	<a href="http://faq.web.archive.org/" title="Get some help using the Wayback Machine" style="top:-6px;"><span class="iconochive-question" style="color:rgb(87,186,244);font-size:160%;"></span></a>
+	<a id="wm-tb-close" href="#close" onclick="__wm.h(event);return false;" style="top:-2px;" title="Close the toolbar"><span class="iconochive-remove-circle" style="color:#888888;font-size:240%;"></span></a>
+      </div>
+      <div id="wm-share">
+          <a href="/web/20211103184409/http://web.archive.org/screenshot/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data"
+             id="wm-screenshot"
+             title="screenshot">
+            <span class="wm-icon-screen-shot"></span>
+          </a>
+          <a href="#"
+            id="wm-video"
+            title="video">
+            <span class="iconochive-movies"></span>
+          </a>
+	<a id="wm-share-facebook" href="#" data-url="https://web.archive.org/web/20211103184409/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="Share on Facebook" style="margin-right:5px;" target="_blank"><span class="iconochive-facebook" style="color:#3b5998;font-size:160%;"></span></a>
+	<a id="wm-share-twitter" href="#" data-url="https://web.archive.org/web/20211103184409/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="Share on Twitter" style="margin-right:5px;" target="_blank"><span class="iconochive-twitter" style="color:#1dcaff;font-size:160%;"></span></a>
+      </div>
+    </div>
+    <table class="c" style="">
+      <tbody>
+	<tr>
+	  <td class="u" colspan="2">
+	    <form target="_top" method="get" action="/web/submit" name="wmtb" id="wmtb"><input type="text" name="url" id="wmtbURL" value="https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" onfocus="this.focus();this.select();" /><input type="hidden" name="type" value="replay" /><input type="hidden" name="date" value="20211103184409" /><input type="submit" value="Go" /></form>
+	  </td>
+	  <td class="n" rowspan="2" style="width:110px;">
+	    <table>
+	      <tbody>
+		<!-- NEXT/PREV MONTH NAV AND MONTH INDICATOR -->
+		<tr class="m">
+		  <td class="b" nowrap="nowrap"><a href="https://web.archive.org/web/20211003170904/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="03 Oct 2021"><strong>Oct</strong></a></td>
+		  <td class="c" id="displayMonthEl" title="You are here: 18:44:09 Nov 03, 2021">NOV</td>
+		  <td class="f" nowrap="nowrap">Dec</td>
+		</tr>
+		<!-- NEXT/PREV CAPTURE NAV AND DAY OF MONTH INDICATOR -->
+		<tr class="d">
+		  <td class="b" nowrap="nowrap"><a href="https://web.archive.org/web/20211102161403/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="16:14:03 Nov 02, 2021"><img src="/_static/images/toolbar/wm_tb_prv_on.png" alt="Previous capture" width="14" height="16" border="0" /></a></td>
+		  <td class="c" id="displayDayEl" style="width:34px;font-size:24px;white-space:nowrap;" title="You are here: 18:44:09 Nov 03, 2021">03</td>
+		  <td class="f" nowrap="nowrap"><a href="https://web.archive.org/web/20211104203147/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="20:31:47 Nov 04, 2021"><img src="/_static/images/toolbar/wm_tb_nxt_on.png" alt="Next capture" width="14" height="16" border="0" /></a></td>
+		</tr>
+		<!-- NEXT/PREV YEAR NAV AND YEAR INDICATOR -->
+		<tr class="y">
+		  <td class="b" nowrap="nowrap">2020</td>
+		  <td class="c" id="displayYearEl" title="You are here: 18:44:09 Nov 03, 2021">2021</td>
+		  <td class="f" nowrap="nowrap">2022</td>
+		</tr>
+	      </tbody>
+	    </table>
+	  </td>
+	</tr>
+	<tr>
+	  <td class="s">
+	    	    <div id="wm-nav-captures">
+	      	      <a class="t" href="/web/20211103184409*/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="See a list of every capture for this URL">682 captures</a>
+	      <div class="r" title="Timespan for captures of this URL">07 Apr 2021 - 06 Nov 2021</div>
+	      </div>
+	  </td>
+	  <td class="k">
+	    <a href="" id="wm-graph-anchor">
+	      <div id="wm-ipp-sparkline" title="Explore captures for this URL" style="position: relative">
+		<canvas id="wm-sparkline-canvas" width="650" height="27" border="0"></canvas>
+	      </div>
+	    </a>
+	  </td>
+	</tr>
+      </tbody>
+    </table>
+    <div style="position:absolute;bottom:0;right:2px;text-align:right;">
+      <a id="wm-expand" class="wm-btn wm-closed" href="#expand" onclick="__wm.ex(event);return false;"><span id="wm-expand-icon" class="iconochive-down-solid"></span> <span style="font-size:80%">About this capture</span></a>
+    </div>
+  </div>
+    <div id="wm-capinfo" style="border-top:1px solid #777;display:none; overflow: hidden">
+                    <div id="wm-capinfo-collected-by">
+    <div style="background-color:#666;color:#fff;font-weight:bold;text-align:center">COLLECTED BY</div>
+    <div style="padding:3px;position:relative" id="wm-collected-by-content">
+            <div style="display:inline-block;vertical-align:top;width:50%;">
+			<span class="c-logo" style="background-image:url(https://archive.org/services/img/focused_crawls);"></span>
+		Organization: <a style="color:#33f;" href="https://archive.org/details/focused_crawls" target="_new"><span class="wm-title">Internet Archive</span></a>
+		<div style="max-height:75px;overflow:hidden;position:relative;">
+	  <div style="position:absolute;top:0;left:0;width:100%;height:75px;background:linear-gradient(to bottom,rgba(255,255,255,0) 0%,rgba(255,255,255,0) 90%,rgba(255,255,255,255) 100%);"></div>
+	  Focused crawls are collections of frequently-updated webcrawl data from narrow (as opposed to broad or wide) web crawls, often focused on a single domain or subdomain.<br />
+	</div>
+	      </div>
+      <div style="display:inline-block;vertical-align:top;width:49%;">
+			<span class="c-logo" style="background-image:url(https://archive.org/services/img/abc.net.au-news)"></span>
+		<div>Collection: <a style="color:#33f;" href="https://archive.org/details/abc.net.au-news" target="_new"><span class="wm-title">abc.net.au-news</span></a></div>
+	      </div>
+    </div>
+    </div>
+    <div id="wm-capinfo-timestamps">
+    <div style="background-color:#666;color:#fff;font-weight:bold;text-align:center" title="Timestamps for the elements of this page">TIMESTAMPS</div>
+    <div>
+      <div id="wm-capresources" style="margin:0 5px 5px 5px;max-height:250px;overflow-y:scroll !important"></div>
+      <div id="wm-capresources-loading" style="text-align:left;margin:0 20px 5px 5px;display:none"><img src="/_static/images/loading.gif" alt="loading" /></div>
+    </div>
+    </div>
+  </div></div></div></div><div id="wm-ipp-print">The Wayback Machine - https://web.archive.org/web/20211103184409/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data</div>
+<div id="donato" style="position:relative;width:100%;">
+  <div id="donato-base">
+    <iframe id="donato-if" src="https://archive.org/includes/donate.php?as_page=1&amp;platform=wb&amp;referer=https%3A//web.archive.org/web/20211103184409/https%3A//www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data"
+	    scrolling="no" frameborder="0" style="width:100%; height:100%">
+    </iframe>
+  </div>
+</div><script type="text/javascript">
+__wm.bt(650,27,25,2,"web","https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data","20211103184409",1996,"/_static/",["/_static/css/banner-styles.css?v=omkqRugM","/_static/css/iconochive.css?v=qtvMKcIJ"], "False");
+  __wm.rw(1);
+</script>
+<!-- END WAYBACK TOOLBAR INSERT -->
+<!--googleoff: all-->
+  <div id="skip-link">
+    <a href="#skip-content" id="skipper" class="element-invisible element-focusable">Skip to main content</a>
+  </div>
+    <div id="page">
+  <header id="navbar" role="banner" class="navbar container navbar-default">
+          <ul class="menu nav navbar-nav secondary"><li class="first leaf jobs depth-1"><a href="https://web.archive.org/web/20211103184409/https://careers.health.govt.nz/" title="">Jobs</a></li>
+<li class="leaf news depth-1"><a href="/web/20211103184409/https://www.health.govt.nz/news-media" data-is-top-level="0" title="">News</a></li>
+<li class="leaf contact-us depth-1"><a href="/web/20211103184409/https://www.health.govt.nz/about-ministry/contact-us" title="">Contact us</a></li>
+<li class="leaf facebook depth-1"><a href="https://web.archive.org/web/20211103184409/https://www.facebook.com/minhealthnz/">Facebook</a></li>
+<li class="leaf twitter depth-1"><a href="https://web.archive.org/web/20211103184409/https://twitter.com/minhealthnz" data-is-top-level="0" title="">Twitter</a></li>
+<li class="last leaf youtube depth-1"><a href="https://web.archive.org/web/20211103184409/https://www.youtube.com/user/minhealthnz" data-is-top-level="0" title="">Youtube</a></li>
+</ul>        <div class="container">
+      <div class="navbar-header">
+                <a class="logo navbar-btn pull-left" href="/web/20211103184409/https://www.health.govt.nz/" title="Home">
+          <img src="/web/20211103184409im_/https://www.health.govt.nz/sites/all/themes/mohpub_bootstrap/images/mohlogo.svg" alt="Ministry of Health"/>
+        </a>
+                  <div class="region region-header-top">
+    <section id="block-apachesolr-panels-search-form" class="block block-apachesolr-panels clearfix">
+
+
+  <form action="/web/20211103184409/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" method="post" id="apachesolr-panels-search-block" accept-charset="UTF-8"><div><div class="form-item form-item-apachesolr-panels-search-form form-type-textfield form-group"> <label class="control-label" for="edit-apachesolr-panels-search-form">Search</label>
+<input title="Enter the terms you wish to search for." class="form-control form-text" type="text" id="edit-apachesolr-panels-search-form" name="apachesolr_panels_search_form" value="" size="15" maxlength="128"/></div><input type="hidden" name="form_build_id" value="form-BprhehU6QKl16kb0XS5PXbo2fja36h-XRGB0iqtXULk"/>
+<input type="hidden" name="form_id" value="apachesolr_panels_search_block"/>
+<div class="form-actions form-wrapper form-group" id="edit-actions"><button type="submit" id="edit-submit" name="op" value="Search" class="btn btn-primary form-submit">Search</button>
+</div></div></form>
+</section>
+  </div>
+        <!-- .btn-navbar is used as the toggle for collapsed navbar content -->
+        <button aria-expanded="false" aria-controls="megamenu" type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+                    <span class="menu-text">Menu</span><span class="sr-only">Toggle navigation</span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+
+        </button>
+      </div>
+
+              <div class="navbar-collapse collapse">
+          <nav id="megamenu" role="navigation">
+                          <h2 class="element-invisible">Main menu</h2><ul id="main-menu" class="menu nav navbar-nav yamm navbar"><li class="first dropdown"><a href="/web/20211103184409/https://www.health.govt.nz/your-health" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="megamenu-dropdown-780">Your health <b class="caret"></b></a>
+    <div id="megamenu-dropdown-780" class="dropdown-menu">
+    <div class="yamm-content">
+      <div class="row">
+                            <div class="col">
+            <h3><a href="/web/20211103184409/https://www.health.govt.nz/your-health/conditions-and-treatments?mega=Your%20health&amp;title=Conditions%20%26%20treatments" class="menu-header">Conditions &amp; treatments</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211103184409/https://www.health.govt.nz/your-health/conditions-and-treatments/mental-health/depression?mega=Your%20health&amp;title=Depression">Depression</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/diabetes?mega=Your%20health&amp;title=Diabetes">Diabetes</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/influenza?mega=Your%20health&amp;title=Influenza">Influenza</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/measles?mega=Your%20health&amp;title=Measles">Measles</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/meningococcal-disease-including-meningitis?mega=Your%20health&amp;title=Meningococcal%20disease">Meningococcal disease</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/mumps?mega=Your%20health&amp;title=Mumps">Mumps</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/respiratory-syncytial-virus-rsv?mega=Your%20health&amp;title=RSV">RSV</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/sore-throat?mega=Your%20health&amp;title=Sore%20throat">Sore throat</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/your-health/conditions-and-treatments?mega=Your%20health&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211103184409/https://www.health.govt.nz/your-health/healthy-living?mega=Your%20health&amp;title=Healthy%20living" class="menu-header">Healthy living</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211103184409/https://www.health.govt.nz/your-health/healthy-living/drinking-water?mega=Your%20health&amp;title=Drinking-water">Drinking-water</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/your-health/healthy-living/food-activity-and-sleep/green-prescriptions?mega=Your%20health&amp;title=Green%20Prescriptions">Green Prescriptions</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/your-health/healthy-living/food-activity-and-sleep/healthy-eating?mega=Your%20health&amp;title=Healthy%20eating">Healthy eating</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/your-health/healthy-living/immunisation?mega=Your%20health&amp;title=Immunisation">Immunisation</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/your-health/healthy-living/food-activity-and-sleep/physical-activity?mega=Your%20health&amp;title=Physical%20activity">Physical activity</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/your-health/healthy-living/addictions/quitting-smoking?mega=Your%20health&amp;title=Smoking">Smoking</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/your-health/healthy-living/teeth-and-gums?mega=Your%20health&amp;title=Teeth%20and%20gums">Teeth and gums</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/your-health/healthy-living?mega=Your%20health&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211103184409/https://www.health.govt.nz/your-health/pregnancy-and-kids?mega=Your%20health&amp;title=Pregnancy%20and%20kids" class="menu-header">Pregnancy and kids</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211103184409/https://www.health.govt.nz/your-health/pregnancy-and-kids/birth-and-afterwards?mega=Your%20health&amp;title=Birth%20and%20afterwards">Birth and afterwards</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/your-health/pregnancy-and-kids/first-year/helpful-advice-during-first-year/breastfeeding-perfect-you-and-your-baby?mega=Your%20health&amp;title=Breastfeeding">Breastfeeding</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/your-health/pregnancy-and-kids/pregnancy?mega=Your%20health&amp;title=Pregnancy">Pregnancy</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/your-health/pregnancy-and-kids/services-and-support-during-pregnancy?mega=Your%20health&amp;title=Services%20and%20support%20during%20pregnancy">Services and support during pregnancy</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/your-health/pregnancy-and-kids/services-and-support-you-and-your-child?mega=Your%20health&amp;title=Services%20and%20support%20for%20you%20and%20your%20child">Services and support for you and your child</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/your-health/pregnancy-and-kids/first-year?mega=Your%20health&amp;title=The%20first%20year">The first year</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/your-health/pregnancy-and-kids/under-fives?mega=Your%20health&amp;title=Under%20fives">Under fives</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/your-health/pregnancy-and-kids?mega=Your%20health&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211103184409/https://www.health.govt.nz/your-health/services-and-support?mega=Your%20health&amp;title=Services%20and%20support" class="menu-header">Services &amp; support</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211103184409/https://www.health.govt.nz/your-health/services-and-support/health-care-services/help-alcohol-and-drug-problems?mega=Your%20health&amp;title=Alcohol%20and%20drugs">Alcohol and drugs</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/your-health/services-and-support/disability-services?mega=Your%20health&amp;title=Disability%20services">Disability services</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/your-health/services-and-support/health-care-services/earthquake-support-line?mega=Your%20health&amp;title=Earthquake%20Support%20Line">Earthquake Support Line</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/your-health/services-and-support/health-care-services/healthline?mega=Your%20health&amp;title=Healthline">Healthline</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/your-health/services-and-support/health-care-services/mental-health-services?mega=Your%20health&amp;title=Mental%20health%20services">Mental health services</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/your-health/services-and-support/health-care-services/maori-health-provider-directory?mega=Your%20health&amp;title=M%C4%81ori%20health%20providers">Māori health providers</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/your-health/services-and-support/health-care-services/services-older-people/rest-home-certification-and-audits?mega=Your%20health&amp;title=Rest%20home%20certification">Rest home certification</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/your-health/services-and-support/health-care-services/hospitals-and-specialist-services/travel-assistance?mega=Your%20health&amp;title=Travel%20assistance">Travel assistance</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/your-health/services-and-support?mega=Your%20health&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                        </div>
+    </div>
+    <div class="feature-links">
+      <h3 class="sr-only">Other related resources</h3>
+      <a href="/web/20211103184409/https://www.health.govt.nz/your-health/full-a-z?mega=Your%20health&amp;title=A-Z">View the full A-Z</a>    </div>
+  </div>
+</li>
+<li class="dropdown"><a href="/web/20211103184409/https://www.health.govt.nz/new-zealand-health-system" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="megamenu-dropdown-6076">NZ health system <b class="caret"></b></a>
+    <div id="megamenu-dropdown-6076" class="dropdown-menu">
+    <div class="yamm-content">
+      <div class="row">
+                            <div class="col">
+            <h3><a href="/web/20211103184409/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people?mega=NZ%20health%20system&amp;title=Key%20organisations" class="menu-header">Key organisations</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211103184409/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/crown-entities-and-statutory-boards?mega=NZ%20health%20system&amp;title=Crown%20entities%20%26%20agencies">Crown entities &amp; agencies</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/district-health-boards?mega=NZ%20health%20system&amp;title=District%20health%20boards">District health boards</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/non-governmental-organisations?mega=NZ%20health%20system&amp;title=Non-governmental%20organisations">Non-governmental organisations</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/primary-health-organisations?mega=NZ%20health%20system&amp;title=Primary%20health%20organisations">Primary health organisations</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/public-health-units?mega=NZ%20health%20system&amp;title=Public%20health%20units">Public health units</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people?mega=NZ%20health%20system&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211103184409/https://www.health.govt.nz/new-zealand-health-system/health-system-indicators-framework?mega=NZ%20health%20system&amp;title=Health%20System%20Indicators%20framework" class="menu-header">Health System Indicators framework</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211103184409/https://www.health.govt.nz/new-zealand-health-system/health-system-indicators-framework?mega=NZ%20health%20system&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211103184409/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services?mega=NZ%20health%20system&amp;title=Eligibility%20for%20public%20health%20services" class="menu-header">Eligibility for public health services</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211103184409/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services/guide-eligibility-publicly-funded-health-services?mega=NZ%20health%20system&amp;title=Guide%20to%20eligibility">Guide to eligibility</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services/eligibility-questions-and-answers-consumers?mega=NZ%20health%20system&amp;title=Q%26A%20for%20consumers">Q&amp;A for consumers</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services/eligibility-questions-and-answers-service-providers?mega=NZ%20health%20system&amp;title=Q%26A%20for%20service%20providers">Q&amp;A for service providers</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services/reciprocal-health-agreements?mega=NZ%20health%20system&amp;title=Reciprocal%20health%20agreements">Reciprocal health agreements</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services?mega=NZ%20health%20system&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211103184409/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements?mega=NZ%20health%20system&amp;title=Claims%2C%20provider%20payments%20and%20entitlements" class="menu-header">Claims &amp; provider payments</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211103184409/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/carer-support-claims?mega=NZ%20health%20system&amp;title=Carer%20Support">Carer Support</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/high-use-health-card-payments?mega=NZ%20health%20system&amp;title=High%20Use%20Health%20Card%20payments">High Use Health Card payments</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/between-travel-settlement?mega=NZ%20health%20system&amp;title=In-Between%20Travel%20Settlement">In-Between Travel Settlement</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/maternity-claim-forms?mega=NZ%20health%20system&amp;title=Maternity%20claim%20forms">Maternity claim forms</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/national-travel-assistance?mega=NZ%20health%20system&amp;title=National%20travel%20assistance%20claims">National travel assistance claims</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements?mega=NZ%20health%20system&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                        </div>
+    </div>
+    <div class="feature-links">
+      <h3 class="sr-only">Other related resources</h3>
+      <a href="/web/20211103184409/https://www.health.govt.nz/new-zealand-health-system/overview-health-system?mega=NZ%20health%20system&amp;title=Overview">Overview of the health system</a>  <a href="/web/20211103184409/https://www.health.govt.nz/new-zealand-health-system/my-dhb?mega=NZ%20health%20system&amp;title=Mydhb">My DHB</a> <a href="/web/20211103184409/https://www.health.govt.nz/new-zealand-health-system/system-level-measures-framework?mega=NZ%20health%20system&amp;title=SLM">System level measures</a>  <a href="/web/20211103184409/https://www.health.govt.nz/publication/new-zealand-health-strategy-2016?mega=NZ%20health%20system&amp;title=HealthStrategy">NZ Health Strategy</a>    </div>
+  </div>
+</li>
+<li class="dropdown"><a href="/web/20211103184409/https://www.health.govt.nz/our-work" class="dropdown-toggle active-trail" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="megamenu-dropdown-776">Our work <b class="caret"></b></a>
+  <div id="megamenu-dropdown-776" class="dropdown-menu">
+    <div class="yamm-content">
+      <div class="row">
+                            <ul class="col list-unstyled no-menu-header">
+                                                                                <li>
+                <a href="/web/20211103184409/https://www.health.govt.nz/our-work/hospitals-and-specialist-care/acute-care?mega=Our%20work&amp;title=Acute%20care" class="menu-header">Acute care</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211103184409/https://www.health.govt.nz/our-work/diseases-and-conditions/antimicrobial-resistance?mega=Our%20work&amp;title=Antimicrobial%20resistance" class="menu-header">Antimicrobial resistance</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211103184409/https://www.health.govt.nz/our-work/populations/asian-and-migrant-health?mega=Our%20work&amp;title=Asian%20and%20migrant%20health" class="menu-header">Asian and migrant health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211103184409/https://www.health.govt.nz/our-work/border-health?mega=Our%20work&amp;title=Border%20health" class="menu-header">Border health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211103184409/https://www.health.govt.nz/our-work/life-stages/breastfeeding?mega=Our%20work&amp;title=Breastfeeding" class="menu-header">Breastfeeding</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211103184409/https://www.health.govt.nz/our-work/diseases-and-conditions/cancer?mega=Our%20work&amp;title=Cancer" class="menu-header">Cancer</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211103184409/https://www.health.govt.nz/our-work/regulation-health-and-disability-system/certification-health-care-services?mega=Our%20work&amp;title=Certification%20of%20health%20care%20services" class="menu-header">Certification of health care services</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211103184409/https://www.health.govt.nz/our-work/life-stages/child-health?mega=Our%20work&amp;title=Child%20health" class="menu-header">Child health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211103184409/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus?mega=Our%20work&amp;title=COVID-19" class="menu-header">COVID-19 (novel coronavirus)</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211103184409/https://www.health.govt.nz/our-work/diseases-and-conditions/diabetes?mega=Our%20work&amp;title=Diabetes" class="menu-header">Diabetes</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211103184409/https://www.health.govt.nz/our-work/digital-health?mega=Our%20work&amp;title=Digital%20health" class="menu-header">Digital health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211103184409/https://www.health.govt.nz/our-work/disability-services?mega=Our%20work&amp;title=Disability%20services" class="menu-header">Disability services</a>                              </li>
+                                                                </ul>
+                            <ul class="col list-unstyled no-menu-header">
+                                                                                <li>
+                <a href="/web/20211103184409/https://www.health.govt.nz/our-work/diseases-and-conditions?mega=Our%20work&amp;title=Diseases%20and%20conditions" class="menu-header">Diseases and conditions</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211103184409/https://www.health.govt.nz/our-work/hospitals-and-specialist-care/emergency-departments?mega=Our%20work&amp;title=Emergency%20departments" class="menu-header">Emergency departments</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211103184409/https://www.health.govt.nz/our-work/emergency-management?mega=Our%20work&amp;title=Emergency%20management" class="menu-header">Emergency management</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211103184409/https://www.health.govt.nz/our-work/environmental-health?mega=Our%20work&amp;title=Environmental%20health" class="menu-header">Environmental health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211103184409/https://www.health.govt.nz/our-work/preventative-health-wellness/family-violence?mega=Our%20work&amp;title=Family%20violence" class="menu-header">Family violence</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211103184409/https://www.health.govt.nz/our-work/preventative-health-wellness/fluoride-and-oral-health?mega=Our%20work&amp;title=Fluoride%20and%20oral%20health" class="menu-header">Fluoride and oral health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211103184409/https://www.health.govt.nz/our-work/health-identity?mega=Our%20work&amp;title=Health%20identity" class="menu-header">Health identity</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211103184409/https://www.health.govt.nz/our-work/digital-health/digital-health-sector-architecture-standards-and-governance/health-information-standards-0?mega=Our%20work&amp;title=Health%20information%20standards" class="menu-header">Health information standards</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211103184409/https://www.health.govt.nz/our-work/health-infrastructure-unit-hiu?mega=Our%20work&amp;title=Health%20Infrastructure%20Unit" class="menu-header">Health Infrastructure Unit</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211103184409/https://www.health.govt.nz/our-work/life-stages/health-older-people?mega=Our%20work&amp;title=Health%20of%20older%20people" class="menu-header">Health of older people</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211103184409/https://www.health.govt.nz/our-work/health-workforce?mega=Our%20work&amp;title=Health%20workforce" class="menu-header">Health workforce</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211103184409/https://www.health.govt.nz/our-work/hospitals-and-specialist-care?mega=Our%20work&amp;title=Hospitals%20and%20specialist%20care" class="menu-header">Hospitals and specialist care</a>                              </li>
+                                                                </ul>
+                            <ul class="col list-unstyled no-menu-header">
+                                                                                <li>
+                <a href="/web/20211103184409/https://www.health.govt.nz/our-work/preventative-health-wellness/immunisation?mega=Our%20work&amp;title=Immunisation" class="menu-header">Immunisation</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211103184409/https://www.health.govt.nz/our-work/ionising-radiation-safety?mega=Our%20work&amp;title=Ionising%20radiation%20safety" class="menu-header">Ionising radiation safety</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211103184409/https://www.health.govt.nz/our-work/populations/maori-health?mega=Our%20work&amp;title=M%C4%81ori%20health" class="menu-header">Māori health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211103184409/https://www.health.govt.nz/our-work/life-stages/maternity-services?mega=Our%20work&amp;title=Maternity" class="menu-header">Maternity</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211103184409/https://www.health.govt.nz/our-work/regulation-health-and-disability-system/medicinal-cannabis-agency?mega=Our%20work&amp;title=Medicinal%20Cannabis%20Agency" class="menu-header">Medicinal cannabis</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211103184409/https://www.health.govt.nz/our-work/regulation-health-and-disability-system/medicines-control?mega=Our%20work&amp;title=Medicines%20control" class="menu-header">Medicines control</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211103184409/https://www.health.govt.nz/our-work/mental-health-and-addiction?mega=Our%20work&amp;title=Mental%20health%20and%20addiction" class="menu-header">Mental health and addiction</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211103184409/https://www.health.govt.nz/our-work/nursing?mega=Our%20work&amp;title=Nursing" class="menu-header">Nursing</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211103184409/https://www.health.govt.nz/our-work/preventative-health-wellness/nutrition?mega=Our%20work&amp;title=Nutrition" class="menu-header">Nutrition</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211103184409/https://www.health.govt.nz/our-work/preventative-health-wellness/oral-health?mega=Our%20work&amp;title=Oral%20health" class="menu-header">Oral health</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211103184409/https://www.health.govt.nz/our-work/hospitals-and-specialist-care/organ-donation-and-transplantation?mega=Our%20work&amp;title=Organ%20donation%20and%20transplantation" class="menu-header">Organ donation and transplantation</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211103184409/https://www.health.govt.nz/our-work/populations/pacific-health?mega=Our%20work&amp;title=Pacific%20health" class="menu-header">Pacific health</a>                              </li>
+                                                                </ul>
+                            <ul class="col list-unstyled no-menu-header">
+                                                                                <li>
+                <a href="/web/20211103184409/https://www.health.govt.nz/new-zealand-health-system/pay-equity-settlements?mega=Our%20work&amp;title=Pay%20equity%20settlements" class="menu-header">Pay equity</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211103184409/https://www.health.govt.nz/our-work/preventative-health-wellness/physical-activity?mega=Our%20work&amp;title=Physical%20activity" class="menu-header">Physical activity</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211103184409/https://www.health.govt.nz/our-work/hospitals-and-specialist-care/planned-care-services?mega=Our%20work&amp;title=Planned%20Care%20services" class="menu-header">Planned Care services</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211103184409/https://www.health.govt.nz/our-work/preventative-health-wellness?mega=Our%20work&amp;title=Preventative%20health/wellness" class="menu-header">Preventative health/wellness</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211103184409/https://www.health.govt.nz/our-work/primary-health-care?mega=Our%20work&amp;title=Primary%20health%20care" class="menu-header">Primary health care</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211103184409/https://www.health.govt.nz/our-work/public-health-workforce-development?mega=Our%20work&amp;title=Public%20health%20workforce%20development" class="menu-header">Public health workforce</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211103184409/https://www.health.govt.nz/our-work/regulation-health-and-disability-system?mega=Our%20work&amp;title=Regulation" class="menu-header">Regulation</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211103184409/https://www.health.govt.nz/our-work/preventative-health-wellness/tobacco-control?mega=Our%20work&amp;title=Tobacco%20control" class="menu-header">Tobacco control</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211103184409/https://www.health.govt.nz/our-work/regulation-health-and-disability-system/regulation-vaping-and-smokeless-tobacco-products?mega=Our%20work&amp;title=Vaping%20and%20smokeless%20tobacco%20products" class="menu-header">Vaping &amp; smokeless tobacco</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211103184409/https://www.health.govt.nz/our-work/who-code-nz?mega=Our%20work&amp;title=WHO%20Code%20in%20NZ" class="menu-header">WHO Code in NZ</a>                              </li>
+                                                                    <li>
+                <a href="/web/20211103184409/https://www.health.govt.nz/our-work/life-stages/youth-health?mega=Our%20work&amp;title=Youth%20health" class="menu-header">Youth health</a>                              </li>
+                      </ul>
+              </div>
+    </div>
+    <div class="feature-links">
+      <a href="/web/20211103184409/https://www.health.govt.nz/our-work?mega=Our%20work&amp;title=A-Z">View the full A-Z</a>    </div>
+  </div>
+</li>
+<li class="dropdown"><a href="/web/20211103184409/https://www.health.govt.nz/nz-health-statistics" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="megamenu-dropdown-778">Health statistics <b class="caret"></b></a>
+    <div id="megamenu-dropdown-778" class="dropdown-menu">
+    <div class="yamm-content">
+      <div class="row">
+                            <div class="col">
+            <h3><a href="/web/20211103184409/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets?mega=Health%20statistics&amp;title=Health%20statistics%20and%20data%20sets" class="menu-header">Statistics by topic</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211103184409/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/cancer-data-and-stats?mega=Health%20statistics&amp;title=Cancer">Cancer</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/diabetes-data-and-stats?mega=Health%20statistics&amp;title=Diabetes">Diabetes</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/mental-health-data-and-stats?mega=Health%20statistics&amp;title=Mental%20health">Mental health</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/maori-health-data-and-stats?mega=Health%20statistics&amp;title=M%C4%81ori%20health">Māori health</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/obesity-statistics?mega=Health%20statistics&amp;title=Obesity">Obesity</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/suicide-data-and-stats?mega=Health%20statistics&amp;title=Suicide">Suicide</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/tobacco-data-and-stats?mega=Health%20statistics&amp;title=Tobacco">Tobacco</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets?mega=Health%20statistics&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211103184409/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys?mega=Health%20statistics&amp;title=National%20collections%20and%20surveys" class="menu-header">About our surveys &amp; data collections</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211103184409/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/surveys/past-surveys/alcohol-and-drug-use-survey?mega=Health%20statistics&amp;title=Alcohol%20%26%20Drug%20Use%20Survey">Alcohol &amp; Drug Use Survey</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/national-collections-annual-maintenance-project?mega=Health%20statistics&amp;title=NCAMP">NCAMP</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/collections/new-zealand-cancer-registry-nzcr?mega=Health%20statistics&amp;title=NZ%20Cancer%20Registry">NZ Cancer Registry</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/surveys/new-zealand-health-survey?mega=Health%20statistics&amp;title=NZ%20Health%20Survey">NZ Health Survey</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/surveys/past-surveys/nutrition-survey?mega=Health%20statistics&amp;title=Nutrition%20Survey">Nutrition Survey</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/collections/primhd-mental-health-data?mega=Health%20statistics&amp;title=PRIMHD">PRIMHD</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys?mega=Health%20statistics&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211103184409/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology?mega=Health%20statistics&amp;title=Classification%20and%20Terminology" class="menu-header">Classification &amp; terminology</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211103184409/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology/using-icd-10-am-achi-acs/coding-queries/coding-query-database?mega=Health%20statistics&amp;title=Coding%20query%20database">Coding query database</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology/using-icd-10-am-achi-acs/courses-clinical-coding?mega=Health%20statistics&amp;title=Courses%20on%20clinical%20coding">Courses on clinical coding</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology/new-zealand-snomed-ct-national-release-centre?mega=Health%20statistics&amp;title=SNOMED%20CT">SNOMED CT</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology/using-icd-10-am-achi-acs?mega=Health%20statistics&amp;title=Using%20ICD-10-AM/ACHI/ACS">Using ICD-10-AM/ACHI/ACS</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology?mega=Health%20statistics&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/web/20211103184409/https://www.health.govt.nz/nz-health-statistics/data-references?mega=Health%20statistics&amp;title=Data%20references" class="menu-header">Data references</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/web/20211103184409/https://www.health.govt.nz/nz-health-statistics/data-references/code-tables?mega=Health%20statistics&amp;title=Code%20tables">Code tables</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/nz-health-statistics/data-references/data-dictionaries?mega=Health%20statistics&amp;title=Data%20dictionaries">Data dictionaries</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/nz-health-statistics/data-references/diagnosis-related-groups?mega=Health%20statistics&amp;title=Diagnosis-related%20groups">Diagnosis-related groups</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/nz-health-statistics/data-references/code-tables/common-code-tables/domicile-code-table?mega=Health%20statistics&amp;title=Domicile%20code%20table">Domicile code table</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/nz-health-statistics/data-references/mapping-tools?mega=Health%20statistics&amp;title=ICD%20mapping%20tools">ICD mapping tools</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/nz-health-statistics/data-references/weighted-inlier-equivalent-separations?mega=Health%20statistics&amp;title=Weighted%20Inlier%20Equivalent%20Separations">Weighted Inlier Equivalent Separations</a></li>
+                                  <li><a href="/web/20211103184409/https://www.health.govt.nz/nz-health-statistics/data-references?mega=Health%20statistics&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                        </div>
+    </div>
+    <div class="feature-links">
+      <h3 class="sr-only">Other related resources</h3>
+      <a href="/web/20211103184409/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/tier-1-health-statistics-release-calendar?mega=Health%20statistics&amp;title=Tier%201%20calendar">Release calendar for our Tier 1 statistics</a> <a href="/web/20211103184409/https://www.health.govt.nz/nz-health-statistics/about-data-collection?mega=Health%20statistics&amp;title=Enquiries">Data and survey enquiries</a>    </div>
+  </div>
+</li>
+<li class=""><a href="/web/20211103184409/https://www.health.govt.nz/publications" aria-haspopup="false">Publications</a></li>
+<li class=""><a href="/web/20211103184409/https://www.health.govt.nz/about-ministry" aria-haspopup="false">About us</a></li>
+<li class="visible-xs"><a href="/web/20211103184409/https://www.health.govt.nz/contactus" aria-haspopup="false">Contact us</a></li>
+</ul>
+                                  </nav>
+        </div>
+          </div>
+  </header>
+
+  <div class="main-container container">
+    <!-- announcement -->
+        <!-- /announcement -->
+
+    <header role="banner" id="page-header">
+
+          </header> <!-- /#page-header -->
+
+    <div class="row">
+
+      <section class="col-sm-12">
+                        <a id="main-content"></a>
+                                                                            <div class="breadcrumbs">
+            <ul><li><a href="/web/20211103184409/https://www.health.govt.nz/">Home</a></li><li><a href="/web/20211103184409/https://www.health.govt.nz/our-work">Our work</a></li><li><a href="/web/20211103184409/https://www.health.govt.nz/our-work/diseases-and-conditions">Diseases and conditions</a></li><li><a href="/web/20211103184409/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished" data-is-top-level="1" title="">COVID-19</a></li><li><a href="/web/20211103184409/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics" class="menu-node-unpublished menu-node-unpublished">Data and statistics</a></li><li><span class="current-breadcrumb">Vaccine data</span></li></ul>          </div>
+
+
+
+          <div class="region region-content">
+    <section id="block-system-main" class="block block-system clearfix">
+
+
+  <div class="bootstrap-threecol-stacked">
+
+      <div class="row"> <!-- @TODO: Add extra classes -->
+      <div class="panel-panel left col-xs-12 col-md-3 col-lg-3"><div class="panel-pane pane-block pane-menu-block-1 odd pane-top-link">
+
+        <span class="top-link"><a href="/web/20211103184409/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished active-trail" data-is-top-level="1">COVID-19</a></span>
+
+
+  <div class="pane-content">
+        <div class="menu-block-wrapper menu-block-1 menu-name-main-menu parent-mlid-1445 menu-level-2">
+  <ul class="menu nav"><li class="first collapsed menu-mlid-10163 health-advice depth-4"><a href="/web/20211103184409/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-health-advice-public" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished">Health advice</a></li>
+<li class="collapsed menu-mlid-10630 covid-19-vaccines- depth-4 section-overview hide-children"><a href="/web/20211103184409/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-vaccines" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished" data-is-top-level="1" title="">COVID-19 vaccines </a></li>
+<li class="collapsed menu-mlid-9997 health-professionals depth-4"><a href="/web/20211103184409/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-information-health-professionals" class="menu-node-unpublished menu-node-unpublished">Health professionals</a></li>
+<li class="collapsed menu-mlid-10019 specific-audiences depth-4"><a href="/web/20211103184409/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-information-specific-audiences" class="menu-node-unpublished">Specific audiences</a></li>
+<li class="expanded active-trail menu-mlid-10096 data-and-statistics depth-4"><a href="/web/20211103184409/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics" class="menu-node-unpublished menu-node-unpublished active-trail">Data and statistics</a><ul class="menu nav"><li class="first leaf menu-mlid-10062 current-cases depth-5 same-level-as-node"><a href="/web/20211103184409/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-current-cases" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Current cases</a></li>
+<li class="leaf menu-mlid-10146 case-demographics depth-5 same-level-as-node"><a href="/web/20211103184409/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-case-demographics">Case demographics</a></li>
+<li class="leaf menu-mlid-10097 source-of-cases depth-5 same-level-as-node"><a href="/web/20211103184409/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-source-cases" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Source of cases</a></li>
+<li class="leaf menu-mlid-10119 testing-for-covid-19 depth-5 same-level-as-node"><a href="/web/20211103184409/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/testing-covid-19" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Testing for COVID-19</a></li>
+<li class="leaf menu-mlid-10371 nz-covid-tracer-app-data depth-5 same-level-as-node"><a href="/web/20211103184409/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-nz-covid-tracer-app-data" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">NZ COVID Tracer app data</a></li>
+<li class="expanded active-trail active menu-mlid-10584 active vaccine-data depth-5 same-level-as-node"><a href="/web/20211103184409/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished active-trail active">Vaccine data</a><ul class="menu nav"><li class="first leaf menu-mlid-10867 covid-19-vaccination-uptake-rates-across-nz depth-6"><a href="/web/20211103184409/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-across-nz" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">COVID-19 Vaccination uptake rates across NZ</a></li>
+<li class="leaf menu-mlid-10868 covid-19-vaccination-uptake-rates---māori depth-6"><a href="/web/20211103184409/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-maori-communities-across-nz" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">COVID-19 Vaccination uptake rates - Māori</a></li>
+<li class="last leaf menu-mlid-10869 covid-19-vaccination-uptake-rates---pacific depth-6"><a href="/web/20211103184409/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-pacific-communities-across-nz" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">COVID-19 Vaccination uptake rates - Pacific</a></li>
+</ul></li>
+<li class="last leaf menu-mlid-10404 data-resources depth-5 same-level-as-node"><a href="/web/20211103184409/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-data-resources" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Data resources</a></li>
+</ul></li>
+<li class="collapsed menu-mlid-10369 response-planning depth-4"><a href="/web/20211103184409/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-response-planning" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished" data-is-top-level="1" title="">Response planning</a></li>
+<li class="collapsed menu-mlid-10015 resources-and-tools depth-4"><a href="/web/20211103184409/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-resources-and-tools" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Resources and tools</a></li>
+<li class="last leaf menu-mlid-10004 news-and-media depth-4 section-overview hide-children"><a href="/web/20211103184409/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-news-and-media-updates" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">News and media</a></li>
+</ul></div>
+  </div>
+
+
+  </div>
+</div>      <div class="panel-panel middle col-xs-12 col-md-9 col-lg-9"><div class="panel-pane pane-page-title even">
+
+
+
+  <div class="pane-content">
+    <span id="skip-content" tabindex="-1"></span>    <h1>COVID-19: Vaccine data</h1>
+  </div>
+
+
+  </div>
+<div class="panel-pane pane-node-content odd">
+
+
+
+  <div class="pane-content">
+        <article id="node-12052" class="node node-page node-sticky view-mode-full clearfix" about="/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" typeof="sioc:Item foaf:Document">
+    <header>
+            <span property="dc:title" content="COVID-19: Vaccine data" class="rdf-meta element-hidden"></span>      </header>
+    <div class="field field-name-field-intro-text field-type-text-long field-label-hidden"><div class="field-items"><div class="field-item even"><p class="intro-text">Data and statistics about the rollout of COVID-19 vaccines in New Zealand.</p></div></div></div><div class="field field-name-body field-type-text-with-summary field-label-hidden"><div class="field-items"><div class="field-item even" property="content:encoded"><p>On this page:</p>
+
+<ul>
+	<li><a href="#daily">Daily updates</a>
+
+	<ul>
+		<li><a href="#total-vaccinations">Total vaccinations</a></li>
+		<li><a href="#ethnicity">Vaccinations by ethnicity</a></li>
+		<li><a href="#90pct">Vaccinations to 90% by DHB</a></li>
+	</ul>
+	</li>
+	<li><a href="#weekly-updates">Weekly updates</a>
+	<ul>
+		<li><a href="#model">Vaccinations against plan</a></li>
+		<li><a href="#uptake">Vaccinations uptake</a></li>
+		<li><a href="#by-day">Vaccinations by day</a></li>
+		<li><a href="#location">Vaccinations by DHB</a></li>
+		<li><a href="#group">Vaccinations by group</a></li>
+		<li><a href="#by_soh">Stock on hand</a></li>
+		<li><a href="#age">Vaccinations by age</a></li>
+		<li><a href="#workforce">Trained vaccinator and active vaccinator</a></li>
+		<li><a href="#group">Vaccinations by group</a></li>
+		<li><a href="#download">Details of vaccination&nbsp;data</a></li>
+	</ul>
+	</li>
+	<li><a href="#adverse-events">Adverse events from immunisations</a></li>
+</ul>
+
+<hr/><!--daily-->
+<h2><a id="daily" name="daily"></a>COVID-19 vaccinations: daily updates</h2>
+
+<div class="well well-sm">
+<p style="margin-top: 0"><strong>Data in this section is as at 11:59pm 02 November 2021 and is updated daily.</strong></p>
+</div>
+
+<h3><a id="total-vaccinations" name="total-vaccinations"></a>Total Vaccinations</h3>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">&nbsp;</th>
+			<th scope="col" style="text-align:right">Vaccinations yesterday</th>
+			<th scope="col" style="text-align:right">Cumulative total</th>
+			<th scope="col" style="text-align:right">Eligible population vaccinated %</th>
+			<th scope="col" style="text-align:right">Total population vaccinated %</th>
+			<th scope="col" style="text-align:right">Vaccinated or booked</th>
+			<th scope="col" style="text-align:right">Eligible vaccinated or booked %</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">First dose</th>
+			<td style="text-align:right">7,574</td>
+			<td style="text-align:right">3,724,359</td>
+			<td style="text-align:right">88%</td>
+			<td style="text-align:right">74%</td>
+			<td style="text-align:right">3,735,100</td>
+			<td style="text-align:right">89%</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Second dose</th>
+			<td style="text-align:right">21,347</td>
+			<td style="text-align:right">3,201,226</td>
+			<td style="text-align:right">76%</td>
+			<td style="text-align:right">64%</td>
+			<td style="text-align:right">3,397,494</td>
+			<td style="text-align:right">82%</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total doses</strong></th>
+			<td style="text-align:right"><strong>28,921</strong></td>
+			<td style="text-align:right"><strong>6,925,585</strong></td>
+		</tr>
+	</tbody>
+</table>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Total vaccinations" class="img-responsive" height="900" src="/web/20211103184409im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_summary_18.png" width="5340"/></figure>
+
+<h5>Definitions</h5>
+
+<ul>
+	<li><strong>Cumulative total:</strong>&nbsp;All vaccinations that have been administered and entered into the COVID-19 Immunisation Register up until midnight of the night before the data is published.</li>
+	<li><strong>Eligible population vaccinated %:</strong>&nbsp;Vaccinations administered divided by HSU population estimates for the eligible population (12+).</li>
+	<li><strong>Total population vaccinated %:</strong>&nbsp;Vaccinations administered divided by HSU population estimates for the total population (0+).</li>
+	<li><strong>Vaccinated or booked:</strong>&nbsp;Count of individuals who have either received their vaccination or have booked via Book My Vaccine to receive a vaccination.</li>
+	<li><strong>Eligible vaccinated or booked %:</strong>&nbsp;Count of individuals who have either received their vaccination or have booked via Book My Vaccine to receive a vaccination divided by HSU population estimates for the eligible population (12+).</li>
+</ul>
+
+<p>HSU population estimates are available in the downloadable spreadsheet at the bottom of the page. Throughout the rest of this sheet doses per 1,000 are based on eligible (12+) population.</p>
+
+<p>Bookings are only counted if the site is using Book My Vaccine. Bookings made through other Patient Management Systems are not counted.</p>
+
+<hr/>
+<h3><a id="by_eth" name="ethnicity"></a>Cumulative vaccinations by ethnicity</h3>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">Ethnicity *</th>
+			<th scope="col" style="text-align:right">First dose administered</th>
+			<th scope="col" style="text-align:right">First doses per 1,000 people</th>
+			<th scope="col" style="text-align:right">Second dose administered</th>
+			<th scope="col" style="text-align:right">Second doses per 1,000 people</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">Māori</th>
+			<td style="text-align:right">414,971</td>
+			<td style="text-align:right">727</td>
+			<td style="text-align:right">307,415</td>
+			<td style="text-align:right">538</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Pacific Peoples</th>
+			<td style="text-align:right">245,346</td>
+			<td style="text-align:right">856</td>
+			<td style="text-align:right">199,969</td>
+			<td style="text-align:right">698</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Asian</th>
+			<td style="text-align:right">609,061</td>
+			<td style="text-align:right">&gt;950</td>
+			<td style="text-align:right">548,719</td>
+			<td style="text-align:right">917</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">European / Other</th>
+			<td style="text-align:right">2,420,894</td>
+			<td style="text-align:right">887</td>
+			<td style="text-align:right">2,116,217</td>
+			<td style="text-align:right">775</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Unknown</th>
+			<td style="text-align:right">34,087</td>
+			<td style="text-align:right">-</td>
+			<td style="text-align:right">28,906</td>
+			<td style="text-align:right">-</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total</strong></th>
+			<td style="text-align:right"><strong>3,724,359</strong></td>
+			<td style="text-align:right"><strong>885</strong></td>
+			<td style="text-align:right"><strong>3,201,226</strong></td>
+			<td style="text-align:right"><strong>761</strong></td>
+		</tr>
+	</tbody>
+</table>
+
+<p><strong>*</strong> The prioritised ethnicity classification system allocates each person to a single ethnic group, based on the ethnic groups they identify with. Where people identify with more than one group, they are assigned in this order of priority: Māori, Pacific Peoples, Asian, and European/Other. So, if a person identifies as being Māori and New Zealand European, the person is counted as Māori. See <a href="/web/20211103184409/https://www.health.govt.nz/publication/hiso-100012017-ethnicity-data-protocols">Ethnicity Data Protocols</a> for further information.</p>
+
+<p>Ethnicity breakdown by DHB of residence is available in the downloadable spreadsheet at the bottom of the page.</p>
+
+<hr/>
+<h3><a id="90pct" name="90pct"></a>Vaccinations to 90% by DHB</h3>
+
+<h4><a id="90pct all ethnicities" name="90pct all ethnicities"></a>All Ethnicities</h4>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">&nbsp;</th>
+			<th scope="col" style="text-align:right">First doses</th>
+			<th scope="col" style="text-align:right">First doses %</th>
+			<th scope="col" style="text-align:right">First doses to 90%</th>
+			<th scope="col" style="text-align:right">Second doses</th>
+			<th scope="col" style="text-align:right">Second doses %</th>
+			<th scope="col" style="text-align:right">Second doses to 90%</th>
+			<th scope="col" style="text-align:right">Population</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">Northland</th>
+			<td style="text-align:right">128,556</td>
+			<td style="text-align:right">80%</td>
+			<td style="text-align:right">16,632</td>
+			<td style="text-align:right">105,631</td>
+			<td style="text-align:right">65%</td>
+			<td style="text-align:right">39,557</td>
+			<td style="text-align:right">161,320</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waitemata</th>
+			<td style="text-align:right">481,264</td>
+			<td style="text-align:right">91%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">428,451</td>
+			<td style="text-align:right">81%</td>
+			<td style="text-align:right">45,027</td>
+			<td style="text-align:right">526,087</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Auckland</th>
+			<td style="text-align:right">399,426</td>
+			<td style="text-align:right">94%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">361,728</td>
+			<td style="text-align:right">85%</td>
+			<td style="text-align:right">19,834</td>
+			<td style="text-align:right">423,958</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Counties Manukau</th>
+			<td style="text-align:right">431,303</td>
+			<td style="text-align:right">89%</td>
+			<td style="text-align:right">3,193</td>
+			<td style="text-align:right">376,790</td>
+			<td style="text-align:right">78%</td>
+			<td style="text-align:right">57,706</td>
+			<td style="text-align:right">482,773</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waikato</th>
+			<td style="text-align:right">311,221</td>
+			<td style="text-align:right">87%</td>
+			<td style="text-align:right">10,237</td>
+			<td style="text-align:right">261,839</td>
+			<td style="text-align:right">73%</td>
+			<td style="text-align:right">59,619</td>
+			<td style="text-align:right">357,176</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Lakes</th>
+			<td style="text-align:right">76,643</td>
+			<td style="text-align:right">81%</td>
+			<td style="text-align:right">8,334</td>
+			<td style="text-align:right">63,033</td>
+			<td style="text-align:right">67%</td>
+			<td style="text-align:right">21,944</td>
+			<td style="text-align:right">94,419</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Bay of Plenty</th>
+			<td style="text-align:right">181,214</td>
+			<td style="text-align:right">84%</td>
+			<td style="text-align:right">14,033</td>
+			<td style="text-align:right">149,431</td>
+			<td style="text-align:right">69%</td>
+			<td style="text-align:right">45,816</td>
+			<td style="text-align:right">216,941</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Tairawhiti</th>
+			<td style="text-align:right">33,125</td>
+			<td style="text-align:right">79%</td>
+			<td style="text-align:right">4,644</td>
+			<td style="text-align:right">27,017</td>
+			<td style="text-align:right">64%</td>
+			<td style="text-align:right">10,752</td>
+			<td style="text-align:right">41,965</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Taranaki</th>
+			<td style="text-align:right">86,381</td>
+			<td style="text-align:right">85%</td>
+			<td style="text-align:right">5,551</td>
+			<td style="text-align:right">68,720</td>
+			<td style="text-align:right">67%</td>
+			<td style="text-align:right">23,212</td>
+			<td style="text-align:right">102,147</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hawkes Bay</th>
+			<td style="text-align:right">123,666</td>
+			<td style="text-align:right">85%</td>
+			<td style="text-align:right">7,348</td>
+			<td style="text-align:right">104,851</td>
+			<td style="text-align:right">72%</td>
+			<td style="text-align:right">26,163</td>
+			<td style="text-align:right">145,571</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">MidCentral</th>
+			<td style="text-align:right">132,067</td>
+			<td style="text-align:right">87%</td>
+			<td style="text-align:right">5,005</td>
+			<td style="text-align:right">111,587</td>
+			<td style="text-align:right">73%</td>
+			<td style="text-align:right">25,485</td>
+			<td style="text-align:right">152,302</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Whanganui</th>
+			<td style="text-align:right">46,340</td>
+			<td style="text-align:right">81%</td>
+			<td style="text-align:right">5,182</td>
+			<td style="text-align:right">39,339</td>
+			<td style="text-align:right">69%</td>
+			<td style="text-align:right">12,183</td>
+			<td style="text-align:right">57,247</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Capital and Coast</th>
+			<td style="text-align:right">250,511</td>
+			<td style="text-align:right">92%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">220,597</td>
+			<td style="text-align:right">81%</td>
+			<td style="text-align:right">23,460</td>
+			<td style="text-align:right">271,174</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hutt Valley</th>
+			<td style="text-align:right">115,093</td>
+			<td style="text-align:right">88%</td>
+			<td style="text-align:right">2,122</td>
+			<td style="text-align:right">98,405</td>
+			<td style="text-align:right">76%</td>
+			<td style="text-align:right">18,810</td>
+			<td style="text-align:right">130,239</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Wairarapa</th>
+			<td style="text-align:right">35,594</td>
+			<td style="text-align:right">86%</td>
+			<td style="text-align:right">1,690</td>
+			<td style="text-align:right">30,372</td>
+			<td style="text-align:right">73%</td>
+			<td style="text-align:right">6,912</td>
+			<td style="text-align:right">41,427</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Nelson Marlborough</th>
+			<td style="text-align:right">118,314</td>
+			<td style="text-align:right">87%</td>
+			<td style="text-align:right">3,855</td>
+			<td style="text-align:right">103,969</td>
+			<td style="text-align:right">77%</td>
+			<td style="text-align:right">18,200</td>
+			<td style="text-align:right">135,743</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">West Coast</th>
+			<td style="text-align:right">22,945</td>
+			<td style="text-align:right">82%</td>
+			<td style="text-align:right">2,170</td>
+			<td style="text-align:right">18,966</td>
+			<td style="text-align:right">68%</td>
+			<td style="text-align:right">6,149</td>
+			<td style="text-align:right">27,906</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Canterbury</th>
+			<td style="text-align:right">442,737</td>
+			<td style="text-align:right">92%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">363,253</td>
+			<td style="text-align:right">75%</td>
+			<td style="text-align:right">71,348</td>
+			<td style="text-align:right">482,890</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">South Canterbury</th>
+			<td style="text-align:right">45,784</td>
+			<td style="text-align:right">87%</td>
+			<td style="text-align:right">1,542</td>
+			<td style="text-align:right">39,780</td>
+			<td style="text-align:right">76%</td>
+			<td style="text-align:right">7,546</td>
+			<td style="text-align:right">52,584</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Southern</th>
+			<td style="text-align:right">260,128</td>
+			<td style="text-align:right">90%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">225,777</td>
+			<td style="text-align:right">78%</td>
+			<td style="text-align:right">33,436</td>
+			<td style="text-align:right">288,015</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Overseas / Unknown</th>
+			<td style="text-align:right">2,047</td>
+			<td style="text-align:right">12%</td>
+			<td style="text-align:right">13,409</td>
+			<td style="text-align:right">1,690</td>
+			<td style="text-align:right">10%</td>
+			<td style="text-align:right">13,766</td>
+			<td style="text-align:right">17,173</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total</strong></th>
+			<td style="text-align:right"><strong>3,724,359</strong></td>
+			<td style="text-align:right"><strong>88%</strong></td>
+			<td style="text-align:right"><strong>63,792</strong></td>
+			<td style="text-align:right"><strong>3,201,226</strong></td>
+			<td style="text-align:right"><strong>76%</strong></td>
+			<td style="text-align:right"><strong>586,925</strong></td>
+			<td style="text-align:right"><strong>4,209,057</strong></td>
+		</tr>
+	</tbody>
+</table>
+
+<p>First/second doses % are the number of first/second doses administered divided by the eligible population. First/second doses to 90% are the number of doses required to reach 90% of the eligible population. For these two measures, the national total may not be the sum of DHB measures.</p>
+
+<h4><a id="90pct Māori" name="90pct Māori">Māori</a></h4>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">&nbsp;</th>
+			<th scope="col" style="text-align:right">First doses</th>
+			<th scope="col" style="text-align:right">First doses %</th>
+			<th scope="col" style="text-align:right">First doses to 90%</th>
+			<th scope="col" style="text-align:right">Second doses</th>
+			<th scope="col" style="text-align:right">Second doses %</th>
+			<th scope="col" style="text-align:right">Second doses to 90%</th>
+			<th scope="col" style="text-align:right">Population</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">Northland</th>
+			<td style="text-align:right">34,349</td>
+			<td style="text-align:right">68%</td>
+			<td style="text-align:right">11,090</td>
+			<td style="text-align:right">24,451</td>
+			<td style="text-align:right">48%</td>
+			<td style="text-align:right">20,988</td>
+			<td style="text-align:right">50,488</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waitemata</th>
+			<td style="text-align:right">33,172</td>
+			<td style="text-align:right">81%</td>
+			<td style="text-align:right">3,830</td>
+			<td style="text-align:right">26,072</td>
+			<td style="text-align:right">63%</td>
+			<td style="text-align:right">10,930</td>
+			<td style="text-align:right">41,113</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Auckland</th>
+			<td style="text-align:right">23,137</td>
+			<td style="text-align:right">83%</td>
+			<td style="text-align:right">1,876</td>
+			<td style="text-align:right">18,621</td>
+			<td style="text-align:right">67%</td>
+			<td style="text-align:right">6,392</td>
+			<td style="text-align:right">27,792</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Counties Manukau</th>
+			<td style="text-align:right">47,289</td>
+			<td style="text-align:right">74%</td>
+			<td style="text-align:right">9,855</td>
+			<td style="text-align:right">34,944</td>
+			<td style="text-align:right">55%</td>
+			<td style="text-align:right">22,200</td>
+			<td style="text-align:right">63,493</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waikato</th>
+			<td style="text-align:right">51,441</td>
+			<td style="text-align:right">74%</td>
+			<td style="text-align:right">11,295</td>
+			<td style="text-align:right">36,908</td>
+			<td style="text-align:right">53%</td>
+			<td style="text-align:right">25,828</td>
+			<td style="text-align:right">69,707</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Lakes</th>
+			<td style="text-align:right">20,039</td>
+			<td style="text-align:right">67%</td>
+			<td style="text-align:right">7,038</td>
+			<td style="text-align:right">14,447</td>
+			<td style="text-align:right">48%</td>
+			<td style="text-align:right">12,630</td>
+			<td style="text-align:right">30,085</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Bay of Plenty</th>
+			<td style="text-align:right">31,019</td>
+			<td style="text-align:right">65%</td>
+			<td style="text-align:right">11,942</td>
+			<td style="text-align:right">22,295</td>
+			<td style="text-align:right">47%</td>
+			<td style="text-align:right">20,666</td>
+			<td style="text-align:right">47,734</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Tairawhiti</th>
+			<td style="text-align:right">13,701</td>
+			<td style="text-align:right">69%</td>
+			<td style="text-align:right">4,154</td>
+			<td style="text-align:right">10,138</td>
+			<td style="text-align:right">51%</td>
+			<td style="text-align:right">7,717</td>
+			<td style="text-align:right">19,839</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Taranaki</th>
+			<td style="text-align:right">10,992</td>
+			<td style="text-align:right">69%</td>
+			<td style="text-align:right">3,322</td>
+			<td style="text-align:right">7,531</td>
+			<td style="text-align:right">47%</td>
+			<td style="text-align:right">6,783</td>
+			<td style="text-align:right">15,904</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hawkes Bay</th>
+			<td style="text-align:right">23,189</td>
+			<td style="text-align:right">68%</td>
+			<td style="text-align:right">7,464</td>
+			<td style="text-align:right">16,840</td>
+			<td style="text-align:right">49%</td>
+			<td style="text-align:right">13,813</td>
+			<td style="text-align:right">34,059</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">MidCentral</th>
+			<td style="text-align:right">17,548</td>
+			<td style="text-align:right">72%</td>
+			<td style="text-align:right">4,254</td>
+			<td style="text-align:right">12,847</td>
+			<td style="text-align:right">53%</td>
+			<td style="text-align:right">8,956</td>
+			<td style="text-align:right">24,225</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Whanganui</th>
+			<td style="text-align:right">8,913</td>
+			<td style="text-align:right">66%</td>
+			<td style="text-align:right">3,248</td>
+			<td style="text-align:right">6,729</td>
+			<td style="text-align:right">50%</td>
+			<td style="text-align:right">5,432</td>
+			<td style="text-align:right">13,512</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Capital and Coast</th>
+			<td style="text-align:right">21,695</td>
+			<td style="text-align:right">80%</td>
+			<td style="text-align:right">2,575</td>
+			<td style="text-align:right">17,179</td>
+			<td style="text-align:right">64%</td>
+			<td style="text-align:right">7,091</td>
+			<td style="text-align:right">26,967</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hutt Valley</th>
+			<td style="text-align:right">14,159</td>
+			<td style="text-align:right">74%</td>
+			<td style="text-align:right">3,052</td>
+			<td style="text-align:right">10,708</td>
+			<td style="text-align:right">56%</td>
+			<td style="text-align:right">6,503</td>
+			<td style="text-align:right">19,123</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Wairarapa</th>
+			<td style="text-align:right">4,477</td>
+			<td style="text-align:right">71%</td>
+			<td style="text-align:right">1,195</td>
+			<td style="text-align:right">3,243</td>
+			<td style="text-align:right">51%</td>
+			<td style="text-align:right">2,429</td>
+			<td style="text-align:right">6,302</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Nelson Marlborough</th>
+			<td style="text-align:right">8,027</td>
+			<td style="text-align:right">71%</td>
+			<td style="text-align:right">2,096</td>
+			<td style="text-align:right">6,125</td>
+			<td style="text-align:right">54%</td>
+			<td style="text-align:right">3,998</td>
+			<td style="text-align:right">11,248</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">West Coast</th>
+			<td style="text-align:right">2,036</td>
+			<td style="text-align:right">74%</td>
+			<td style="text-align:right">452</td>
+			<td style="text-align:right">1,504</td>
+			<td style="text-align:right">54%</td>
+			<td style="text-align:right">984</td>
+			<td style="text-align:right">2,765</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Canterbury</th>
+			<td style="text-align:right">28,933</td>
+			<td style="text-align:right">78%</td>
+			<td style="text-align:right">4,339</td>
+			<td style="text-align:right">20,719</td>
+			<td style="text-align:right">56%</td>
+			<td style="text-align:right">12,553</td>
+			<td style="text-align:right">36,969</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">South Canterbury</th>
+			<td style="text-align:right">2,495</td>
+			<td style="text-align:right">73%</td>
+			<td style="text-align:right">590</td>
+			<td style="text-align:right">1,881</td>
+			<td style="text-align:right">55%</td>
+			<td style="text-align:right">1,204</td>
+			<td style="text-align:right">3,428</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Southern</th>
+			<td style="text-align:right">18,171</td>
+			<td style="text-align:right">77%</td>
+			<td style="text-align:right">3,110</td>
+			<td style="text-align:right">14,096</td>
+			<td style="text-align:right">60%</td>
+			<td style="text-align:right">7,185</td>
+			<td style="text-align:right">23,646</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Overseas / Unknown</th>
+			<td style="text-align:right">189</td>
+			<td style="text-align:right">7%</td>
+			<td style="text-align:right">2,199</td>
+			<td style="text-align:right">137</td>
+			<td style="text-align:right">5%</td>
+			<td style="text-align:right">2,251</td>
+			<td style="text-align:right">2,653</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total</strong></th>
+			<td style="text-align:right"><strong>414,971</strong></td>
+			<td style="text-align:right"><strong>73%</strong></td>
+			<td style="text-align:right"><strong>98,976</strong></td>
+			<td style="text-align:right"><strong>307,415</strong></td>
+			<td style="text-align:right"><strong>54%</strong></td>
+			<td style="text-align:right"><strong>206,532</strong></td>
+			<td style="text-align:right"><strong>571,052</strong></td>
+		</tr>
+	</tbody>
+</table>
+
+<h4><a id="90pct Pacific Peoples" name="90pct Pacific Peoples"></a>Pacific Peoples</h4>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">&nbsp;</th>
+			<th scope="col" style="text-align:right">First doses</th>
+			<th scope="col" style="text-align:right">First doses %</th>
+			<th scope="col" style="text-align:right">First doses to 90%</th>
+			<th scope="col" style="text-align:right">Second doses</th>
+			<th scope="col" style="text-align:right">Second doses %</th>
+			<th scope="col" style="text-align:right">Second doses to 90%</th>
+			<th scope="col" style="text-align:right">Population</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">Northland</th>
+			<td style="text-align:right">2,392</td>
+			<td style="text-align:right">82%</td>
+			<td style="text-align:right">249</td>
+			<td style="text-align:right">1,794</td>
+			<td style="text-align:right">61%</td>
+			<td style="text-align:right">847</td>
+			<td style="text-align:right">2,934</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waitemata</th>
+			<td style="text-align:right">32,292</td>
+			<td style="text-align:right">86%</td>
+			<td style="text-align:right">1,524</td>
+			<td style="text-align:right">26,546</td>
+			<td style="text-align:right">71%</td>
+			<td style="text-align:right">7,270</td>
+			<td style="text-align:right">37,573</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Auckland</th>
+			<td style="text-align:right">39,803</td>
+			<td style="text-align:right">85%</td>
+			<td style="text-align:right">2,376</td>
+			<td style="text-align:right">32,830</td>
+			<td style="text-align:right">70%</td>
+			<td style="text-align:right">9,349</td>
+			<td style="text-align:right">46,866</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Counties Manukau</th>
+			<td style="text-align:right">97,726</td>
+			<td style="text-align:right">84%</td>
+			<td style="text-align:right">7,122</td>
+			<td style="text-align:right">79,994</td>
+			<td style="text-align:right">69%</td>
+			<td style="text-align:right">24,854</td>
+			<td style="text-align:right">116,498</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Waikato</th>
+			<td style="text-align:right">9,223</td>
+			<td style="text-align:right">86%</td>
+			<td style="text-align:right">391</td>
+			<td style="text-align:right">7,435</td>
+			<td style="text-align:right">70%</td>
+			<td style="text-align:right">2,179</td>
+			<td style="text-align:right">10,682</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Lakes</th>
+			<td style="text-align:right">1,837</td>
+			<td style="text-align:right">80%</td>
+			<td style="text-align:right">220</td>
+			<td style="text-align:right">1,468</td>
+			<td style="text-align:right">64%</td>
+			<td style="text-align:right">589</td>
+			<td style="text-align:right">2,286</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Bay of Plenty</th>
+			<td style="text-align:right">4,067</td>
+			<td style="text-align:right">&gt;95%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">3,211</td>
+			<td style="text-align:right">87%</td>
+			<td style="text-align:right">100</td>
+			<td style="text-align:right">3,679</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Tairawhiti</th>
+			<td style="text-align:right">883</td>
+			<td style="text-align:right">92%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">687</td>
+			<td style="text-align:right">71%</td>
+			<td style="text-align:right">182</td>
+			<td style="text-align:right">965</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Taranaki</th>
+			<td style="text-align:right">1,066</td>
+			<td style="text-align:right">84%</td>
+			<td style="text-align:right">77</td>
+			<td style="text-align:right">810</td>
+			<td style="text-align:right">64%</td>
+			<td style="text-align:right">333</td>
+			<td style="text-align:right">1,270</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hawkes Bay</th>
+			<td style="text-align:right">5,149</td>
+			<td style="text-align:right">&gt;95%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">4,254</td>
+			<td style="text-align:right">85%</td>
+			<td style="text-align:right">264</td>
+			<td style="text-align:right">5,020</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">MidCentral</th>
+			<td style="text-align:right">3,810</td>
+			<td style="text-align:right">85%</td>
+			<td style="text-align:right">211</td>
+			<td style="text-align:right">2,984</td>
+			<td style="text-align:right">67%</td>
+			<td style="text-align:right">1,037</td>
+			<td style="text-align:right">4,468</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Whanganui</th>
+			<td style="text-align:right">1,054</td>
+			<td style="text-align:right">76%</td>
+			<td style="text-align:right">189</td>
+			<td style="text-align:right">847</td>
+			<td style="text-align:right">61%</td>
+			<td style="text-align:right">396</td>
+			<td style="text-align:right">1,381</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Capital and Coast</th>
+			<td style="text-align:right">15,750</td>
+			<td style="text-align:right">82%</td>
+			<td style="text-align:right">1,509</td>
+			<td style="text-align:right">12,781</td>
+			<td style="text-align:right">67%</td>
+			<td style="text-align:right">4,478</td>
+			<td style="text-align:right">19,177</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Hutt Valley</th>
+			<td style="text-align:right">8,021</td>
+			<td style="text-align:right">81%</td>
+			<td style="text-align:right">884</td>
+			<td style="text-align:right">6,498</td>
+			<td style="text-align:right">66%</td>
+			<td style="text-align:right">2,407</td>
+			<td style="text-align:right">9,894</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Wairarapa</th>
+			<td style="text-align:right">699</td>
+			<td style="text-align:right">84%</td>
+			<td style="text-align:right">54</td>
+			<td style="text-align:right">574</td>
+			<td style="text-align:right">69%</td>
+			<td style="text-align:right">179</td>
+			<td style="text-align:right">837</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Nelson Marlborough</th>
+			<td style="text-align:right">3,638</td>
+			<td style="text-align:right">&gt;95%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">3,188</td>
+			<td style="text-align:right">&gt;95%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">2,115</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">West Coast</th>
+			<td style="text-align:right">233</td>
+			<td style="text-align:right">83%</td>
+			<td style="text-align:right">21</td>
+			<td style="text-align:right">182</td>
+			<td style="text-align:right">65%</td>
+			<td style="text-align:right">72</td>
+			<td style="text-align:right">282</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Canterbury</th>
+			<td style="text-align:right">10,907</td>
+			<td style="text-align:right">86%</td>
+			<td style="text-align:right">556</td>
+			<td style="text-align:right">8,328</td>
+			<td style="text-align:right">65%</td>
+			<td style="text-align:right">3,135</td>
+			<td style="text-align:right">12,737</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">South Canterbury</th>
+			<td style="text-align:right">801</td>
+			<td style="text-align:right">&gt;95%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">643</td>
+			<td style="text-align:right">77%</td>
+			<td style="text-align:right">110</td>
+			<td style="text-align:right">837</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Southern</th>
+			<td style="text-align:right">5,656</td>
+			<td style="text-align:right">94%</td>
+			<td style="text-align:right">0</td>
+			<td style="text-align:right">4,612</td>
+			<td style="text-align:right">76%</td>
+			<td style="text-align:right">816</td>
+			<td style="text-align:right">6,031</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">Overseas / Unknown</th>
+			<td style="text-align:right">339</td>
+			<td style="text-align:right">30%</td>
+			<td style="text-align:right">695</td>
+			<td style="text-align:right">303</td>
+			<td style="text-align:right">26%</td>
+			<td style="text-align:right">731</td>
+			<td style="text-align:right">1,149</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total</strong></th>
+			<td style="text-align:right"><strong>245,346</strong></td>
+			<td style="text-align:right"><strong>86%</strong></td>
+			<td style="text-align:right"><strong>12,667</strong></td>
+			<td style="text-align:right"><strong>199,969</strong></td>
+			<td style="text-align:right"><strong>70%</strong></td>
+			<td style="text-align:right"><strong>58,044</strong></td>
+			<td style="text-align:right"><strong>286,681</strong></td>
+		</tr>
+	</tbody>
+</table>
+<!--daily_end-->
+
+<hr/>
+<h2><a id="weekly-updates" name="weekly-updates"></a>COVID-19 vaccinations: weekly updates</h2>
+
+<div class="well well-sm">
+<p style="margin-top: 0"><strong>Data in this section is as at 11:59pm 02 November 2021 and is updated weekly on Wednesdays.</strong></p>
+</div>
+
+<h3><a id="model" model="" name="id="></a>Cumulative vaccinations</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccination doses administered compared to plan doses" class="img-responsive" height="830" src="/web/20211103184409im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/vaccineplanmodel_14.png" width="1780"/></figure>
+
+<p>Production plan figures are the volumes agreed with DHBs and national providers for expected vaccinations. These figures have been matched with expected supply. Detailed plans are available in the Excel file at the bottom of this page.</p>
+
+<p>The Stock received figures are the cumulative supply of doses to date.</p>
+
+<p>DHB capacity plans for the remainder of the year are undergoing review.</p>
+
+<hr/><!--
+<h3><a id="model" model="" name="id="></a>Cumulative vaccinations for last 6 weeks</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccination doses administered compared to plan doses - 6wks" class="img-responsive" height="830" src="/vaccineplanmodel_wks.png" width="1780" /></figure>
+
+<hr />
+-->
+<h3><a id="uptake" name="uptake"></a>Vaccine uptake</h3>
+
+<p>Maps and data related to uptake rates of the COVID-19 vaccine across the country are available on the pages linked below. These show&nbsp;vaccination records aggregated by area of residence for all New Zealand residents, Māori communities, and Pacific communities.</p>
+
+<ul>
+	<li><a href="/web/20211103184409/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-across-nz">COVID-19 Vaccination uptake rates across NZ</a></li>
+	<li><a href="/web/20211103184409/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-maori-communities-across-nz">COVID-19 Vaccination uptake rates within Māori communities across NZ</a></li>
+	<li><a href="/web/20211103184409/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-pacific-communities-across-nz">COVID-19 Vaccination uptake rates within Pacific communities across NZ</a></li>
+</ul>
+
+<h4><a id="uptake" name="uptake"></a>Vaccine uptake per rate ratio (unadjusted) Māori and Pacific compared with Non-Māori non-Pacific</h4>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine Uptake per 1,000 (HSU) Rate Ratio, Showing Prioritised Ethnicity, vs Non-Māori Non-Pacific, By Age Band" class="img-responsive" height="830" src="/web/20211103184409im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_mix_9.png" width="1780"/></figure>
+
+<p>In the Chart above, rate ratios tell us the rate Māori or Pacific People per population are being vaccinated compared with non-Māori non-Pacific. This comparison can be split by age group.</p>
+
+<ul>
+	<li>A rate of one means the groups being compared are being vaccinated at the same rate.</li>
+	<li>A rate over one means Māori (or Pacific) are being vaccinated at a higher rate than non-Māori non-Pacific.</li>
+	<li>A rate under one means Māori (or Pacific) are being vaccinated at a lower rate than non-Māori non-Pacific.</li>
+</ul>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<td colspan="2" style="border-top: 0 !important; border-bottom-color: #FDD6AF !important; border-right: 0 !important;">&nbsp;</td>
+			<th colspan="6" id="ac1">Māori</th>
+			<th colspan="6" id="ac8">Pacific Peoples</th>
+		</tr>
+		<tr>
+			<th id="ar1">DHB</th>
+			<th>Dose number</th>
+			<th headers="ac1" id="ac2">65+</th>
+			<th headers="ac1" id="ac3">50-64</th>
+			<th headers="ac1" id="ac4">35-49</th>
+			<th headers="ac1" id="ac5">20-34</th>
+			<th headers="ac1" id="ac6">12-19</th>
+			<th headers="ac1" id="ac7">All ages</th>
+			<th headers="ac8" id="ac9">65+</th>
+			<th headers="ac8" id="ac10">50-64</th>
+			<th headers="ac8" id="ac11">35-49</th>
+			<th headers="ac8" id="ac12">20-34</th>
+			<th headers="ac8" id="ac13">12-19</th>
+			<th headers="ac8" id="ac14">All ages</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th headers="ar1" id="ar2" rowspan="2">National</th>
+			<th headers="ar1 ar2" id="ar3">Dose 1</th>
+			<td headers="ar1 ar2 ar3 ac1 ac2" style="background-color:green; color: #FFF;"><strong>1.00</strong></td>
+			<td headers="ar1 ar2 ar3 ac1 ac3" style="background-color:mediumseagreen"><strong>0.94</strong></td>
+			<td headers="ar1 ar2 ar3 ac1 ac4" style="background-color:palegreen"><strong>0.81</strong></td>
+			<td headers="ar1 ar2 ar3 ac1 ac5" style="background-color:orange"><strong>0.70</strong></td>
+			<td headers="ar1 ar2 ar3 ac1 ac6" style="background-color:orange"><strong>0.74</strong></td>
+			<td headers="ar1 ar2 ar3 ac1 ac7" style="background-color:yellow"><strong>0.79</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac9" style="background-color:mediumseagreen"><strong>0.94</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac10" style="background-color:green; color: #FFF;"><strong>1.00</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac11" style="background-color:green; color: #FFF;"><strong>0.98</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac12" style="background-color:mediumseagreen"><strong>0.91</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac13" style="background-color:mediumseagreen"><strong>0.91</strong></td>
+			<td headers="ar1 ar2 ar3 ac8 ac14" style="background-color:mediumseagreen"><strong>0.94</strong></td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar2" id="ar4">Dose 2</th>
+			<td headers="ar1 ar2 ar4 ac1 ac2" style="background-color:green; color: #FFF;"><strong>0.97</strong></td>
+			<td headers="ar1 ar2 ar4 ac1 ac3" style="background-color:lightgreen"><strong>0.88</strong></td>
+			<td headers="ar1 ar2 ar4 ac1 ac4" style="background-color:orange"><strong>0.70</strong></td>
+			<td headers="ar1 ar2 ar4 ac1 ac5" style="background-color:crimson; color: #FFF;"><strong>0.54</strong></td>
+			<td headers="ar1 ar2 ar4 ac1 ac6" style="background-color:tomato"><strong>0.60</strong></td>
+			<td headers="ar1 ar2 ar4 ac1 ac7" style="background-color:coral"><strong>0.67</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac9" style="background-color:mediumseagreen"><strong>0.93</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac10" style="background-color:green; color: #FFF;"><strong>0.99</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac11" style="background-color:green; color: #FFF;"><strong>0.96</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac12" style="background-color:palegreen"><strong>0.83</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac13" style="background-color:lightgreen"><strong>0.87</strong></td>
+			<td headers="ar1 ar2 ar4 ac8 ac14" style="background-color:lightgreen"><strong>0.87</strong></td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar5" rowspan="2">Northland</th>
+			<th headers="ar1 ar5" id="ar6">Dose 1</th>
+			<td headers="ar1 ar5 ar6 ac1 ac2" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar5 ar6 ac1 ac3" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar5 ar6 ac1 ac4" style="background-color:palegreen">0.84</td>
+			<td headers="ar1 ar5 ar6 ac1 ac5" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar5 ar6 ac1 ac6" style="background-color:yellow">0.77</td>
+			<td headers="ar1 ar5 ar6 ac1 ac7" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar5 ar6 ac8 ac9" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar5 ar6 ac8 ac10" style="background-color:green; color: #FFF;">1.06</td>
+			<td headers="ar1 ar5 ar6 ac8 ac11" style="background-color:green; color: #FFF;">1.05</td>
+			<td headers="ar1 ar5 ar6 ac8 ac12" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar5 ar6 ac8 ac13" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar5 ar6 ac8 ac14" style="background-color:green; color: #FFF;">0.96</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar5" id="ar7">Dose 2</th>
+			<td headers="ar1 ar5 ar7 ac1 ac2" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar5 ar7 ac1 ac3" style="background-color:lightgreen">0.88</td>
+			<td headers="ar1 ar5 ar7 ac1 ac4" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar5 ar7 ac1 ac5" style="background-color:crimson; color: #FFF;">0.52</td>
+			<td headers="ar1 ar5 ar7 ac1 ac6" style="background-color:tomato">0.61</td>
+			<td headers="ar1 ar5 ar7 ac1 ac7" style="background-color:coral">0.66</td>
+			<td headers="ar1 ar5 ar7 ac8 ac9" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar5 ar7 ac8 ac10" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar5 ar7 ac8 ac11" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar5 ar7 ac8 ac12" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar5 ar7 ac8 ac13" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar5 ar7 ac8 ac14" style="background-color:palegreen">0.83</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar8" rowspan="2">Auckland Metro</th>
+			<th headers="ar1 ar8" id="ar9">Dose 1</th>
+			<td headers="ar1 ar8 ar9 ac1 ac2" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar8 ar9 ac1 ac3" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar8 ar9 ac1 ac4" style="background-color:palegreen">0.83</td>
+			<td headers="ar1 ar8 ar9 ac1 ac5" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar8 ar9 ac1 ac6" style="background-color:yellow">0.77</td>
+			<td headers="ar1 ar8 ar9 ac1 ac7" style="background-color:palegreen">0.83</td>
+			<td headers="ar1 ar8 ar9 ac8 ac9" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar8 ar9 ac8 ac10" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar8 ar9 ac8 ac11" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar8 ar9 ac8 ac12" style="background-color:palegreen">0.84</td>
+			<td headers="ar1 ar8 ar9 ac8 ac13" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar8 ar9 ac8 ac14" style="background-color:mediumseagreen">0.90</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar8" id="ar10">Dose 2</th>
+			<td headers="ar1 ar8 ar10 ac1 ac2" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar8 ar10 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar8 ar10 ac1 ac4" style="background-color:orange">0.72</td>
+			<td headers="ar1 ar8 ar10 ac1 ac5" style="background-color:crimson; color: #FFF;">0.57</td>
+			<td headers="ar1 ar8 ar10 ac1 ac6" style="background-color:tomato">0.62</td>
+			<td headers="ar1 ar8 ar10 ac1 ac7" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar8 ar10 ac8 ac9" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar8 ar10 ac8 ac10" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar8 ar10 ac8 ac11" style="background-color:lightgreen">0.86</td>
+			<td headers="ar1 ar8 ar10 ac8 ac12" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar8 ar10 ac8 ac13" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar8 ar10 ac8 ac14" style="background-color:palegreen">0.80</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar11" rowspan="2">Waikato</th>
+			<th headers="ar1 ar11" id="ar12">Dose 1</th>
+			<td headers="ar1 ar11 ar12 ac1 ac2" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar11 ar12 ac1 ac3" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar11 ar12 ac1 ac4" style="background-color:palegreen">0.84</td>
+			<td headers="ar1 ar11 ar12 ac1 ac5" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar11 ar12 ac1 ac6" style="background-color:yellow">0.76</td>
+			<td headers="ar1 ar11 ar12 ac1 ac7" style="background-color:palegreen">0.81</td>
+			<td headers="ar1 ar11 ar12 ac8 ac9" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar11 ar12 ac8 ac10" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar11 ar12 ac8 ac11" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar11 ar12 ac8 ac12" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar11 ar12 ac8 ac13" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar11 ar12 ac8 ac14" style="background-color:green; color: #FFF;">0.95</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar11" id="ar13">Dose 2</th>
+			<td headers="ar1 ar11 ar13 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar11 ar13 ac1 ac3" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar11 ar13 ac1 ac4" style="background-color:orange">0.72</td>
+			<td headers="ar1 ar11 ar13 ac1 ac5" style="background-color:crimson; color: #FFF;">0.54</td>
+			<td headers="ar1 ar11 ar13 ac1 ac6" style="background-color:tomato">0.61</td>
+			<td headers="ar1 ar11 ar13 ac1 ac7" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar11 ar13 ac8 ac9" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar11 ar13 ac8 ac10" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar11 ar13 ac8 ac11" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar11 ar13 ac8 ac12" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar11 ar13 ac8 ac13" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar11 ar13 ac8 ac14" style="background-color:lightgreen">0.89</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar14" rowspan="2">Bay of Plenty</th>
+			<th headers="ar1 ar14" id="ar15">Dose 1</th>
+			<td headers="ar1 ar14 ar15 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar14 ar15 ac1 ac3" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar14 ar15 ac1 ac4" style="background-color:yellow">0.77</td>
+			<td headers="ar1 ar14 ar15 ac1 ac5" style="background-color:tomato">0.60</td>
+			<td headers="ar1 ar14 ar15 ac1 ac6" style="background-color:coral">0.66</td>
+			<td headers="ar1 ar14 ar15 ac1 ac7" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar14 ar15 ac8 ac9" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar14 ar15 ac8 ac10" style="background-color:green; color: #FFF;">1.10</td>
+			<td headers="ar1 ar14 ar15 ac8 ac11" style="background-color:green; color: #FFF;">1.48</td>
+			<td headers="ar1 ar14 ar15 ac8 ac12" style="background-color:green; color: #FFF;">1.51</td>
+			<td headers="ar1 ar14 ar15 ac8 ac13" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar14 ar15 ac8 ac14" style="background-color:green; color: #FFF;">1.24</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar14" id="ar16">Dose 2</th>
+			<td headers="ar1 ar14 ar16 ac1 ac2" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar14 ar16 ac1 ac3" style="background-color:lightgreen">0.86</td>
+			<td headers="ar1 ar14 ar16 ac1 ac4" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar14 ar16 ac1 ac5" style="background-color:crimson; color: #FFF;">0.47</td>
+			<td headers="ar1 ar14 ar16 ac1 ac6" style="background-color:crimson; color: #FFF;">0.56</td>
+			<td headers="ar1 ar14 ar16 ac1 ac7" style="background-color:tomato">0.62</td>
+			<td headers="ar1 ar14 ar16 ac8 ac9" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar14 ar16 ac8 ac10" style="background-color:green; color: #FFF;">1.05</td>
+			<td headers="ar1 ar14 ar16 ac8 ac11" style="background-color:green; color: #FFF;">1.53</td>
+			<td headers="ar1 ar14 ar16 ac8 ac12" style="background-color:green; color: #FFF;">1.61</td>
+			<td headers="ar1 ar14 ar16 ac8 ac13" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar14 ar16 ac8 ac14" style="background-color:green; color: #FFF;">1.15</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar17" rowspan="2">Tairawhiti</th>
+			<th headers="ar1 ar17" id="ar18">Dose 1</th>
+			<td headers="ar1 ar17 ar18 ac1 ac2" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar17 ar18 ac1 ac3" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar17 ar18 ac1 ac4" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar17 ar18 ac1 ac5" style="background-color:coral">0.66</td>
+			<td headers="ar1 ar17 ar18 ac1 ac6" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar17 ar18 ac1 ac7" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar17 ar18 ac8 ac9" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar17 ar18 ac8 ac10" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar17 ar18 ac8 ac11" style="background-color:green; color: #FFF;">1.10</td>
+			<td headers="ar1 ar17 ar18 ac8 ac12" style="background-color:green; color: #FFF;">1.05</td>
+			<td headers="ar1 ar17 ar18 ac8 ac13" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar17 ar18 ac8 ac14" style="background-color:green; color: #FFF;">1.04</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar17" id="ar19">Dose 2</th>
+			<td headers="ar1 ar17 ar19 ac1 ac2" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar17 ar19 ac1 ac3" style="background-color:lightgreen">0.87</td>
+			<td headers="ar1 ar17 ar19 ac1 ac4" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar17 ar19 ac1 ac5" style="background-color:crimson; color: #FFF;">0.51</td>
+			<td headers="ar1 ar17 ar19 ac1 ac6" style="background-color:crimson; color: #FFF;">0.59</td>
+			<td headers="ar1 ar17 ar19 ac1 ac7" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar17 ar19 ac8 ac9" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar17 ar19 ac8 ac10" style="background-color:green; color: #FFF;">1.06</td>
+			<td headers="ar1 ar17 ar19 ac8 ac11" style="background-color:green; color: #FFF;">1.07</td>
+			<td headers="ar1 ar17 ar19 ac8 ac12" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar17 ar19 ac8 ac13" style="background-color:palegreen">0.81</td>
+			<td headers="ar1 ar17 ar19 ac8 ac14" style="background-color:mediumseagreen">0.92</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar20" rowspan="2">Lakes</th>
+			<th headers="ar1 ar20" id="ar21">Dose 1</th>
+			<td headers="ar1 ar20 ar21 ac1 ac2" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar20 ar21 ac1 ac3" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar20 ar21 ac1 ac4" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar20 ar21 ac1 ac5" style="background-color:tomato">0.62</td>
+			<td headers="ar1 ar20 ar21 ac1 ac6" style="background-color:coral">0.68</td>
+			<td headers="ar1 ar20 ar21 ac1 ac7" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar20 ar21 ac8 ac9" style="background-color:green; color: #FFF;">1.06</td>
+			<td headers="ar1 ar20 ar21 ac8 ac10" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar20 ar21 ac8 ac11" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar20 ar21 ac8 ac12" style="background-color:palegreen">0.83</td>
+			<td headers="ar1 ar20 ar21 ac8 ac13" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar20 ar21 ac8 ac14" style="background-color:mediumseagreen">0.91</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar20" id="ar22">Dose 2</th>
+			<td headers="ar1 ar20 ar22 ac1 ac2" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar20 ar22 ac1 ac3" style="background-color:lightgreen">0.86</td>
+			<td headers="ar1 ar20 ar22 ac1 ac4" style="background-color:coral">0.69</td>
+			<td headers="ar1 ar20 ar22 ac1 ac5" style="background-color:crimson; color: #FFF;">0.47</td>
+			<td headers="ar1 ar20 ar22 ac1 ac6" style="background-color:crimson; color: #FFF;">0.55</td>
+			<td headers="ar1 ar20 ar22 ac1 ac7" style="background-color:tomato">0.63</td>
+			<td headers="ar1 ar20 ar22 ac8 ac9" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar20 ar22 ac8 ac10" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar20 ar22 ac8 ac11" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar20 ar22 ac8 ac12" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar20 ar22 ac8 ac13" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar20 ar22 ac8 ac14" style="background-color:lightgreen">0.85</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar23" rowspan="2">Taranaki</th>
+			<th headers="ar1 ar23" id="ar24">Dose 1</th>
+			<td headers="ar1 ar23 ar24 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar23 ar24 ac1 ac3" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar23 ar24 ac1 ac4" style="background-color:palegreen">0.83</td>
+			<td headers="ar1 ar23 ar24 ac1 ac5" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar23 ar24 ac1 ac6" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar23 ar24 ac1 ac7" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar23 ar24 ac8 ac9" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar23 ar24 ac8 ac10" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar23 ar24 ac8 ac11" style="background-color:green; color: #FFF;">1.07</td>
+			<td headers="ar1 ar23 ar24 ac8 ac12" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar23 ar24 ac8 ac13" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar23 ar24 ac8 ac14" style="background-color:green; color: #FFF;">0.96</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar23" id="ar25">Dose 2</th>
+			<td headers="ar1 ar23 ar25 ac1 ac2" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar23 ar25 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar23 ar25 ac1 ac4" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar23 ar25 ac1 ac5" style="background-color:crimson; color: #FFF;">0.55</td>
+			<td headers="ar1 ar23 ar25 ac1 ac6" style="background-color:crimson; color: #FFF;">0.59</td>
+			<td headers="ar1 ar23 ar25 ac1 ac7" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar23 ar25 ac8 ac9" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar23 ar25 ac8 ac10" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar23 ar25 ac8 ac11" style="background-color:green; color: #FFF;">1.13</td>
+			<td headers="ar1 ar23 ar25 ac8 ac12" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar23 ar25 ac8 ac13" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar23 ar25 ac8 ac14" style="background-color:mediumseagreen">0.90</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar26" rowspan="2">Whanganui</th>
+			<th headers="ar1 ar26" id="ar27">Dose 1</th>
+			<td headers="ar1 ar26 ar27 ac1 ac2" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar26 ar27 ac1 ac3" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar26 ar27 ac1 ac4" style="background-color:palegreen">0.81</td>
+			<td headers="ar1 ar26 ar27 ac1 ac5" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar26 ar27 ac1 ac6" style="background-color:orange">0.72</td>
+			<td headers="ar1 ar26 ar27 ac1 ac7" style="background-color:yellow">0.77</td>
+			<td headers="ar1 ar26 ar27 ac8 ac9" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar26 ar27 ac8 ac10" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar26 ar27 ac8 ac11" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar26 ar27 ac8 ac12" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar26 ar27 ac8 ac13" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar26 ar27 ac8 ac14" style="background-color:lightgreen">0.88</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar26" id="ar28">Dose 2</th>
+			<td headers="ar1 ar26 ar28 ac1 ac2" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar26 ar28 ac1 ac3" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar26 ar28 ac1 ac4" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar26 ar28 ac1 ac5" style="background-color:crimson; color: #FFF;">0.53</td>
+			<td headers="ar1 ar26 ar28 ac1 ac6" style="background-color:tomato">0.61</td>
+			<td headers="ar1 ar26 ar28 ac1 ac7" style="background-color:coral">0.66</td>
+			<td headers="ar1 ar26 ar28 ac8 ac9" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar26 ar28 ac8 ac10" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar26 ar28 ac8 ac11" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar26 ar28 ac8 ac12" style="background-color:palegreen">0.84</td>
+			<td headers="ar1 ar26 ar28 ac8 ac13" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar26 ar28 ac8 ac14" style="background-color:palegreen">0.82</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar29" rowspan="2">Hawke&#39;s Bay</th>
+			<th headers="ar1 ar29" id="ar30">Dose 1</th>
+			<td headers="ar1 ar29 ar30 ac1 ac2" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar29 ar30 ac1 ac3" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar29 ar30 ac1 ac4" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar29 ar30 ac1 ac5" style="background-color:tomato">0.62</td>
+			<td headers="ar1 ar29 ar30 ac1 ac6" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar29 ar30 ac1 ac7" style="background-color:yellow">0.76</td>
+			<td headers="ar1 ar29 ar30 ac8 ac9" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar29 ar30 ac8 ac10" style="background-color:green; color: #FFF;">1.06</td>
+			<td headers="ar1 ar29 ar30 ac8 ac11" style="background-color:green; color: #FFF;">1.43</td>
+			<td headers="ar1 ar29 ar30 ac8 ac12" style="background-color:green; color: #FFF;">1.32</td>
+			<td headers="ar1 ar29 ar30 ac8 ac13" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar29 ar30 ac8 ac14" style="background-color:green; color: #FFF;">1.17</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar29" id="ar31">Dose 2</th>
+			<td headers="ar1 ar29 ar31 ac1 ac2" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar29 ar31 ac1 ac3" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar29 ar31 ac1 ac4" style="background-color:coral">0.68</td>
+			<td headers="ar1 ar29 ar31 ac1 ac5" style="background-color:crimson; color: #FFF;">0.47</td>
+			<td headers="ar1 ar29 ar31 ac1 ac6" style="background-color:crimson; color: #FFF;">0.59</td>
+			<td headers="ar1 ar29 ar31 ac1 ac7" style="background-color:tomato">0.63</td>
+			<td headers="ar1 ar29 ar31 ac8 ac9" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar29 ar31 ac8 ac10" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar29 ar31 ac8 ac11" style="background-color:green; color: #FFF;">1.45</td>
+			<td headers="ar1 ar29 ar31 ac8 ac12" style="background-color:green; color: #FFF;">1.40</td>
+			<td headers="ar1 ar29 ar31 ac8 ac13" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar29 ar31 ac8 ac14" style="background-color:green; color: #FFF;">1.10</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar32" rowspan="2">MidCentral</th>
+			<th headers="ar1 ar32" id="ar33">Dose 1</th>
+			<td headers="ar1 ar32 ar33 ac1 ac2" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar32 ar33 ac1 ac3" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar32 ar33 ac1 ac4" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar32 ar33 ac1 ac5" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar32 ar33 ac1 ac6" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar32 ar33 ac1 ac7" style="background-color:palegreen">0.81</td>
+			<td headers="ar1 ar32 ar33 ac8 ac9" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar32 ar33 ac8 ac10" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar32 ar33 ac8 ac11" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar32 ar33 ac8 ac12" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar32 ar33 ac8 ac13" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar32 ar33 ac8 ac14" style="background-color:green; color: #FFF;">0.95</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar32" id="ar34">Dose 2</th>
+			<td headers="ar1 ar32 ar34 ac1 ac2" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar32 ar34 ac1 ac3" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar32 ar34 ac1 ac4" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar32 ar34 ac1 ac5" style="background-color:crimson; color: #FFF;">0.59</td>
+			<td headers="ar1 ar32 ar34 ac1 ac6" style="background-color:tomato">0.61</td>
+			<td headers="ar1 ar32 ar34 ac1 ac7" style="background-color:coral">0.68</td>
+			<td headers="ar1 ar32 ar34 ac8 ac9" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar32 ar34 ac8 ac10" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar32 ar34 ac8 ac11" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar32 ar34 ac8 ac12" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar32 ar34 ac8 ac13" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar32 ar34 ac8 ac14" style="background-color:lightgreen">0.86</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar35" rowspan="2">Wairarapa</th>
+			<th headers="ar1 ar35" id="ar36">Dose 1</th>
+			<td headers="ar1 ar35 ar36 ac1 ac2" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar35 ar36 ac1 ac3" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar35 ar36 ac1 ac4" style="background-color:lightgreen">0.86</td>
+			<td headers="ar1 ar35 ar36 ac1 ac5" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar35 ar36 ac1 ac6" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar35 ar36 ac1 ac7" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar35 ar36 ac8 ac9" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar35 ar36 ac8 ac10" style="background-color:green; color: #FFF;">1.10</td>
+			<td headers="ar1 ar35 ar36 ac8 ac11" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar35 ar36 ac8 ac12" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar35 ar36 ac8 ac13" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar35 ar36 ac8 ac14" style="background-color:mediumseagreen">0.94</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar35" id="ar37">Dose 2</th>
+			<td headers="ar1 ar35 ar37 ac1 ac2" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar35 ar37 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar35 ar37 ac1 ac4" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar35 ar37 ac1 ac5" style="background-color:crimson; color: #FFF;">0.58</td>
+			<td headers="ar1 ar35 ar37 ac1 ac6" style="background-color:tomato">0.64</td>
+			<td headers="ar1 ar35 ar37 ac1 ac7" style="background-color:coral">0.66</td>
+			<td headers="ar1 ar35 ar37 ac8 ac9" style="background-color:green; color: #FFF;">1.07</td>
+			<td headers="ar1 ar35 ar37 ac8 ac10" style="background-color:green; color: #FFF;">1.09</td>
+			<td headers="ar1 ar35 ar37 ac8 ac11" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar35 ar37 ac8 ac12" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar35 ar37 ac8 ac13" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar35 ar37 ac8 ac14" style="background-color:lightgreen">0.88</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar38" rowspan="2">Capital &amp; Coast and Hutt Valley</th>
+			<th headers="ar1 ar38" id="ar39">Dose 1</th>
+			<td headers="ar1 ar38 ar39 ac1 ac2" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar38 ar39 ac1 ac3" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar38 ar39 ac1 ac4" style="background-color:palegreen">0.84</td>
+			<td headers="ar1 ar38 ar39 ac1 ac5" style="background-color:yellow">0.76</td>
+			<td headers="ar1 ar38 ar39 ac1 ac6" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar38 ar39 ac1 ac7" style="background-color:palegreen">0.83</td>
+			<td headers="ar1 ar38 ar39 ac8 ac9" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar38 ar39 ac8 ac10" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar38 ar39 ac8 ac11" style="background-color:mediumseagreen">0.90</td>
+			<td headers="ar1 ar38 ar39 ac8 ac12" style="background-color:palegreen">0.80</td>
+			<td headers="ar1 ar38 ar39 ac8 ac13" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar38 ar39 ac8 ac14" style="background-color:lightgreen">0.87</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar38" id="ar40">Dose 2</th>
+			<td headers="ar1 ar38 ar40 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar38 ar40 ac1 ac3" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar38 ar40 ac1 ac4" style="background-color:yellow">0.76</td>
+			<td headers="ar1 ar38 ar40 ac1 ac5" style="background-color:tomato">0.64</td>
+			<td headers="ar1 ar38 ar40 ac1 ac6" style="background-color:tomato">0.63</td>
+			<td headers="ar1 ar38 ar40 ac1 ac7" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar38 ar40 ac8 ac9" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar38 ar40 ac8 ac10" style="background-color:mediumseagreen">0.93</td>
+			<td headers="ar1 ar38 ar40 ac8 ac11" style="background-color:palegreen">0.84</td>
+			<td headers="ar1 ar38 ar40 ac8 ac12" style="background-color:coral">0.69</td>
+			<td headers="ar1 ar38 ar40 ac8 ac13" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar38 ar40 ac8 ac14" style="background-color:palegreen">0.80</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar41" rowspan="2">Nelson Marlborough</th>
+			<th headers="ar1 ar41" id="ar42">Dose 1</th>
+			<td headers="ar1 ar41 ar42 ac1 ac2" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar41 ar42 ac1 ac3" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar41 ar42 ac1 ac4" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar41 ar42 ac1 ac5" style="background-color:orange">0.72</td>
+			<td headers="ar1 ar41 ar42 ac1 ac6" style="background-color:palegreen">0.83</td>
+			<td headers="ar1 ar41 ar42 ac1 ac7" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar41 ar42 ac8 ac9" style="background-color:green; color: #FFF;">1.05</td>
+			<td headers="ar1 ar41 ar42 ac8 ac10" style="background-color:green; color: #FFF;">1.29</td>
+			<td headers="ar1 ar41 ar42 ac8 ac11" style="background-color:green; color: #FFF;">2.43</td>
+			<td headers="ar1 ar41 ar42 ac8 ac12" style="background-color:green; color: #FFF;">2.84</td>
+			<td headers="ar1 ar41 ar42 ac8 ac13" style="background-color:green; color: #FFF;">1.07</td>
+			<td headers="ar1 ar41 ar42 ac8 ac14" style="background-color:green; color: #FFF;">1.97</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar41" id="ar43">Dose 2</th>
+			<td headers="ar1 ar41 ar43 ac1 ac2" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar41 ar43 ac1 ac3" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar41 ar43 ac1 ac4" style="background-color:orange">0.72</td>
+			<td headers="ar1 ar41 ar43 ac1 ac5" style="background-color:crimson; color: #FFF;">0.59</td>
+			<td headers="ar1 ar41 ar43 ac1 ac6" style="background-color:coral">0.68</td>
+			<td headers="ar1 ar41 ar43 ac1 ac7" style="background-color:orange">0.70</td>
+			<td headers="ar1 ar41 ar43 ac8 ac9" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar41 ar43 ac8 ac10" style="background-color:green; color: #FFF;">1.23</td>
+			<td headers="ar1 ar41 ar43 ac8 ac11" style="background-color:green; color: #FFF;">2.53</td>
+			<td headers="ar1 ar41 ar43 ac8 ac12" style="background-color:green; color: #FFF;">3.26</td>
+			<td headers="ar1 ar41 ar43 ac8 ac13" style="background-color:green; color: #FFF;">1.07</td>
+			<td headers="ar1 ar41 ar43 ac8 ac14" style="background-color:green; color: #FFF;">1.94</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar44" rowspan="2">West Coast</th>
+			<th headers="ar1 ar44" id="ar45">Dose 1</th>
+			<td headers="ar1 ar44 ar45 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar44 ar45 ac1 ac3" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar44 ar45 ac1 ac4" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar44 ar45 ac1 ac5" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar44 ar45 ac1 ac6" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar44 ar45 ac1 ac7" style="background-color:lightgreen">0.89</td>
+			<td headers="ar1 ar44 ar45 ac8 ac9" style="background-color:green; color: #FFF;">1.32</td>
+			<td headers="ar1 ar44 ar45 ac8 ac10" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar44 ar45 ac8 ac11" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar44 ar45 ac8 ac12" style="background-color:green; color: #FFF;">1.19</td>
+			<td headers="ar1 ar44 ar45 ac8 ac13" style="background-color:lightgreen">0.86</td>
+			<td headers="ar1 ar44 ar45 ac8 ac14" style="background-color:green; color: #FFF;">0.99</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar44" id="ar46">Dose 2</th>
+			<td headers="ar1 ar44 ar46 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar44 ar46 ac1 ac3" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar44 ar46 ac1 ac4" style="background-color:lightgreen">0.88</td>
+			<td headers="ar1 ar44 ar46 ac1 ac5" style="background-color:orange">0.72</td>
+			<td headers="ar1 ar44 ar46 ac1 ac6" style="background-color:palegreen">0.83</td>
+			<td headers="ar1 ar44 ar46 ac1 ac7" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar44 ar46 ac8 ac9" style="background-color:green; color: #FFF;">1.30</td>
+			<td headers="ar1 ar44 ar46 ac8 ac10" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar44 ar46 ac8 ac11" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar44 ar46 ac8 ac12" style="background-color:green; color: #FFF;">1.40</td>
+			<td headers="ar1 ar44 ar46 ac8 ac13" style="background-color:yellow">0.76</td>
+			<td headers="ar1 ar44 ar46 ac8 ac14" style="background-color:mediumseagreen">0.92</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar47" rowspan="2">Canterbury</th>
+			<th headers="ar1 ar47" id="ar48">Dose 1</th>
+			<td headers="ar1 ar47 ar48 ac1 ac2" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar47 ar48 ac1 ac3" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar47 ar48 ac1 ac4" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar47 ar48 ac1 ac5" style="background-color:yellow">0.77</td>
+			<td headers="ar1 ar47 ar48 ac1 ac6" style="background-color:palegreen">0.83</td>
+			<td headers="ar1 ar47 ar48 ac1 ac7" style="background-color:palegreen">0.84</td>
+			<td headers="ar1 ar47 ar48 ac8 ac9" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar47 ar48 ac8 ac10" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar47 ar48 ac8 ac11" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar47 ar48 ac8 ac12" style="background-color:lightgreen">0.88</td>
+			<td headers="ar1 ar47 ar48 ac8 ac13" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar47 ar48 ac8 ac14" style="background-color:mediumseagreen">0.92</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar47" id="ar49">Dose 2</th>
+			<td headers="ar1 ar47 ar49 ac1 ac2" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar47 ar49 ac1 ac3" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar47 ar49 ac1 ac4" style="background-color:yellow">0.76</td>
+			<td headers="ar1 ar47 ar49 ac1 ac5" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar47 ar49 ac1 ac6" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar47 ar49 ac1 ac7" style="background-color:orange">0.73</td>
+			<td headers="ar1 ar47 ar49 ac8 ac9" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar47 ar49 ac8 ac10" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar47 ar49 ac8 ac11" style="background-color:green; color: #FFF;">0.98</td>
+			<td headers="ar1 ar47 ar49 ac8 ac12" style="background-color:palegreen">0.83</td>
+			<td headers="ar1 ar47 ar49 ac8 ac13" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar47 ar49 ac8 ac14" style="background-color:lightgreen">0.85</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar50" rowspan="2">South Canterbury</th>
+			<th headers="ar1 ar50" id="ar51">Dose 1</th>
+			<td headers="ar1 ar50 ar51 ac1 ac2" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar50 ar51 ac1 ac3" style="background-color:green; color: #FFF;">0.97</td>
+			<td headers="ar1 ar50 ar51 ac1 ac4" style="background-color:palegreen">0.84</td>
+			<td headers="ar1 ar50 ar51 ac1 ac5" style="background-color:yellow">0.77</td>
+			<td headers="ar1 ar50 ar51 ac1 ac6" style="background-color:palegreen">0.83</td>
+			<td headers="ar1 ar50 ar51 ac1 ac7" style="background-color:palegreen">0.83</td>
+			<td headers="ar1 ar50 ar51 ac8 ac9" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar50 ar51 ac8 ac10" style="background-color:green; color: #FFF;">1.11</td>
+			<td headers="ar1 ar50 ar51 ac8 ac11" style="background-color:green; color: #FFF;">1.18</td>
+			<td headers="ar1 ar50 ar51 ac8 ac12" style="background-color:green; color: #FFF;">1.23</td>
+			<td headers="ar1 ar50 ar51 ac8 ac13" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar50 ar51 ac8 ac14" style="background-color:green; color: #FFF;">1.09</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar50" id="ar52">Dose 2</th>
+			<td headers="ar1 ar50 ar52 ac1 ac2" style="background-color:green; color: #FFF;">1.04</td>
+			<td headers="ar1 ar50 ar52 ac1 ac3" style="background-color:mediumseagreen">0.92</td>
+			<td headers="ar1 ar50 ar52 ac1 ac4" style="background-color:yellow">0.75</td>
+			<td headers="ar1 ar50 ar52 ac1 ac5" style="background-color:tomato">0.62</td>
+			<td headers="ar1 ar50 ar52 ac1 ac6" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar50 ar52 ac1 ac7" style="background-color:orange">0.71</td>
+			<td headers="ar1 ar50 ar52 ac8 ac9" style="background-color:mediumseagreen">0.94</td>
+			<td headers="ar1 ar50 ar52 ac8 ac10" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar50 ar52 ac8 ac11" style="background-color:green; color: #FFF;">1.20</td>
+			<td headers="ar1 ar50 ar52 ac8 ac12" style="background-color:green; color: #FFF;">1.26</td>
+			<td headers="ar1 ar50 ar52 ac8 ac13" style="background-color:green; color: #FFF;">1.03</td>
+			<td headers="ar1 ar50 ar52 ac8 ac14" style="background-color:green; color: #FFF;">0.99</td>
+		</tr>
+		<tr>
+			<th headers="ar1" id="ar53" rowspan="2">Southern</th>
+			<th headers="ar1 ar53" id="ar54">Dose 1</th>
+			<td headers="ar1 ar53 ar54 ac1 ac2" style="background-color:green; color: #FFF;">1.00</td>
+			<td headers="ar1 ar53 ar54 ac1 ac3" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar53 ar54 ac1 ac4" style="background-color:lightgreen">0.85</td>
+			<td headers="ar1 ar53 ar54 ac1 ac5" style="background-color:yellow">0.78</td>
+			<td headers="ar1 ar53 ar54 ac1 ac6" style="background-color:palegreen">0.82</td>
+			<td headers="ar1 ar53 ar54 ac1 ac7" style="background-color:palegreen">0.84</td>
+			<td headers="ar1 ar53 ar54 ac8 ac9" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar53 ar54 ac8 ac10" style="background-color:green; color: #FFF;">1.02</td>
+			<td headers="ar1 ar53 ar54 ac8 ac11" style="background-color:green; color: #FFF;">1.08</td>
+			<td headers="ar1 ar53 ar54 ac8 ac12" style="background-color:green; color: #FFF;">1.09</td>
+			<td headers="ar1 ar53 ar54 ac8 ac13" style="background-color:green; color: #FFF;">0.95</td>
+			<td headers="ar1 ar53 ar54 ac8 ac14" style="background-color:green; color: #FFF;">1.03</td>
+		</tr>
+		<tr>
+			<th headers="ar1 ar53" id="ar55">Dose 2</th>
+			<td headers="ar1 ar53 ar55 ac1 ac2" style="background-color:green; color: #FFF;">0.99</td>
+			<td headers="ar1 ar53 ar55 ac1 ac3" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar53 ar55 ac1 ac4" style="background-color:yellow">0.79</td>
+			<td headers="ar1 ar53 ar55 ac1 ac5" style="background-color:coral">0.67</td>
+			<td headers="ar1 ar53 ar55 ac1 ac6" style="background-color:orange">0.72</td>
+			<td headers="ar1 ar53 ar55 ac1 ac7" style="background-color:orange">0.74</td>
+			<td headers="ar1 ar53 ar55 ac8 ac9" style="background-color:green; color: #FFF;">0.96</td>
+			<td headers="ar1 ar53 ar55 ac8 ac10" style="background-color:green; color: #FFF;">1.01</td>
+			<td headers="ar1 ar53 ar55 ac8 ac11" style="background-color:green; color: #FFF;">1.07</td>
+			<td headers="ar1 ar53 ar55 ac8 ac12" style="background-color:green; color: #FFF;">1.05</td>
+			<td headers="ar1 ar53 ar55 ac8 ac13" style="background-color:mediumseagreen">0.91</td>
+			<td headers="ar1 ar53 ar55 ac8 ac14" style="background-color:green; color: #FFF;">0.95</td>
+		</tr>
+	</tbody>
+</table>
+
+<p>This table shows the rate of doses administered (per 1,000 population) to Māori or Pacific Peoples, relative to the rate of doses for Non-Māori and Non-Pacific groups. Less than one means the group is receiving a lower proportion of doses than would be expected if equity is being achieved. More than one means they are receiving a higher proportion of doses than would be expected if equity is being achieved. Exactly one means doses administered are in line with their proportion of population.</p>
+
+<ul>
+	<li><a download="" href="/web/20211103184409/https://www.health.govt.nz/system/files/documents/pages/rateratioexplainer_3.docx">Rate Ratio Explainer (Word, 434 KB)</a></li>
+</ul>
+
+<p>At all ages the size (weightings) of the age groups becomes a major contributing factor to comparative ratios, which is why the all ages (12+) figure may not appear to be in line with the age splits.</p>
+
+<h4><a id="uptake" name="uptake"></a>Vaccine uptake per 1,000 people by ethnicity</h4>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine uptake per 1,000 people by ethnicity" class="img-responsive" height="830" src="/web/20211103184409im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_eth_9.png" width="1780"/></figure>
+
+<h4><a id="uptake" name="uptake"></a>Vaccine uptake per 1,000 people by age band</h4>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine uptake per 1,000 people by age band" class="img-responsive" height="1030" src="/web/20211103184409im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_age_10.png" width="1780"/></figure>
+
+<h4><a id="uptake" name="location"></a>Vaccine uptake per 1,000 people by DHB of residence</h4>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine uptake per 1,000 people by DHB of residence" class="img-responsive" height="1030" src="/web/20211103184409im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_dhb_5.png" width="1780"/></figure>
+<!--
+<hr />
+<h3><a id="by_dhb_plan" name="dhb_plan"></a>Cumulative vaccination plan for DHBs</h3>
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">DHB of service</th>
+			<th scope="col" style="text-align:right">Actuals to Sunday 31 October</th>
+			<th scope="col" style="text-align:right">DHB Plan to Sunday 31 October</th>
+			<th scope="col" style="text-align:right">Variance</th>
+			<th scope="col" style="text-align:right">% of Plan</th>
+			<th scope="col" style="text-align:right">Week to date</th>
+		</tr>
+	</thead>
+	<tbody> --><!--plan--><!--
+<tr><td nowrap="nowrap">Auckland Metro</td><td>190621</td><td>205515</td><td>-14894</td><td>93%</td><td>9913</td></tr>
+<tr><td nowrap="nowrap">Bay of Plenty</td><td>22841</td><td>14255</td><td>8586</td><td>160%</td><td>1843</td></tr>
+<tr><td nowrap="nowrap">Canterbury</td><td>50558</td><td>39266</td><td>11292</td><td>129%</td><td>2769</td></tr>
+<tr><td nowrap="nowrap">Capital & Coast and Hutt Valley</td><td>48758</td><td>39742</td><td>9016</td><td>123%</td><td>1796</td></tr>
+<tr><td nowrap="nowrap">Hawke's Bay</td><td>15319</td><td>18205</td><td>-2886</td><td>84%</td><td>1351</td></tr>
+<tr><td nowrap="nowrap">Lakes</td><td>13437</td><td>12810</td><td>627</td><td>105%</td><td>731</td></tr>
+<tr><td nowrap="nowrap">MidCentral</td><td>10708</td><td>7237</td><td>3471</td><td>148%</td><td>1191</td></tr>
+<tr><td nowrap="nowrap">Nelson Marlborough</td><td>30198</td><td>18574</td><td>11624</td><td>163%</td><td>1285</td></tr>
+<tr><td nowrap="nowrap">Northland</td><td>21469</td><td>24762</td><td>-3293</td><td>87%</td><td>1257</td></tr>
+<tr><td nowrap="nowrap">South Canterbury</td><td>8106</td><td>8033</td><td>73</td><td>101%</td><td>389</td></tr>
+<tr><td nowrap="nowrap">Southern</td><td>35234</td><td>34594</td><td>640</td><td>102%</td><td>1794</td></tr>
+<tr><td nowrap="nowrap">Tairāwhiti</td><td>4579</td><td>4928</td><td>-349</td><td>93%</td><td>290</td></tr>
+<tr><td nowrap="nowrap">Taranaki</td><td>5619</td><td>5297</td><td>322</td><td>106%</td><td>168</td></tr>
+<tr><td nowrap="nowrap">Waikato</td><td>36070</td><td>32842</td><td>3228</td><td>110%</td><td>1905</td></tr>
+<tr><td nowrap="nowrap">Wairarapa</td><td>4516</td><td>4960</td><td>-444</td><td>91%</td><td>468</td></tr>
+<tr><td nowrap="nowrap">West Coast</td><td>3533</td><td>3300</td><td>233</td><td>107%</td><td>336</td></tr>
+<tr><td nowrap="nowrap">Whanganui</td><td>6982</td><td>4711</td><td>2271</td><td>148%</td><td>612</td></tr>
+<tr><td nowrap="nowrap">Other Sites</td><td>24890</td><td>14575</td><td>10315</td><td>171%</td><td>613</td></tr>
+<tr><td nowrap="nowrap">Total</td><td>533438</td><td>493606</td><td>39832</td><td>108%</td><td>28711</td></tr>
+!--plan_end--><!--	</tbody>
+</table>
+
+
+<p>The information provided in this table is based on cumulative DHB plans to the last week ending on Sunday. The final column shows vaccinations administered since Sunday by DHB of service to reconcile total actuals in this table to other total numbers shown.   On-going, and as we roll-out the vaccination programme, we anticipate that there could be a potential variance of up to ten percent (plus or minus) between DHB Plans and actual vaccination numbers. This is on the basis that, for example, an unplanned significant event could affect roll-out implementation or some DHBs might exceed their planned vaccination numbers.
+</p>
+-->
+
+<hr/>
+<h3><a id="by_dhb" name="location"></a>Cumulative vaccinations by DHB</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Cumulative vaccinations for DHBs" class="img-responsive" height="830" src="/web/20211103184409im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/dhbstacked_13.png" width="1780"/></figure>
+
+<hr/>
+<h3><a id="by-day" name="by-day"></a>Vaccinations by day</h3>
+
+<figure class="image-captioned img-responsive"><img alt="Vaccination doses administered per day" class="img-responsive" height="830" src="/web/20211103184409im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/vaccinebyday_13.png" width="1780"/></figure>
+
+<p>This chart shows the count of vaccinations administered on a given day from the COVID-19 Immunisation Register. Note some records are entered in the register at a later date than the immunisation was received. This means that the figures for a given date may move for some time after that date.</p>
+
+<hr/>
+<h3><a id="by_soh" name="stockonhand"></a>Vaccine available for distribution at week end</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine available for distribution at week end" class="img-responsive" height="830" src="/web/20211103184409im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/stockonhand_14.png" width="1780"/></figure>
+
+<p>Vaccine available for distribution is stock (in doses) held at central warehouses. It does not include stock in transit or available at sites ready for use.</p>
+
+<hr/>
+<h3><a id="by_eth" name="ethnicity"></a>Total cumulative doses per 1,000 people by ethnicity</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Total cumulative doses per 1,000 people by ethnicity" class="img-responsive" height="830" src="/web/20211103184409im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/ethnicity_13.png" width="1780"/></figure>
+
+<p>This chart shows both first and second doses. As a result this chart may exceed 1,000 doses per 1,000 people.</p>
+
+<p><strong>*</strong> The prioritised ethnicity classification system allocates each person to a single ethnic group, based on the ethnic groups they identify with. Where people identify with more than one group, they are assigned in this order of priority: Māori, Pacific Peoples, Asian, and European/Other. So, if a person identifies as being Māori and New Zealand European, the person is counted as Māori. See <a href="/web/20211103184409/https://www.health.govt.nz/publication/hiso-100012017-ethnicity-data-protocols">Ethnicity Data Protocols</a> for further information.</p>
+
+<p>Ethnicity breakdown by DHB of residence is available in the downloadable spreadsheet at the bottom of the page.</p>
+
+<hr/>
+<h3><a id="by_age" name="age"></a>Cumulative vaccinations by age</h3>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">Age</th>
+			<th scope="col" style="text-align:right">First dose administered</th>
+			<th scope="col" style="text-align:right">First doses per 1,000 people</th>
+			<th scope="col" style="text-align:right">Fully vaccinated</th>
+			<th scope="col" style="text-align:right">Fully vaccinated per 1,000 people</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">12 - 19 years</th>
+			<td style="text-align:right">416,297</td>
+			<td style="text-align:right">829</td>
+			<td style="text-align:right">311,515</td>
+			<td style="text-align:right">620</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">20 - 34 years</th>
+			<td style="text-align:right">871,957</td>
+			<td style="text-align:right">843</td>
+			<td style="text-align:right">669,936</td>
+			<td style="text-align:right">648</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">35 - 49 years</th>
+			<td style="text-align:right">838,370</td>
+			<td style="text-align:right">877</td>
+			<td style="text-align:right">718,744</td>
+			<td style="text-align:right">751</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">50 - 64 years</th>
+			<td style="text-align:right">844,656</td>
+			<td style="text-align:right">911</td>
+			<td style="text-align:right">776,619</td>
+			<td style="text-align:right">837</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap">65 and over</th>
+			<td style="text-align:right">753,079</td>
+			<td style="text-align:right">955</td>
+			<td style="text-align:right">724,412</td>
+			<td style="text-align:right">919</td>
+		</tr>
+		<tr>
+			<th nowrap="nowrap"><strong>Total</strong></th>
+			<td style="text-align:right"><strong>3,724,359</strong></td>
+			<td style="text-align:right"><strong>885</strong></td>
+			<td style="text-align:right"><strong>3,201,226</strong></td>
+			<td style="text-align:right"><strong>761</strong></td>
+		</tr>
+	</tbody>
+</table>
+
+<p>Age breakdown by ethnicity and gender is available in the downloadable spreadsheet at the bottom of the page.</p>
+
+<hr/>
+<h3><a id="workforce" name="workforce"></a>Trained vaccinators and active vaccinators</h3>
+
+<figure class="image-captioned img-responsive"><img 761="" alt="Trained vaccinators and active vaccinators" class="img-responsive" height="830" src="/web/20211103184409im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/workforce_13.png" width="1780"/></figure>
+
+<p><strong>Trained vaccinators</strong> are individuals who have completed the COVID-19 training. Many trained people are only able to offer a small number of hours to the COVID-19 vaccination programme.</p>
+
+<p><strong>Active vaccinators</strong> are trained individuals who are actively vaccinating. The number of active vaccinators does not reflect the hours worked vaccinating. For example, one vaccinator may work 40 hours in a week at one DHB and will show as 1 vaccinator in the headcount. In another DHB, 4 vaccinators may work 10 hours each (total 40 hours), but will show as 4 vaccinators in the headcount for that week.</p>
+
+<p>Both counts of trained and active vaccinators are cumulative. The difference between the two is due to a number of factors. This includes: individuals being trained in anticipation of future sites being opened (the largest factor); rostering; leave or non-availability; local health priorities; sites opening and closing.</p>
+
+<hr/>
+<h3><a id="usage" name="usage"></a>Wastage of vaccine stock</h3>
+
+<table class="table-style-two">
+	<thead>
+		<tr>
+			<th scope="col">&nbsp;</th>
+			<th scope="col">Wastage</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th nowrap="nowrap">New Zealand</th>
+			<td>0.29%</td>
+		</tr>
+	</tbody>
+</table>
+
+<p>Wastage is vials that have been reported as wasted since 13 July in the Inventory portal by DHBs or central warehouses divided by vials used over the same time frame.</p>
+
+<h3><a id="download" name="download"></a>Details of vaccination data</h3>
+
+<p>Download a spreadsheet containing key vaccination data. This includes HSU based population estimates for calculating vaccine uptake rates.</p>
+
+<p><a download="" href="/web/20211103184409/https://www.health.govt.nz/system/files/documents/pages/covid_vaccinations_02_11_2021.xlsx">COVID-19 vaccination data through 02 Nov 2021 (Excel, 300 KB)</a></p>
+
+<p>This spreadsheet is based on the information made available at the time of publishing and may be subject to changes. Please take note of any notes and caveats on each sheet.</p>
+
+<p>The below attachments provide some analysis on our progress on equity. The two PDF files are high level summaries of overall progress. The Excel documents are interactive and provides the ability to delve further into those overall numbers. NB: These Excel workbooks use features that are non-compatible with versions of MS Office 2016 and earlier.</p>
+
+<ul>
+	<li><a download="" href="/web/20211103184409/https://www.health.govt.nz/system/files/documents/pages/211031_-_cvip_equity_-_rate_ratios_by_ethnicity_ageband_and_dhb.pdf">Covid-19 Vaccine Rate Ratios by Ethnicity, Ageband and DHB (PDF, 642 KB)</a></li>
+	<li><a download="" href="/web/20211103184409/https://www.health.govt.nz/system/files/documents/pages/211031_-_cvip_equity_-_uptake_by_ethnicity_ageband_and_dhb.pdf">Covid-19 Vaccine Uptake by Ethnicity, Ageband and DHB (PDF, 550 KB)</a></li>
+	<li><a download="" href="/web/20211103184409/https://www.health.govt.nz/system/files/documents/pages/211031_-_cvip_equity_-_level_1_ethnicity_uptake_and_rate_ratios.xlsx">Covid-19 Vaccine Equity - Level 1 Ethnicity Uptake and Rate Ratios (Excel, 153 KB)</a></li>
+	<li><a download="" href="/web/20211103184409/https://www.health.govt.nz/system/files/documents/pages/211031_-_cvip_equity_-_level_1_ethnicity_uptake_and_rate_ratios.xlsx">Covid-19 Vaccine Equity - Level 2 Ethnicity Uptake and Rate Ratios (Excel, 379 KB)</a></li>
+	<li><a download="" href="/web/20211103184409/https://www.health.govt.nz/system/files/documents/pages/211031_-_cvip_equity_-_rate_ratios_and_uptake_over_time.xlsx">Rate Ratios and Uptake Over Time (Excel, 1.1 MB)</a></li>
+</ul>
+
+<hr/>
+<h3><a id="adverse-events" name="adverse-events"></a>Adverse events following&nbsp;immunisations (AEFI)</h3>
+
+<p>Like all medicines, the COVID-19 vaccine may cause side effects in some people. These are common, are usually mild, don&rsquo;t last long and won&rsquo;t stop people from having the second dose or going about daily life. Serious allergic reactions do occur but are extremely rare.</p>
+
+<p>Suspected AEFI to COVID-19 vaccines are reported to the <a href="https://web.archive.org/web/20211103184409/https://nzphvc.otago.ac.nz/">Centre for Adverse Reactions Monitoring</a> (CARM).&nbsp;<a href="https://web.archive.org/web/20211103184409/https://www.medsafe.govt.nz/">Medsafe</a> is closely monitoring the AEFI reported from the use of the COVID-19 vaccine and will report regularly on their findings.&nbsp;</p>
+
+<p><a href="https://web.archive.org/web/20211103184409/https://www.medsafe.govt.nz/COVID-19/vaccine-report-overview.asp">View Medsafe data on COVID-19 vaccine adverse effects following immunisation</a></p>
+</div></div></div>    </article>
+  </div>
+
+
+  </div>
+<div class="panel-pane pane-node-links even">
+
+
+
+  <div class="pane-content">
+          </div>
+
+
+  </div>
+
+<div class="panel-pane pane-views pane-sub-pages even">
+
+        <h2 class="pane-title h3">In this section</h2>
+
+
+  <div class="pane-content">
+        <div class="view view-sub-pages view-id-sub_pages view-display-id-block view-dom-id-e6364ae1d8654920721c50f2148aab1e">
+
+
+
+      <div class="view-content">
+      <div class="item-list">    <ul>          <li class="views-row views-row-1 views-row-odd views-row-first">
+  <div class="views-field views-field-title">        <div class="field-content">
+<div class="views-field views-field-title">
+  <h3 class="field-content">
+    <a href="/web/20211103184409/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-across-nz">COVID-19 Vaccination uptake rates across NZ</a>  </h3>
+</div></div>  </div>
+  <span class="views-field views-field-body">        <span class="field-content">This page provides information related to uptake rates of the COVID-19 vaccine across the country.
+</span>  </span>
+  <span class="views-field views-field-view-node">        <span class="field-content"><a href="/web/20211103184409/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-across-nz">Read more</a></span>  </span></li>
+          <li class="views-row views-row-2 views-row-even">
+  <div class="views-field views-field-title">        <div class="field-content">
+<div class="views-field views-field-title">
+  <h3 class="field-content">
+    <a href="/web/20211103184409/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-maori-communities-across-nz">COVID-19 Vaccination uptake rates within Māori communities across NZ</a>  </h3>
+</div></div>  </div>
+  <span class="views-field views-field-body">        <span class="field-content">This page provides information related to uptake rates of the COVID-19 vaccine within Māori communities across New Zealand.
+</span>  </span>
+  <span class="views-field views-field-view-node">        <span class="field-content"><a href="/web/20211103184409/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-maori-communities-across-nz">Read more</a></span>  </span></li>
+          <li class="views-row views-row-3 views-row-odd views-row-last">
+  <div class="views-field views-field-title">        <div class="field-content">
+<div class="views-field views-field-title">
+  <h3 class="field-content">
+    <a href="/web/20211103184409/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-pacific-communities-across-nz">COVID-19 Vaccination uptake rates within Pacific communities across NZ</a>  </h3>
+</div></div>  </div>
+  <span class="views-field views-field-body">        <span class="field-content">This page provides information related to uptake rates of the COVID-19 vaccine within Pacific communities across New Zealand.
+</span>  </span>
+  <span class="views-field views-field-view-node">        <span class="field-content"><a href="/web/20211103184409/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-pacific-communities-across-nz">Read more</a></span>  </span></li>
+      </ul></div>    </div>
+
+
+
+
+
+
+</div>  </div>
+
+
+  </div>
+</div>          </div>
+
+  </div>
+
+</section>
+  </div>
+      </section>
+
+
+    </div>
+    <div id="content-footer-wrapper" class="clearfix">
+      <div id="content-footer" class="clearfix">
+                  <p class="page_updated">Page last updated: <span class="date">03 November 2021</span></p>                  <div class="region region-content-footer">
+    <section id="block-moh-tools-page-tools" class="block block-moh-tools clearfix">
+  <a href="#" data-placement="top" data-title="Share this content." data-html="true" data-content="<p>Share this page on some of the most popular social networking and content sites on the internet.</p><div class='service-links'><ul><li><a href='https://twitter.com/share?url=https%3A//www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data&amp;text=COVID-19%3A%20Vaccine%20data' title='Share this on Twitter' class='service-links-twitter' rel='nofollow'><img typeof='foaf:Image' class='img-responsive' src='https://www.health.govt.nz/sites/all/modules/contrib/service_links/images/twitter.png' alt='Twitter' /> Twitter</a></li>
+<li><a href='https://www.facebook.com/sharer.php?u=https%3A//www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data&amp;t=COVID-19%3A%20Vaccine%20data' title='Share on Facebook' class='service-links-facebook' rel='nofollow'><img typeof='foaf:Image' class='img-responsive' src='https://www.health.govt.nz/sites/all/modules/contrib/service_links/images/facebook.png' alt='Facebook' /> Facebook</a></li>
+</ul></div>" class="share-this-content"><i class="fa fa-share"></i> Share</a><a href="#" title="print this page" class="print"><i class="fa fa-print"></i> Print</a><a href="https://web.archive.org/web/20211103184409/https://www.health.govt.nz/forward?path=node/12052" title="Email this page" class="email"><i class="fa fa-envelope"></i> Email</a><a href="/web/20211103184409/https://www.health.govt.nz/feedback?ref=https%3A//www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="Feedback" class="rss"><i class="fa fa-comment"></i> Feedback</a></section>
+
+  </div>
+      </div>
+    </div>
+
+  </div>
+  <footer class="footer container">
+    <h2 class="hidden">Site Footer</h2>
+    <div class="footer-default">
+      <div class="row">
+        <div class="col-sm-6 col-md-6">
+          <div class="field field-name-field-tax-first-column-links">
+            <ul class="field-items"><li class="field-item"><a href="https://web.archive.org/web/20211103184409/https://www.health.govt.nz/node/492" class="">About this site</a></li><li class="field-item"><a href="https://web.archive.org/web/20211103184409/https://www.health.govt.nz/node/524" class="">Contact us</a></li><li class="field-item"><a href="https://web.archive.org/web/20211103184409/https://www.health.govt.nz/node/488" class="">Other Ministry of Health websites</a></li><li class="field-item"><a href="https://web.archive.org/web/20211103184409/https://www.health.govt.nz/node/7497" class="">Official Information Act requests</a></li><li class="field-item"><a href="https://web.archive.org/web/20211103184409/https://www.health.govt.nz/about-ministry/information-releases" class="">Information releases</a></li><li class="field-item"><a href="https://web.archive.org/web/20211103184409/https://consult.health.govt.nz/" class="">Consultations</a></li></ul>
+          </div>
+        </div>
+        <div class="col-sm-6 col-md-6">
+          <div class="field field-name-field-tax-footer-body field-type-text-long field-label-hidden"><div class="field-items"><div class="field-item even"><h3>Where to go for help</h3>
+
+<table>
+	<tbody>
+		<tr>
+			<th scope="row">Emergencies</th>
+			<td><strong>Dial <a href="tel:111">111</a></strong> (for ambulance, fire or police)</td>
+		</tr>
+		<tr>
+			<th scope="row">Healthline</th>
+			<td><strong>Dial <a href="tel:0800611116">0800 611 116</a></strong></td>
+		</tr>
+		<tr>
+			<th scope="row">Poisons</th>
+			<td><strong>Dial <a href="tel:0800764766">0800 POISON</a> </strong>(<a href="tel:0800764766">0800 764 766</a>)</td>
+		</tr>
+		<tr>
+			<th scope="row">Mental health crisis</th>
+			<td><strong><a href="/web/20211103184409/https://www.health.govt.nz/your-health/services-and-support/health-care-services/mental-health-services/crisis-assessment-teams">Emergency contact numbers</a></strong></td>
+		</tr>
+	</tbody>
+</table>
+</div></div></div>        </div>
+      </div>
+      <div class="row">
+        <div class="sub-footer">
+          <div class="column col-sm-12 col-md-3">
+            <a href="https://web.archive.org/web/20211103184409/https://www.govt.nz/">
+              <img src="/web/20211103184409im_/https://www.health.govt.nz/sites/all/themes/mohpub_bootstrap/images/nzgovtlogo-te-kawanatanga-white.png" width="230" height="52" alt="govt.nz - connecting you to New Zealand central &amp; local government services" title="govt.nz - connecting you to New Zealand central &amp; local government services"/>
+            </a>
+          </div>
+          <div class="column col-sm-12 col-md-9">
+          <span class="bottom-menu-moh with-v-divider">&copy; Ministry of Health – Manatū Hauora</span><ul class="bottom-menu-list"><li class="bottom-menu-list-item with-v-divider"><a href="https://web.archive.org/web/20211103184409/https://www.health.govt.nz/sitemap" class="">Site map</a></li><li class="bottom-menu-list-item with-v-divider"><a href="https://web.archive.org/web/20211103184409/https://www.health.govt.nz/about-site/privacy-and-security" class="">Privacy &amp; security</a></li><li class="bottom-menu-list-item with-v-divider"><a href="https://web.archive.org/web/20211103184409/https://www.health.govt.nz/about-site/copyright" class="">Copyright</a></li></ul>          </div>
+        </div>
+      </div>
+    </div>
+    <div class="footer-print">&copy; Ministry of Health – Manatū Hauora</div>
+  </footer>
+  <a class="scrollToTop">Back to top <i class="fas fa-arrow-up"></i></a>
+</div>
+  <script src="https://web.archive.org/web/20211103184409js_/https://www.health.govt.nz/sites/default/files/js/js_akZOsKtodu3PdnQzY3_ElOfujkLxJcowmaWgHTBBLOE.js"></script>
+</body>
+</html>
+<!--
+     FILE ARCHIVED ON 18:44:09 Nov 03, 2021 AND RETRIEVED FROM THE
+     INTERNET ARCHIVE ON 03:13:04 Nov 07, 2021.
+     JAVASCRIPT APPENDED BY WAYBACK MACHINE, COPYRIGHT INTERNET ARCHIVE.
+
+     ALL OTHER CONTENT MAY ALSO BE PROTECTED BY COPYRIGHT (17 U.S.C.
+     SECTION 108(a)(3)).
+-->
+<!--
+playback timings (ms):
+  captures_list: 153.888
+  exclusion.robots: 0.189
+  exclusion.robots.policy: 0.183
+  RedisCDXSource: 2.383
+  esindex: 0.008
+  LoadShardBlock: 106.299 (3)
+  PetaboxLoader3.datanode: 97.763 (4)
+  CDXLines.iter: 32.914 (3)
+  load_resource: 129.681
+  PetaboxLoader3.resolve: 87.241
+-->

--- a/data/rawSite/2021-11-03.html
+++ b/data/rawSite/2021-11-03.html
@@ -2,13 +2,13 @@
 <!DOCTYPE html>
 <html lang="en" dir="ltr" prefix="" class="no-js">
 <head><script src="//archive.org/includes/analytics.js?v=cf34f82" type="text/javascript"></script>
-<script type="text/javascript">window.addEventListener('DOMContentLoaded',function(){var v=archive_analytics.values;v.service='wb';v.server_name='wwwb-app215.us.archive.org';v.server_ms=229;archive_analytics.send_pageview({});});</script>
+<script type="text/javascript">window.addEventListener('DOMContentLoaded',function(){var v=archive_analytics.values;v.service='wb';v.server_name='wwwb-app58.us.archive.org';v.server_ms=295;archive_analytics.send_pageview({});});</script>
 <script type="text/javascript" src="/_static/js/bundle-playback.js?v=UfTkgsKx" charset="utf-8"></script>
 <script type="text/javascript" src="/_static/js/wombat.js?v=UHAOicsW" charset="utf-8"></script>
 <script type="text/javascript">
   __wm.init("https://web.archive.org/web");
-  __wm.wombat("https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data","20211105212204","https://web.archive.org/","web","/_static/",
-	      "1636147324");
+  __wm.wombat("https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data","20211104203147","https://web.archive.org/","web","/_static/",
+	      "1636057907");
 </script>
 <link rel="stylesheet" type="text/css" href="/_static/css/banner-styles.css?v=omkqRugM" />
 <link rel="stylesheet" type="text/css" href="/_static/css/iconochive.css?v=qtvMKcIJ" />
@@ -19,29 +19,29 @@
   <meta name="format-detection" content="telephone=no"/>
   <link rel="profile" href="http://www.w3.org/1999/xhtml/vocab"/>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
-<link rel="shortcut icon" href="https://web.archive.org/web/20211105212204im_/https://www.health.govt.nz/sites/all/themes/mohpub_bootstrap/favicon.ico" type="image/vnd.microsoft.icon"/>
+<link rel="shortcut icon" href="https://web.archive.org/web/20211104203147im_/https://www.health.govt.nz/sites/all/themes/mohpub_bootstrap/favicon.ico" type="image/vnd.microsoft.icon"/>
 <meta name="description" content="Dashboard of data and statistics about the rollout of COVID-19 vaccines in New Zealand"/>
 <meta name="generator" content="Drupal 7 (https://www.drupal.org)"/>
-<link rel="canonical" href="https://web.archive.org/web/20211105212204/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data"/>
-<link rel="shortlink" href="https://web.archive.org/web/20211105212204/https://www.health.govt.nz/node/12052"/>
+<link rel="canonical" href="https://web.archive.org/web/20211104203147/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data"/>
+<link rel="shortlink" href="https://web.archive.org/web/20211104203147/https://www.health.govt.nz/node/12052"/>
 <meta property="og:site_name" content="Ministry of Health NZ"/>
 <meta property="og:type" content="article"/>
-<meta property="og:url" content="https://web.archive.org/web/20211105212204/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data"/>
+<meta property="og:url" content="https://web.archive.org/web/20211104203147/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data"/>
 <meta property="og:title" content="COVID-19: Vaccine data"/>
 <meta property="og:description" content="Dashboard of data and statistics about the rollout of COVID-19 vaccines in New Zealand"/>
   <title>COVID-19: Vaccine data | Ministry of Health NZ</title>
-  <link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211105212204cs_/https://www.health.govt.nz/sites/default/files/css/css_lQaZfjVpwP_oGNqdtWCSpJT1EMqXdMiU84ekLLxQnc4.css" media="all"/>
-<link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211105212204cs_/https://www.health.govt.nz/sites/default/files/css/css_jqUBpWfMaxMiP7LismdZVlyVv8azUJSE2yaH58nj0cE.css" media="all"/>
-<link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211105212204cs_/https://www.health.govt.nz/sites/default/files/css/css_Rb1wqFBC8VXCJC-BuNY53cvjjlj6UADGvqzo_f-1yN0.css" media="all"/>
-<link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211105212204cs_/https://www.health.govt.nz/sites/default/files/css/css_38_K1lHKg-98m4KKRfv57JBK0gvlKscexGt9MKoi0DE.css" media="all"/>
-<link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211105212204cs_/https://www.health.govt.nz/sites/default/files/css/css_r7NPyvpdYfAyZmk9zkK8OaFKEFj6er5ZJnam2H644DM.css" media="print"/>
-  <link rel="alternate stylesheet" type="text/css" href="/web/20211105212204cs_/https://www.health.govt.nz/sites/all/themes/mohpub_bootstrap/css/high-contrast.css" media="screen" title="High Contrast"/>
-  <script src="https://web.archive.org/web/20211105212204js_/https://www.health.govt.nz/sites/default/files/js/js_zS-CmNFGyegtLYJmqFRpxQvvQrfPIFrOMq_3T3C8sZE.js"></script>
-<script src="https://web.archive.org/web/20211105212204js_/https://www.health.govt.nz/sites/default/files/js/js_fNgZ4Okisfr70Q0yvAYsATgB0o_jD3-srhQQ-VHmlXE.js"></script>
-<script src="https://web.archive.org/web/20211105212204js_/https://www.health.govt.nz/sites/default/files/js/js_YAdPZfg12M1m7ROp3_gVJPS5sArqL0kYQgNRPoicvHE.js"></script>
-<script>(function(i,s,o,g,r,a,m){i["GoogleAnalyticsObject"]=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,"script","https://web.archive.org/web/20211105212204/https://www.google-analytics.com/analytics.js","ga");ga("create", "UA-3573389-24", {"cookieDomain":".www.health.govt.nz","siteSpeedSampleRate":15});ga("send", "pageview");</script>
-<script src="https://web.archive.org/web/20211105212204js_/https://www.health.govt.nz/sites/default/files/js/js_wauJ-VUoyA1MrZ6ZPFtGhNR7qiKnBdBSKEwQJjdEXIk.js"></script>
-<script src="https://web.archive.org/web/20211105212204js_/https://www.health.govt.nz/sites/default/files/js/js_4VW9edmu3V8VjGJxFfXGAwkXeW2cJIa5h-6y7SgwVrk.js"></script>
+  <link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211104203147cs_/https://www.health.govt.nz/sites/default/files/css/css_lQaZfjVpwP_oGNqdtWCSpJT1EMqXdMiU84ekLLxQnc4.css" media="all"/>
+<link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211104203147cs_/https://www.health.govt.nz/sites/default/files/css/css_jqUBpWfMaxMiP7LismdZVlyVv8azUJSE2yaH58nj0cE.css" media="all"/>
+<link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211104203147cs_/https://www.health.govt.nz/sites/default/files/css/css_Rb1wqFBC8VXCJC-BuNY53cvjjlj6UADGvqzo_f-1yN0.css" media="all"/>
+<link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211104203147cs_/https://www.health.govt.nz/sites/default/files/css/css_38_K1lHKg-98m4KKRfv57JBK0gvlKscexGt9MKoi0DE.css" media="all"/>
+<link type="text/css" rel="stylesheet" href="https://web.archive.org/web/20211104203147cs_/https://www.health.govt.nz/sites/default/files/css/css_r7NPyvpdYfAyZmk9zkK8OaFKEFj6er5ZJnam2H644DM.css" media="print"/>
+  <link rel="alternate stylesheet" type="text/css" href="/web/20211104203147cs_/https://www.health.govt.nz/sites/all/themes/mohpub_bootstrap/css/high-contrast.css" media="screen" title="High Contrast"/>
+  <script src="https://web.archive.org/web/20211104203147js_/https://www.health.govt.nz/sites/default/files/js/js_zS-CmNFGyegtLYJmqFRpxQvvQrfPIFrOMq_3T3C8sZE.js"></script>
+<script src="https://web.archive.org/web/20211104203147js_/https://www.health.govt.nz/sites/default/files/js/js_fNgZ4Okisfr70Q0yvAYsATgB0o_jD3-srhQQ-VHmlXE.js"></script>
+<script src="https://web.archive.org/web/20211104203147js_/https://www.health.govt.nz/sites/default/files/js/js_YAdPZfg12M1m7ROp3_gVJPS5sArqL0kYQgNRPoicvHE.js"></script>
+<script>(function(i,s,o,g,r,a,m){i["GoogleAnalyticsObject"]=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,"script","https://web.archive.org/web/20211104203147/https://www.google-analytics.com/analytics.js","ga");ga("create", "UA-3573389-24", {"cookieDomain":".www.health.govt.nz","siteSpeedSampleRate":15});ga("send", "pageview");</script>
+<script src="https://web.archive.org/web/20211104203147js_/https://www.health.govt.nz/sites/default/files/js/js_wauJ-VUoyA1MrZ6ZPFtGhNR7qiKnBdBSKEwQJjdEXIk.js"></script>
+<script src="https://web.archive.org/web/20211104203147js_/https://www.health.govt.nz/sites/default/files/js/js_4VW9edmu3V8VjGJxFfXGAwkXeW2cJIa5h-6y7SgwVrk.js"></script>
 <script>    (function(h,o,t,j,a,r){
         h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
         h._hjSettings={hjid:930919,hjsv:6};
@@ -49,9 +49,9 @@
         r=o.createElement('script');r.async=1;
         r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
         a.appendChild(r);
-    })(window,document,'https://web.archive.org/web/20211105212204/https://static.hotjar.com/c/hotjar-','.js?sv=');
+    })(window,document,'https://web.archive.org/web/20211104203147/https://static.hotjar.com/c/hotjar-','.js?sv=');
 </script>
-<script>jQuery.extend(Drupal.settings, {"basePath":"\/","pathPrefix":"","ajaxPageState":{"theme":"mohpub_bootstrap","theme_token":"sG17d5nY2p-xVKOvUv-8mTERBtGUY-KscwPfU3dYiOo","js":{"sites\/all\/modules\/custom\/table_d3chart\/js\/table_d3chart.js":1,"sites\/all\/modules\/custom\/moh_d3\/moh_d3.js":1,"sites\/all\/modules\/contrib\/jquery_update\/replace\/jquery\/1.7\/jquery.min.js":1,"misc\/jquery-extend-3.4.0.js":1,"misc\/jquery-html-prefilter-3.5.0-backport.js":1,"misc\/jquery.once.js":1,"misc\/drupal.js":1,"sites\/all\/modules\/contrib\/ckeditor_accordion\/js\/ckeditor-accordion.js":1,"sites\/all\/modules\/contrib\/extlink\/extlink.js":1,"modules\/field\/modules\/text\/text.js":1,"sites\/all\/modules\/contrib\/field_group\/field_group.js":1,"sites\/all\/modules\/contrib\/google_analytics\/googleanalytics.js":1,"0":1,"sites\/all\/libraries\/c3\/c3.js":1,"sites\/all\/libraries\/d3\/d3.js":1,"sites\/all\/modules\/contrib\/d3\/js\/d3.js":1,"sites\/all\/libraries\/d3.helpers\/d3.helpers.js":1,"sites\/all\/libraries\/d3.c3\/d3-c3.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/assets\/ios-fix.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/affix.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/alert.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/button.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/carousel.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/collapse.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/dropdown.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/modal.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/tooltip.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/popover.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/scrollspy.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/tab.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/transition.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/jquery.cookie.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/jquery.moh.announcement.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/svgeezy.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/fitvids.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/bootstrap-tabcollapse.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/jquery.scrollTo.min.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/script.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/jquery.google_analytics.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/bootstrap-accessibility.min.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/style-switcher.js":1,"1":1},"css":{"modules\/system\/system.base.css":1,"sites\/all\/modules\/contrib\/calendar\/css\/calendar_multiday.css":1,"sites\/all\/modules\/contrib\/ckeditor_accordion\/css\/ckeditor-accordion.css":1,"modules\/field\/theme\/field.css":1,"modules\/node\/node.css":1,"sites\/all\/modules\/contrib\/extlink\/extlink.css":1,"sites\/all\/modules\/contrib\/views\/css\/views.css":1,"sites\/all\/modules\/contrib\/ckeditor\/css\/ckeditor.css":1,"sites\/all\/modules\/contrib\/ctools\/css\/ctools.css":1,"sites\/all\/modules\/contrib\/panels\/css\/panels.css":1,"sites\/all\/libraries\/c3\/c3.css":1,"sites\/all\/libraries\/d3.c3\/d3-c3.css":1,"sites\/all\/themes\/mohpub_bootstrap\/fontawesome\/css\/fontawesome.min.css":1,"sites\/all\/themes\/mohpub_bootstrap\/fontawesome\/css\/solid.min.css":1,"sites\/all\/themes\/mohpub_bootstrap\/fontawesome\/css\/brands.min.css":1,"sites\/all\/modules\/features\/site_profile\/css\/fix-rubik-multiselect-height.css":1,"sites\/all\/themes\/mohpub_bootstrap\/css\/style.css":1,"sites\/all\/themes\/mohpub_bootstrap\/css\/responsive-tables.css":1,"sites\/all\/themes\/mohpub_bootstrap\/css\/print.css":1}},"field_group":{"div":"full"},"ckeditor_accordion":{"collapseAll":1},"extlink":{"extTarget":0,"extClass":"ext","extLabel":"(link is external)","extImgClass":0,"extIconPlacement":"append","extSubdomains":0,"extExclude":"","extInclude":"","extCssExclude":"","extCssExplicit":"","extAlert":0,"extAlertText":"This link will take you to an external web site. We are not responsible for their content.","mailtoClass":"mailto","mailtoLabel":"(link sends e-mail)"},"googleanalytics":{"trackOutbound":1,"trackMailto":1,"trackDownload":1,"trackDownloadExtensions":"7z|aac|arc|arj|asf|asx|avi|bin|csv|doc|exe|flv|gif|gz|gzip|hqx|jar|jpe?g|js|mp(2|3|4|e?g)|mov(ie)?|msi|msp|pdf|phps|png|ppt|qtm?|ra(m|r)?|sea|sit|tar|tgz|torrent|txt|wav|wma|wmv|wpd|xls|xml|z|zip|docx|xlsx|pptx|pptm|ppsx|ppsm|epub"},"mohD3":{"C3Types":["line","spline","step","area","area-spline","area-step","bar","scatter","pie","donut","gauge"],"graphRender":"line","graphLegend":true,"graphDefaultColors":"#2b8cbe, #abdda4, #7f7f7f, #92cddc, #dc8b0c","graphDefaultGroupedTooltip":0,"graphDefaultGridX":0,"graphDefaultGridY":0,"graphDefaultLegendPosition":"top-right","graphDefaultTooltip":1,"graphDefaultDataLabel":0,"graphLegendStep":"5","graphInteraction":true,"graphTypes":"","graphXaxisShow":true,"graphXaxisLabel":"","graphYaxisLabel":"","graphXaxisType":"category","graphXaxisCentered":false,"graphXaxisRotation":"","graphXaxisHeight":"","graphYaxisShow":true,"graphYaxisMax":"","graphYaxisMin":"","graphYaxisInverted":false,"graphYaxisCenter":"","graphYaxisPrefix":"","graphYaxisSuffix":"","graphYaxisPosition":"","graphY2axisShow":false,"graphY2axisSource":"","graphY2axisMax":"","graphY2axisMin":"","graphGroups":"","graphRotated":false,"graphIgnoreEmpty":false,"graphLineDot":true,"graphBarRatio":"0.9","graphDot":true,"graphDotR":"2.5","graphFocus":false},"tableD3":{"show":"View table data source","hide":"Hide table data source"},"urlIsAjaxTrusted":{"\/our-work\/diseases-and-conditions\/covid-19-novel-coronavirus\/covid-19-data-and-statistics\/covid-19-vaccine-data":true},"bootstrap":{"anchorsFix":1,"anchorsSmoothScrolling":1,"formHasError":1,"popoverEnabled":1,"popoverOptions":{"animation":1,"html":0,"placement":"right","selector":"","trigger":"click","triggerAutoclose":1,"title":"","content":"","delay":0,"container":"body"},"tooltipEnabled":1,"tooltipOptions":{"animation":1,"html":0,"placement":"auto left","selector":"","trigger":"hover focus","delay":0,"container":"body"}}});</script>
+<script>jQuery.extend(Drupal.settings, {"basePath":"\/","pathPrefix":"","ajaxPageState":{"theme":"mohpub_bootstrap","theme_token":"PgOnX29DjN1wJtmUACR1w-ZggVbhRF99GKETS8fQvfM","js":{"sites\/all\/modules\/custom\/table_d3chart\/js\/table_d3chart.js":1,"sites\/all\/modules\/custom\/moh_d3\/moh_d3.js":1,"sites\/all\/modules\/contrib\/jquery_update\/replace\/jquery\/1.7\/jquery.min.js":1,"misc\/jquery-extend-3.4.0.js":1,"misc\/jquery-html-prefilter-3.5.0-backport.js":1,"misc\/jquery.once.js":1,"misc\/drupal.js":1,"sites\/all\/modules\/contrib\/ckeditor_accordion\/js\/ckeditor-accordion.js":1,"sites\/all\/modules\/contrib\/extlink\/extlink.js":1,"modules\/field\/modules\/text\/text.js":1,"sites\/all\/modules\/contrib\/field_group\/field_group.js":1,"sites\/all\/modules\/contrib\/google_analytics\/googleanalytics.js":1,"0":1,"sites\/all\/libraries\/c3\/c3.js":1,"sites\/all\/libraries\/d3\/d3.js":1,"sites\/all\/modules\/contrib\/d3\/js\/d3.js":1,"sites\/all\/libraries\/d3.helpers\/d3.helpers.js":1,"sites\/all\/libraries\/d3.c3\/d3-c3.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/assets\/ios-fix.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/affix.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/alert.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/button.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/carousel.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/collapse.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/dropdown.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/modal.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/tooltip.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/popover.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/scrollspy.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/tab.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/transition.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/jquery.cookie.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/jquery.moh.announcement.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/svgeezy.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/fitvids.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/bootstrap-tabcollapse.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/jquery.scrollTo.min.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/script.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/jquery.google_analytics.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/bootstrap-accessibility.min.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/style-switcher.js":1,"1":1},"css":{"modules\/system\/system.base.css":1,"sites\/all\/modules\/contrib\/calendar\/css\/calendar_multiday.css":1,"sites\/all\/modules\/contrib\/ckeditor_accordion\/css\/ckeditor-accordion.css":1,"modules\/field\/theme\/field.css":1,"modules\/node\/node.css":1,"sites\/all\/modules\/contrib\/extlink\/extlink.css":1,"sites\/all\/modules\/contrib\/views\/css\/views.css":1,"sites\/all\/modules\/contrib\/ckeditor\/css\/ckeditor.css":1,"sites\/all\/modules\/contrib\/ctools\/css\/ctools.css":1,"sites\/all\/modules\/contrib\/panels\/css\/panels.css":1,"sites\/all\/libraries\/c3\/c3.css":1,"sites\/all\/libraries\/d3.c3\/d3-c3.css":1,"sites\/all\/themes\/mohpub_bootstrap\/fontawesome\/css\/fontawesome.min.css":1,"sites\/all\/themes\/mohpub_bootstrap\/fontawesome\/css\/solid.min.css":1,"sites\/all\/themes\/mohpub_bootstrap\/fontawesome\/css\/brands.min.css":1,"sites\/all\/modules\/features\/site_profile\/css\/fix-rubik-multiselect-height.css":1,"sites\/all\/themes\/mohpub_bootstrap\/css\/style.css":1,"sites\/all\/themes\/mohpub_bootstrap\/css\/responsive-tables.css":1,"sites\/all\/themes\/mohpub_bootstrap\/css\/print.css":1}},"field_group":{"div":"full"},"ckeditor_accordion":{"collapseAll":1},"extlink":{"extTarget":0,"extClass":"ext","extLabel":"(link is external)","extImgClass":0,"extIconPlacement":"append","extSubdomains":0,"extExclude":"","extInclude":"","extCssExclude":"","extCssExplicit":"","extAlert":0,"extAlertText":"This link will take you to an external web site. We are not responsible for their content.","mailtoClass":"mailto","mailtoLabel":"(link sends e-mail)"},"googleanalytics":{"trackOutbound":1,"trackMailto":1,"trackDownload":1,"trackDownloadExtensions":"7z|aac|arc|arj|asf|asx|avi|bin|csv|doc|exe|flv|gif|gz|gzip|hqx|jar|jpe?g|js|mp(2|3|4|e?g)|mov(ie)?|msi|msp|pdf|phps|png|ppt|qtm?|ra(m|r)?|sea|sit|tar|tgz|torrent|txt|wav|wma|wmv|wpd|xls|xml|z|zip|docx|xlsx|pptx|pptm|ppsx|ppsm|epub"},"mohD3":{"C3Types":["line","spline","step","area","area-spline","area-step","bar","scatter","pie","donut","gauge"],"graphRender":"line","graphLegend":true,"graphDefaultColors":"#2b8cbe, #abdda4, #7f7f7f, #92cddc, #dc8b0c","graphDefaultGroupedTooltip":0,"graphDefaultGridX":0,"graphDefaultGridY":0,"graphDefaultLegendPosition":"top-right","graphDefaultTooltip":1,"graphDefaultDataLabel":0,"graphLegendStep":"5","graphInteraction":true,"graphTypes":"","graphXaxisShow":true,"graphXaxisLabel":"","graphYaxisLabel":"","graphXaxisType":"category","graphXaxisCentered":false,"graphXaxisRotation":"","graphXaxisHeight":"","graphYaxisShow":true,"graphYaxisMax":"","graphYaxisMin":"","graphYaxisInverted":false,"graphYaxisCenter":"","graphYaxisPrefix":"","graphYaxisSuffix":"","graphYaxisPosition":"","graphY2axisShow":false,"graphY2axisSource":"","graphY2axisMax":"","graphY2axisMin":"","graphGroups":"","graphRotated":false,"graphIgnoreEmpty":false,"graphLineDot":true,"graphBarRatio":"0.9","graphDot":true,"graphDotR":"2.5","graphFocus":false},"tableD3":{"show":"View table data source","hide":"Hide table data source"},"urlIsAjaxTrusted":{"\/our-work\/diseases-and-conditions\/covid-19-novel-coronavirus\/covid-19-data-and-statistics\/covid-19-vaccine-data":true},"bootstrap":{"anchorsFix":1,"anchorsSmoothScrolling":1,"formHasError":1,"popoverEnabled":1,"popoverOptions":{"animation":1,"html":0,"placement":"right","selector":"","trigger":"click","triggerAutoclose":1,"title":"","content":"","delay":0,"container":"body"},"tooltipEnabled":1,"tooltipOptions":{"animation":1,"html":0,"placement":"auto left","selector":"","trigger":"hover focus","delay":0,"container":"body"}}});</script>
   <!-- HTML5 element support for IE6-8 -->
   <!--[if lt IE 9]>
     <script src="/sites/all/themes/mohpub_bootstrap/js/assets/html5shiv.js"></script>
@@ -93,7 +93,7 @@ body {
 	<a id="wm-tb-close" href="#close" onclick="__wm.h(event);return false;" style="top:-2px;" title="Close the toolbar"><span class="iconochive-remove-circle" style="color:#888888;font-size:240%;"></span></a>
       </div>
       <div id="wm-share">
-          <a href="/web/20211105212204/http://web.archive.org/screenshot/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data"
+          <a href="/web/20211104203147/http://web.archive.org/screenshot/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data"
              id="wm-screenshot"
              title="screenshot">
             <span class="wm-icon-screen-shot"></span>
@@ -103,35 +103,35 @@ body {
             title="video">
             <span class="iconochive-movies"></span>
           </a>
-	<a id="wm-share-facebook" href="#" data-url="https://web.archive.org/web/20211105212204/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="Share on Facebook" style="margin-right:5px;" target="_blank"><span class="iconochive-facebook" style="color:#3b5998;font-size:160%;"></span></a>
-	<a id="wm-share-twitter" href="#" data-url="https://web.archive.org/web/20211105212204/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="Share on Twitter" style="margin-right:5px;" target="_blank"><span class="iconochive-twitter" style="color:#1dcaff;font-size:160%;"></span></a>
+	<a id="wm-share-facebook" href="#" data-url="https://web.archive.org/web/20211104203147/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="Share on Facebook" style="margin-right:5px;" target="_blank"><span class="iconochive-facebook" style="color:#3b5998;font-size:160%;"></span></a>
+	<a id="wm-share-twitter" href="#" data-url="https://web.archive.org/web/20211104203147/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="Share on Twitter" style="margin-right:5px;" target="_blank"><span class="iconochive-twitter" style="color:#1dcaff;font-size:160%;"></span></a>
       </div>
     </div>
     <table class="c" style="">
       <tbody>
 	<tr>
 	  <td class="u" colspan="2">
-	    <form target="_top" method="get" action="/web/submit" name="wmtb" id="wmtb"><input type="text" name="url" id="wmtbURL" value="https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" onfocus="this.focus();this.select();" /><input type="hidden" name="type" value="replay" /><input type="hidden" name="date" value="20211105212204" /><input type="submit" value="Go" /></form>
+	    <form target="_top" method="get" action="/web/submit" name="wmtb" id="wmtb"><input type="text" name="url" id="wmtbURL" value="https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" onfocus="this.focus();this.select();" /><input type="hidden" name="type" value="replay" /><input type="hidden" name="date" value="20211104203147" /><input type="submit" value="Go" /></form>
 	  </td>
 	  <td class="n" rowspan="2" style="width:110px;">
 	    <table>
 	      <tbody>
 		<!-- NEXT/PREV MONTH NAV AND MONTH INDICATOR -->
 		<tr class="m">
-		  <td class="b" nowrap="nowrap"><a href="https://web.archive.org/web/20211005185143/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="05 Oct 2021"><strong>Oct</strong></a></td>
-		  <td class="c" id="displayMonthEl" title="You are here: 21:22:04 Nov 05, 2021">NOV</td>
+		  <td class="b" nowrap="nowrap"><a href="https://web.archive.org/web/20211004141144/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="04 Oct 2021"><strong>Oct</strong></a></td>
+		  <td class="c" id="displayMonthEl" title="You are here: 20:31:47 Nov 04, 2021">NOV</td>
 		  <td class="f" nowrap="nowrap">Dec</td>
 		</tr>
 		<!-- NEXT/PREV CAPTURE NAV AND DAY OF MONTH INDICATOR -->
 		<tr class="d">
-		  <td class="b" nowrap="nowrap"><a href="https://web.archive.org/web/20211104203147/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="20:31:47 Nov 04, 2021"><img src="/_static/images/toolbar/wm_tb_prv_on.png" alt="Previous capture" width="14" height="16" border="0" /></a></td>
-		  <td class="c" id="displayDayEl" style="width:34px;font-size:24px;white-space:nowrap;" title="You are here: 21:22:04 Nov 05, 2021">05</td>
-		  <td class="f" nowrap="nowrap"><img src="/_static/images/toolbar/wm_tb_nxt_off.png" alt="Next capture" width="14" height="16" border="0" /></td>
+		  <td class="b" nowrap="nowrap"><a href="https://web.archive.org/web/20211103184409/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="18:44:09 Nov 03, 2021"><img src="/_static/images/toolbar/wm_tb_prv_on.png" alt="Previous capture" width="14" height="16" border="0" /></a></td>
+		  <td class="c" id="displayDayEl" style="width:34px;font-size:24px;white-space:nowrap;" title="You are here: 20:31:47 Nov 04, 2021">04</td>
+		  <td class="f" nowrap="nowrap"><a href="https://web.archive.org/web/20211105212204/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="21:22:04 Nov 05, 2021"><img src="/_static/images/toolbar/wm_tb_nxt_on.png" alt="Next capture" width="14" height="16" border="0" /></a></td>
 		</tr>
 		<!-- NEXT/PREV YEAR NAV AND YEAR INDICATOR -->
 		<tr class="y">
 		  <td class="b" nowrap="nowrap">2020</td>
-		  <td class="c" id="displayYearEl" title="You are here: 21:22:04 Nov 05, 2021">2021</td>
+		  <td class="c" id="displayYearEl" title="You are here: 20:31:47 Nov 04, 2021">2021</td>
 		  <td class="f" nowrap="nowrap">2022</td>
 		</tr>
 	      </tbody>
@@ -141,7 +141,7 @@ body {
 	<tr>
 	  <td class="s">
 	    	    <div id="wm-nav-captures">
-	      	      <a class="t" href="/web/20211105212204*/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="See a list of every capture for this URL">682 captures</a>
+	      	      <a class="t" href="/web/20211104203147*/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="See a list of every capture for this URL">682 captures</a>
 	      <div class="r" title="Timespan for captures of this URL">07 Apr 2021 - 06 Nov 2021</div>
 	      </div>
 	  </td>
@@ -184,15 +184,15 @@ body {
       <div id="wm-capresources-loading" style="text-align:left;margin:0 20px 5px 5px;display:none"><img src="/_static/images/loading.gif" alt="loading" /></div>
     </div>
     </div>
-  </div></div></div></div><div id="wm-ipp-print">The Wayback Machine - https://web.archive.org/web/20211105212204/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data</div>
+  </div></div></div></div><div id="wm-ipp-print">The Wayback Machine - https://web.archive.org/web/20211104203147/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data</div>
 <div id="donato" style="position:relative;width:100%;">
   <div id="donato-base">
-    <iframe id="donato-if" src="https://archive.org/includes/donate.php?as_page=1&amp;platform=wb&amp;referer=https%3A//web.archive.org/web/20211105212204/https%3A//www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data"
+    <iframe id="donato-if" src="https://archive.org/includes/donate.php?as_page=1&amp;platform=wb&amp;referer=https%3A//web.archive.org/web/20211104203147/https%3A//www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data"
 	    scrolling="no" frameborder="0" style="width:100%; height:100%">
     </iframe>
   </div>
 </div><script type="text/javascript">
-__wm.bt(650,27,25,2,"web","https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data","20211105212204",1996,"/_static/",["/_static/css/banner-styles.css?v=omkqRugM","/_static/css/iconochive.css?v=qtvMKcIJ"], "False");
+__wm.bt(650,27,25,2,"web","https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data","20211104203147",1996,"/_static/",["/_static/css/banner-styles.css?v=omkqRugM","/_static/css/iconochive.css?v=qtvMKcIJ"], "False");
   __wm.rw(1);
 </script>
 <!-- END WAYBACK TOOLBAR INSERT -->
@@ -202,23 +202,23 @@ __wm.bt(650,27,25,2,"web","https://www.health.govt.nz/our-work/diseases-and-cond
   </div>
     <div id="page">
   <header id="navbar" role="banner" class="navbar container navbar-default">
-          <ul class="menu nav navbar-nav secondary"><li class="first leaf jobs depth-1"><a href="https://web.archive.org/web/20211105212204/https://careers.health.govt.nz/" title="">Jobs</a></li>
-<li class="leaf news depth-1"><a href="/web/20211105212204/https://www.health.govt.nz/news-media" data-is-top-level="0" title="">News</a></li>
-<li class="leaf contact-us depth-1"><a href="/web/20211105212204/https://www.health.govt.nz/about-ministry/contact-us" title="">Contact us</a></li>
-<li class="leaf facebook depth-1"><a href="https://web.archive.org/web/20211105212204/https://www.facebook.com/minhealthnz/">Facebook</a></li>
-<li class="leaf twitter depth-1"><a href="https://web.archive.org/web/20211105212204/https://twitter.com/minhealthnz" data-is-top-level="0" title="">Twitter</a></li>
-<li class="last leaf youtube depth-1"><a href="https://web.archive.org/web/20211105212204/https://www.youtube.com/user/minhealthnz" data-is-top-level="0" title="">Youtube</a></li>
+          <ul class="menu nav navbar-nav secondary"><li class="first leaf jobs depth-1"><a href="https://web.archive.org/web/20211104203147/https://careers.health.govt.nz/" title="">Jobs</a></li>
+<li class="leaf news depth-1"><a href="/web/20211104203147/https://www.health.govt.nz/news-media" data-is-top-level="0" title="">News</a></li>
+<li class="leaf contact-us depth-1"><a href="/web/20211104203147/https://www.health.govt.nz/about-ministry/contact-us" title="">Contact us</a></li>
+<li class="leaf facebook depth-1"><a href="https://web.archive.org/web/20211104203147/https://www.facebook.com/minhealthnz/">Facebook</a></li>
+<li class="leaf twitter depth-1"><a href="https://web.archive.org/web/20211104203147/https://twitter.com/minhealthnz" data-is-top-level="0" title="">Twitter</a></li>
+<li class="last leaf youtube depth-1"><a href="https://web.archive.org/web/20211104203147/https://www.youtube.com/user/minhealthnz" data-is-top-level="0" title="">Youtube</a></li>
 </ul>        <div class="container">
       <div class="navbar-header">
-                <a class="logo navbar-btn pull-left" href="/web/20211105212204/https://www.health.govt.nz/" title="Home">
-          <img src="/web/20211105212204im_/https://www.health.govt.nz/sites/all/themes/mohpub_bootstrap/images/mohlogo.svg" alt="Ministry of Health"/>
+                <a class="logo navbar-btn pull-left" href="/web/20211104203147/https://www.health.govt.nz/" title="Home">
+          <img src="/web/20211104203147im_/https://www.health.govt.nz/sites/all/themes/mohpub_bootstrap/images/mohlogo.svg" alt="Ministry of Health"/>
         </a>
                   <div class="region region-header-top">
     <section id="block-apachesolr-panels-search-form" class="block block-apachesolr-panels clearfix">
 
 
-  <form action="/web/20211105212204/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" method="post" id="apachesolr-panels-search-block" accept-charset="UTF-8"><div><div class="form-item form-item-apachesolr-panels-search-form form-type-textfield form-group"> <label class="control-label" for="edit-apachesolr-panels-search-form">Search</label>
-<input title="Enter the terms you wish to search for." class="form-control form-text" type="text" id="edit-apachesolr-panels-search-form" name="apachesolr_panels_search_form" value="" size="15" maxlength="128"/></div><input type="hidden" name="form_build_id" value="form-8PHjo7AOdBEFFTnfEDVdbHYwEEo9lozkLOTIzlzKkko"/>
+  <form action="/web/20211104203147/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" method="post" id="apachesolr-panels-search-block" accept-charset="UTF-8"><div><div class="form-item form-item-apachesolr-panels-search-form form-type-textfield form-group"> <label class="control-label" for="edit-apachesolr-panels-search-form">Search</label>
+<input title="Enter the terms you wish to search for." class="form-control form-text" type="text" id="edit-apachesolr-panels-search-form" name="apachesolr_panels_search_form" value="" size="15" maxlength="128"/></div><input type="hidden" name="form_build_id" value="form-jfo3wv1Lf5-3SauLcv7N8dkMLygjM0Q42lkxndsVuvQ"/>
 <input type="hidden" name="form_id" value="apachesolr_panels_search_block"/>
 <div class="form-actions form-wrapper form-group" id="edit-actions"><button type="submit" id="edit-submit" name="op" value="Search" class="btn btn-primary form-submit">Search</button>
 </div></div></form>
@@ -236,293 +236,293 @@ __wm.bt(650,27,25,2,"web","https://www.health.govt.nz/our-work/diseases-and-cond
 
               <div class="navbar-collapse collapse">
           <nav id="megamenu" role="navigation">
-                          <h2 class="element-invisible">Main menu</h2><ul id="main-menu" class="menu nav navbar-nav yamm navbar"><li class="first dropdown"><a href="/web/20211105212204/https://www.health.govt.nz/your-health" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="megamenu-dropdown-780">Your health <b class="caret"></b></a>
+                          <h2 class="element-invisible">Main menu</h2><ul id="main-menu" class="menu nav navbar-nav yamm navbar"><li class="first dropdown"><a href="/web/20211104203147/https://www.health.govt.nz/your-health" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="megamenu-dropdown-780">Your health <b class="caret"></b></a>
     <div id="megamenu-dropdown-780" class="dropdown-menu">
     <div class="yamm-content">
       <div class="row">
                             <div class="col">
-            <h3><a href="/web/20211105212204/https://www.health.govt.nz/your-health/conditions-and-treatments?mega=Your%20health&amp;title=Conditions%20%26%20treatments" class="menu-header">Conditions &amp; treatments</a></h3>
+            <h3><a href="/web/20211104203147/https://www.health.govt.nz/your-health/conditions-and-treatments?mega=Your%20health&amp;title=Conditions%20%26%20treatments" class="menu-header">Conditions &amp; treatments</a></h3>
             <ul class="list-unstyled">
-                                                <li><a href="/web/20211105212204/https://www.health.govt.nz/your-health/conditions-and-treatments/mental-health/depression?mega=Your%20health&amp;title=Depression">Depression</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/diabetes?mega=Your%20health&amp;title=Diabetes">Diabetes</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/influenza?mega=Your%20health&amp;title=Influenza">Influenza</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/measles?mega=Your%20health&amp;title=Measles">Measles</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/meningococcal-disease-including-meningitis?mega=Your%20health&amp;title=Meningococcal%20disease">Meningococcal disease</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/mumps?mega=Your%20health&amp;title=Mumps">Mumps</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/respiratory-syncytial-virus-rsv?mega=Your%20health&amp;title=RSV">RSV</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/sore-throat?mega=Your%20health&amp;title=Sore%20throat">Sore throat</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/your-health/conditions-and-treatments?mega=Your%20health&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                                <li><a href="/web/20211104203147/https://www.health.govt.nz/your-health/conditions-and-treatments/mental-health/depression?mega=Your%20health&amp;title=Depression">Depression</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/diabetes?mega=Your%20health&amp;title=Diabetes">Diabetes</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/influenza?mega=Your%20health&amp;title=Influenza">Influenza</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/measles?mega=Your%20health&amp;title=Measles">Measles</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/meningococcal-disease-including-meningitis?mega=Your%20health&amp;title=Meningococcal%20disease">Meningococcal disease</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/mumps?mega=Your%20health&amp;title=Mumps">Mumps</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/respiratory-syncytial-virus-rsv?mega=Your%20health&amp;title=RSV">RSV</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/your-health/conditions-and-treatments/diseases-and-illnesses/sore-throat?mega=Your%20health&amp;title=Sore%20throat">Sore throat</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/your-health/conditions-and-treatments?mega=Your%20health&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
                                           </ul>
           </div>
                                       <div class="col">
-            <h3><a href="/web/20211105212204/https://www.health.govt.nz/your-health/healthy-living?mega=Your%20health&amp;title=Healthy%20living" class="menu-header">Healthy living</a></h3>
+            <h3><a href="/web/20211104203147/https://www.health.govt.nz/your-health/healthy-living?mega=Your%20health&amp;title=Healthy%20living" class="menu-header">Healthy living</a></h3>
             <ul class="list-unstyled">
-                                                <li><a href="/web/20211105212204/https://www.health.govt.nz/your-health/healthy-living/drinking-water?mega=Your%20health&amp;title=Drinking-water">Drinking-water</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/your-health/healthy-living/food-activity-and-sleep/green-prescriptions?mega=Your%20health&amp;title=Green%20Prescriptions">Green Prescriptions</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/your-health/healthy-living/food-activity-and-sleep/healthy-eating?mega=Your%20health&amp;title=Healthy%20eating">Healthy eating</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/your-health/healthy-living/immunisation?mega=Your%20health&amp;title=Immunisation">Immunisation</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/your-health/healthy-living/food-activity-and-sleep/physical-activity?mega=Your%20health&amp;title=Physical%20activity">Physical activity</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/your-health/healthy-living/addictions/quitting-smoking?mega=Your%20health&amp;title=Smoking">Smoking</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/your-health/healthy-living/teeth-and-gums?mega=Your%20health&amp;title=Teeth%20and%20gums">Teeth and gums</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/your-health/healthy-living?mega=Your%20health&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                                <li><a href="/web/20211104203147/https://www.health.govt.nz/your-health/healthy-living/drinking-water?mega=Your%20health&amp;title=Drinking-water">Drinking-water</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/your-health/healthy-living/food-activity-and-sleep/green-prescriptions?mega=Your%20health&amp;title=Green%20Prescriptions">Green Prescriptions</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/your-health/healthy-living/food-activity-and-sleep/healthy-eating?mega=Your%20health&amp;title=Healthy%20eating">Healthy eating</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/your-health/healthy-living/immunisation?mega=Your%20health&amp;title=Immunisation">Immunisation</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/your-health/healthy-living/food-activity-and-sleep/physical-activity?mega=Your%20health&amp;title=Physical%20activity">Physical activity</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/your-health/healthy-living/addictions/quitting-smoking?mega=Your%20health&amp;title=Smoking">Smoking</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/your-health/healthy-living/teeth-and-gums?mega=Your%20health&amp;title=Teeth%20and%20gums">Teeth and gums</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/your-health/healthy-living?mega=Your%20health&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
                                           </ul>
           </div>
                                       <div class="col">
-            <h3><a href="/web/20211105212204/https://www.health.govt.nz/your-health/pregnancy-and-kids?mega=Your%20health&amp;title=Pregnancy%20and%20kids" class="menu-header">Pregnancy and kids</a></h3>
+            <h3><a href="/web/20211104203147/https://www.health.govt.nz/your-health/pregnancy-and-kids?mega=Your%20health&amp;title=Pregnancy%20and%20kids" class="menu-header">Pregnancy and kids</a></h3>
             <ul class="list-unstyled">
-                                                <li><a href="/web/20211105212204/https://www.health.govt.nz/your-health/pregnancy-and-kids/birth-and-afterwards?mega=Your%20health&amp;title=Birth%20and%20afterwards">Birth and afterwards</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/your-health/pregnancy-and-kids/first-year/helpful-advice-during-first-year/breastfeeding-perfect-you-and-your-baby?mega=Your%20health&amp;title=Breastfeeding">Breastfeeding</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/your-health/pregnancy-and-kids/pregnancy?mega=Your%20health&amp;title=Pregnancy">Pregnancy</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/your-health/pregnancy-and-kids/services-and-support-during-pregnancy?mega=Your%20health&amp;title=Services%20and%20support%20during%20pregnancy">Services and support during pregnancy</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/your-health/pregnancy-and-kids/services-and-support-you-and-your-child?mega=Your%20health&amp;title=Services%20and%20support%20for%20you%20and%20your%20child">Services and support for you and your child</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/your-health/pregnancy-and-kids/first-year?mega=Your%20health&amp;title=The%20first%20year">The first year</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/your-health/pregnancy-and-kids/under-fives?mega=Your%20health&amp;title=Under%20fives">Under fives</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/your-health/pregnancy-and-kids?mega=Your%20health&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                                <li><a href="/web/20211104203147/https://www.health.govt.nz/your-health/pregnancy-and-kids/birth-and-afterwards?mega=Your%20health&amp;title=Birth%20and%20afterwards">Birth and afterwards</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/your-health/pregnancy-and-kids/first-year/helpful-advice-during-first-year/breastfeeding-perfect-you-and-your-baby?mega=Your%20health&amp;title=Breastfeeding">Breastfeeding</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/your-health/pregnancy-and-kids/pregnancy?mega=Your%20health&amp;title=Pregnancy">Pregnancy</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/your-health/pregnancy-and-kids/services-and-support-during-pregnancy?mega=Your%20health&amp;title=Services%20and%20support%20during%20pregnancy">Services and support during pregnancy</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/your-health/pregnancy-and-kids/services-and-support-you-and-your-child?mega=Your%20health&amp;title=Services%20and%20support%20for%20you%20and%20your%20child">Services and support for you and your child</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/your-health/pregnancy-and-kids/first-year?mega=Your%20health&amp;title=The%20first%20year">The first year</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/your-health/pregnancy-and-kids/under-fives?mega=Your%20health&amp;title=Under%20fives">Under fives</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/your-health/pregnancy-and-kids?mega=Your%20health&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
                                           </ul>
           </div>
                                       <div class="col">
-            <h3><a href="/web/20211105212204/https://www.health.govt.nz/your-health/services-and-support?mega=Your%20health&amp;title=Services%20and%20support" class="menu-header">Services &amp; support</a></h3>
+            <h3><a href="/web/20211104203147/https://www.health.govt.nz/your-health/services-and-support?mega=Your%20health&amp;title=Services%20and%20support" class="menu-header">Services &amp; support</a></h3>
             <ul class="list-unstyled">
-                                                <li><a href="/web/20211105212204/https://www.health.govt.nz/your-health/services-and-support/health-care-services/help-alcohol-and-drug-problems?mega=Your%20health&amp;title=Alcohol%20and%20drugs">Alcohol and drugs</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/your-health/services-and-support/disability-services?mega=Your%20health&amp;title=Disability%20services">Disability services</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/your-health/services-and-support/health-care-services/earthquake-support-line?mega=Your%20health&amp;title=Earthquake%20Support%20Line">Earthquake Support Line</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/your-health/services-and-support/health-care-services/healthline?mega=Your%20health&amp;title=Healthline">Healthline</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/your-health/services-and-support/health-care-services/mental-health-services?mega=Your%20health&amp;title=Mental%20health%20services">Mental health services</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/your-health/services-and-support/health-care-services/maori-health-provider-directory?mega=Your%20health&amp;title=M%C4%81ori%20health%20providers">Māori health providers</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/your-health/services-and-support/health-care-services/services-older-people/rest-home-certification-and-audits?mega=Your%20health&amp;title=Rest%20home%20certification">Rest home certification</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/your-health/services-and-support/health-care-services/hospitals-and-specialist-services/travel-assistance?mega=Your%20health&amp;title=Travel%20assistance">Travel assistance</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/your-health/services-and-support?mega=Your%20health&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                                <li><a href="/web/20211104203147/https://www.health.govt.nz/your-health/services-and-support/health-care-services/help-alcohol-and-drug-problems?mega=Your%20health&amp;title=Alcohol%20and%20drugs">Alcohol and drugs</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/your-health/services-and-support/disability-services?mega=Your%20health&amp;title=Disability%20services">Disability services</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/your-health/services-and-support/health-care-services/earthquake-support-line?mega=Your%20health&amp;title=Earthquake%20Support%20Line">Earthquake Support Line</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/your-health/services-and-support/health-care-services/healthline?mega=Your%20health&amp;title=Healthline">Healthline</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/your-health/services-and-support/health-care-services/mental-health-services?mega=Your%20health&amp;title=Mental%20health%20services">Mental health services</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/your-health/services-and-support/health-care-services/maori-health-provider-directory?mega=Your%20health&amp;title=M%C4%81ori%20health%20providers">Māori health providers</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/your-health/services-and-support/health-care-services/services-older-people/rest-home-certification-and-audits?mega=Your%20health&amp;title=Rest%20home%20certification">Rest home certification</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/your-health/services-and-support/health-care-services/hospitals-and-specialist-services/travel-assistance?mega=Your%20health&amp;title=Travel%20assistance">Travel assistance</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/your-health/services-and-support?mega=Your%20health&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
                                           </ul>
           </div>
                         </div>
     </div>
     <div class="feature-links">
       <h3 class="sr-only">Other related resources</h3>
-      <a href="/web/20211105212204/https://www.health.govt.nz/your-health/full-a-z?mega=Your%20health&amp;title=A-Z">View the full A-Z</a>    </div>
+      <a href="/web/20211104203147/https://www.health.govt.nz/your-health/full-a-z?mega=Your%20health&amp;title=A-Z">View the full A-Z</a>    </div>
   </div>
 </li>
-<li class="dropdown"><a href="/web/20211105212204/https://www.health.govt.nz/new-zealand-health-system" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="megamenu-dropdown-6076">NZ health system <b class="caret"></b></a>
+<li class="dropdown"><a href="/web/20211104203147/https://www.health.govt.nz/new-zealand-health-system" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="megamenu-dropdown-6076">NZ health system <b class="caret"></b></a>
     <div id="megamenu-dropdown-6076" class="dropdown-menu">
     <div class="yamm-content">
       <div class="row">
                             <div class="col">
-            <h3><a href="/web/20211105212204/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people?mega=NZ%20health%20system&amp;title=Key%20organisations" class="menu-header">Key organisations</a></h3>
+            <h3><a href="/web/20211104203147/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people?mega=NZ%20health%20system&amp;title=Key%20organisations" class="menu-header">Key organisations</a></h3>
             <ul class="list-unstyled">
-                                                <li><a href="/web/20211105212204/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/crown-entities-and-statutory-boards?mega=NZ%20health%20system&amp;title=Crown%20entities%20%26%20agencies">Crown entities &amp; agencies</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/district-health-boards?mega=NZ%20health%20system&amp;title=District%20health%20boards">District health boards</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/non-governmental-organisations?mega=NZ%20health%20system&amp;title=Non-governmental%20organisations">Non-governmental organisations</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/primary-health-organisations?mega=NZ%20health%20system&amp;title=Primary%20health%20organisations">Primary health organisations</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/public-health-units?mega=NZ%20health%20system&amp;title=Public%20health%20units">Public health units</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people?mega=NZ%20health%20system&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                                <li><a href="/web/20211104203147/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/crown-entities-and-statutory-boards?mega=NZ%20health%20system&amp;title=Crown%20entities%20%26%20agencies">Crown entities &amp; agencies</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/district-health-boards?mega=NZ%20health%20system&amp;title=District%20health%20boards">District health boards</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/non-governmental-organisations?mega=NZ%20health%20system&amp;title=Non-governmental%20organisations">Non-governmental organisations</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/primary-health-organisations?mega=NZ%20health%20system&amp;title=Primary%20health%20organisations">Primary health organisations</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people/public-health-units?mega=NZ%20health%20system&amp;title=Public%20health%20units">Public health units</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/new-zealand-health-system/key-health-sector-organisations-and-people?mega=NZ%20health%20system&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
                                           </ul>
           </div>
                                       <div class="col">
-            <h3><a href="/web/20211105212204/https://www.health.govt.nz/new-zealand-health-system/health-system-indicators-framework?mega=NZ%20health%20system&amp;title=Health%20System%20Indicators%20framework" class="menu-header">Health System Indicators framework</a></h3>
+            <h3><a href="/web/20211104203147/https://www.health.govt.nz/new-zealand-health-system/health-system-indicators-framework?mega=NZ%20health%20system&amp;title=Health%20System%20Indicators%20framework" class="menu-header">Health System Indicators framework</a></h3>
             <ul class="list-unstyled">
-                                                <li><a href="/web/20211105212204/https://www.health.govt.nz/new-zealand-health-system/health-system-indicators-framework?mega=NZ%20health%20system&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                                <li><a href="/web/20211104203147/https://www.health.govt.nz/new-zealand-health-system/health-system-indicators-framework?mega=NZ%20health%20system&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
                                           </ul>
           </div>
                                       <div class="col">
-            <h3><a href="/web/20211105212204/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services?mega=NZ%20health%20system&amp;title=Eligibility%20for%20public%20health%20services" class="menu-header">Eligibility for public health services</a></h3>
+            <h3><a href="/web/20211104203147/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services?mega=NZ%20health%20system&amp;title=Eligibility%20for%20public%20health%20services" class="menu-header">Eligibility for public health services</a></h3>
             <ul class="list-unstyled">
-                                                <li><a href="/web/20211105212204/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services/guide-eligibility-publicly-funded-health-services?mega=NZ%20health%20system&amp;title=Guide%20to%20eligibility">Guide to eligibility</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services/eligibility-questions-and-answers-consumers?mega=NZ%20health%20system&amp;title=Q%26A%20for%20consumers">Q&amp;A for consumers</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services/eligibility-questions-and-answers-service-providers?mega=NZ%20health%20system&amp;title=Q%26A%20for%20service%20providers">Q&amp;A for service providers</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services/reciprocal-health-agreements?mega=NZ%20health%20system&amp;title=Reciprocal%20health%20agreements">Reciprocal health agreements</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services?mega=NZ%20health%20system&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                                <li><a href="/web/20211104203147/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services/guide-eligibility-publicly-funded-health-services?mega=NZ%20health%20system&amp;title=Guide%20to%20eligibility">Guide to eligibility</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services/eligibility-questions-and-answers-consumers?mega=NZ%20health%20system&amp;title=Q%26A%20for%20consumers">Q&amp;A for consumers</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services/eligibility-questions-and-answers-service-providers?mega=NZ%20health%20system&amp;title=Q%26A%20for%20service%20providers">Q&amp;A for service providers</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services/reciprocal-health-agreements?mega=NZ%20health%20system&amp;title=Reciprocal%20health%20agreements">Reciprocal health agreements</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/new-zealand-health-system/eligibility-publicly-funded-health-services?mega=NZ%20health%20system&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
                                           </ul>
           </div>
                                       <div class="col">
-            <h3><a href="/web/20211105212204/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements?mega=NZ%20health%20system&amp;title=Claims%2C%20provider%20payments%20and%20entitlements" class="menu-header">Claims &amp; provider payments</a></h3>
+            <h3><a href="/web/20211104203147/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements?mega=NZ%20health%20system&amp;title=Claims%2C%20provider%20payments%20and%20entitlements" class="menu-header">Claims &amp; provider payments</a></h3>
             <ul class="list-unstyled">
-                                                <li><a href="/web/20211105212204/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/carer-support-claims?mega=NZ%20health%20system&amp;title=Carer%20Support">Carer Support</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/high-use-health-card-payments?mega=NZ%20health%20system&amp;title=High%20Use%20Health%20Card%20payments">High Use Health Card payments</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/between-travel-settlement?mega=NZ%20health%20system&amp;title=In-Between%20Travel%20Settlement">In-Between Travel Settlement</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/maternity-claim-forms?mega=NZ%20health%20system&amp;title=Maternity%20claim%20forms">Maternity claim forms</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/national-travel-assistance?mega=NZ%20health%20system&amp;title=National%20travel%20assistance%20claims">National travel assistance claims</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements?mega=NZ%20health%20system&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                                <li><a href="/web/20211104203147/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/carer-support-claims?mega=NZ%20health%20system&amp;title=Carer%20Support">Carer Support</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/high-use-health-card-payments?mega=NZ%20health%20system&amp;title=High%20Use%20Health%20Card%20payments">High Use Health Card payments</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/between-travel-settlement?mega=NZ%20health%20system&amp;title=In-Between%20Travel%20Settlement">In-Between Travel Settlement</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/maternity-claim-forms?mega=NZ%20health%20system&amp;title=Maternity%20claim%20forms">Maternity claim forms</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements/national-travel-assistance?mega=NZ%20health%20system&amp;title=National%20travel%20assistance%20claims">National travel assistance claims</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/new-zealand-health-system/claims-provider-payments-and-entitlements?mega=NZ%20health%20system&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
                                           </ul>
           </div>
                         </div>
     </div>
     <div class="feature-links">
       <h3 class="sr-only">Other related resources</h3>
-      <a href="/web/20211105212204/https://www.health.govt.nz/new-zealand-health-system/overview-health-system?mega=NZ%20health%20system&amp;title=Overview">Overview of the health system</a>  <a href="/web/20211105212204/https://www.health.govt.nz/new-zealand-health-system/my-dhb?mega=NZ%20health%20system&amp;title=Mydhb">My DHB</a> <a href="/web/20211105212204/https://www.health.govt.nz/new-zealand-health-system/system-level-measures-framework?mega=NZ%20health%20system&amp;title=SLM">System level measures</a>  <a href="/web/20211105212204/https://www.health.govt.nz/publication/new-zealand-health-strategy-2016?mega=NZ%20health%20system&amp;title=HealthStrategy">NZ Health Strategy</a>    </div>
+      <a href="/web/20211104203147/https://www.health.govt.nz/new-zealand-health-system/overview-health-system?mega=NZ%20health%20system&amp;title=Overview">Overview of the health system</a>  <a href="/web/20211104203147/https://www.health.govt.nz/new-zealand-health-system/my-dhb?mega=NZ%20health%20system&amp;title=Mydhb">My DHB</a> <a href="/web/20211104203147/https://www.health.govt.nz/new-zealand-health-system/system-level-measures-framework?mega=NZ%20health%20system&amp;title=SLM">System level measures</a>  <a href="/web/20211104203147/https://www.health.govt.nz/publication/new-zealand-health-strategy-2016?mega=NZ%20health%20system&amp;title=HealthStrategy">NZ Health Strategy</a>    </div>
   </div>
 </li>
-<li class="dropdown"><a href="/web/20211105212204/https://www.health.govt.nz/our-work" class="dropdown-toggle active-trail" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="megamenu-dropdown-776">Our work <b class="caret"></b></a>
+<li class="dropdown"><a href="/web/20211104203147/https://www.health.govt.nz/our-work" class="dropdown-toggle active-trail" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="megamenu-dropdown-776">Our work <b class="caret"></b></a>
   <div id="megamenu-dropdown-776" class="dropdown-menu">
     <div class="yamm-content">
       <div class="row">
                             <ul class="col list-unstyled no-menu-header">
                                                                                 <li>
-                <a href="/web/20211105212204/https://www.health.govt.nz/our-work/hospitals-and-specialist-care/acute-care?mega=Our%20work&amp;title=Acute%20care" class="menu-header">Acute care</a>                              </li>
+                <a href="/web/20211104203147/https://www.health.govt.nz/our-work/hospitals-and-specialist-care/acute-care?mega=Our%20work&amp;title=Acute%20care" class="menu-header">Acute care</a>                              </li>
                                                                     <li>
-                <a href="/web/20211105212204/https://www.health.govt.nz/our-work/diseases-and-conditions/antimicrobial-resistance?mega=Our%20work&amp;title=Antimicrobial%20resistance" class="menu-header">Antimicrobial resistance</a>                              </li>
+                <a href="/web/20211104203147/https://www.health.govt.nz/our-work/diseases-and-conditions/antimicrobial-resistance?mega=Our%20work&amp;title=Antimicrobial%20resistance" class="menu-header">Antimicrobial resistance</a>                              </li>
                                                                     <li>
-                <a href="/web/20211105212204/https://www.health.govt.nz/our-work/populations/asian-and-migrant-health?mega=Our%20work&amp;title=Asian%20and%20migrant%20health" class="menu-header">Asian and migrant health</a>                              </li>
+                <a href="/web/20211104203147/https://www.health.govt.nz/our-work/populations/asian-and-migrant-health?mega=Our%20work&amp;title=Asian%20and%20migrant%20health" class="menu-header">Asian and migrant health</a>                              </li>
                                                                     <li>
-                <a href="/web/20211105212204/https://www.health.govt.nz/our-work/border-health?mega=Our%20work&amp;title=Border%20health" class="menu-header">Border health</a>                              </li>
+                <a href="/web/20211104203147/https://www.health.govt.nz/our-work/border-health?mega=Our%20work&amp;title=Border%20health" class="menu-header">Border health</a>                              </li>
                                                                     <li>
-                <a href="/web/20211105212204/https://www.health.govt.nz/our-work/life-stages/breastfeeding?mega=Our%20work&amp;title=Breastfeeding" class="menu-header">Breastfeeding</a>                              </li>
+                <a href="/web/20211104203147/https://www.health.govt.nz/our-work/life-stages/breastfeeding?mega=Our%20work&amp;title=Breastfeeding" class="menu-header">Breastfeeding</a>                              </li>
                                                                     <li>
-                <a href="/web/20211105212204/https://www.health.govt.nz/our-work/diseases-and-conditions/cancer?mega=Our%20work&amp;title=Cancer" class="menu-header">Cancer</a>                              </li>
+                <a href="/web/20211104203147/https://www.health.govt.nz/our-work/diseases-and-conditions/cancer?mega=Our%20work&amp;title=Cancer" class="menu-header">Cancer</a>                              </li>
                                                                     <li>
-                <a href="/web/20211105212204/https://www.health.govt.nz/our-work/regulation-health-and-disability-system/certification-health-care-services?mega=Our%20work&amp;title=Certification%20of%20health%20care%20services" class="menu-header">Certification of health care services</a>                              </li>
+                <a href="/web/20211104203147/https://www.health.govt.nz/our-work/regulation-health-and-disability-system/certification-health-care-services?mega=Our%20work&amp;title=Certification%20of%20health%20care%20services" class="menu-header">Certification of health care services</a>                              </li>
                                                                     <li>
-                <a href="/web/20211105212204/https://www.health.govt.nz/our-work/life-stages/child-health?mega=Our%20work&amp;title=Child%20health" class="menu-header">Child health</a>                              </li>
+                <a href="/web/20211104203147/https://www.health.govt.nz/our-work/life-stages/child-health?mega=Our%20work&amp;title=Child%20health" class="menu-header">Child health</a>                              </li>
                                                                     <li>
-                <a href="/web/20211105212204/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus?mega=Our%20work&amp;title=COVID-19" class="menu-header">COVID-19 (novel coronavirus)</a>                              </li>
+                <a href="/web/20211104203147/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus?mega=Our%20work&amp;title=COVID-19" class="menu-header">COVID-19 (novel coronavirus)</a>                              </li>
                                                                     <li>
-                <a href="/web/20211105212204/https://www.health.govt.nz/our-work/diseases-and-conditions/diabetes?mega=Our%20work&amp;title=Diabetes" class="menu-header">Diabetes</a>                              </li>
+                <a href="/web/20211104203147/https://www.health.govt.nz/our-work/diseases-and-conditions/diabetes?mega=Our%20work&amp;title=Diabetes" class="menu-header">Diabetes</a>                              </li>
                                                                     <li>
-                <a href="/web/20211105212204/https://www.health.govt.nz/our-work/digital-health?mega=Our%20work&amp;title=Digital%20health" class="menu-header">Digital health</a>                              </li>
+                <a href="/web/20211104203147/https://www.health.govt.nz/our-work/digital-health?mega=Our%20work&amp;title=Digital%20health" class="menu-header">Digital health</a>                              </li>
                                                                     <li>
-                <a href="/web/20211105212204/https://www.health.govt.nz/our-work/disability-services?mega=Our%20work&amp;title=Disability%20services" class="menu-header">Disability services</a>                              </li>
+                <a href="/web/20211104203147/https://www.health.govt.nz/our-work/disability-services?mega=Our%20work&amp;title=Disability%20services" class="menu-header">Disability services</a>                              </li>
                                                                 </ul>
                             <ul class="col list-unstyled no-menu-header">
                                                                                 <li>
-                <a href="/web/20211105212204/https://www.health.govt.nz/our-work/diseases-and-conditions?mega=Our%20work&amp;title=Diseases%20and%20conditions" class="menu-header">Diseases and conditions</a>                              </li>
+                <a href="/web/20211104203147/https://www.health.govt.nz/our-work/diseases-and-conditions?mega=Our%20work&amp;title=Diseases%20and%20conditions" class="menu-header">Diseases and conditions</a>                              </li>
                                                                     <li>
-                <a href="/web/20211105212204/https://www.health.govt.nz/our-work/hospitals-and-specialist-care/emergency-departments?mega=Our%20work&amp;title=Emergency%20departments" class="menu-header">Emergency departments</a>                              </li>
+                <a href="/web/20211104203147/https://www.health.govt.nz/our-work/hospitals-and-specialist-care/emergency-departments?mega=Our%20work&amp;title=Emergency%20departments" class="menu-header">Emergency departments</a>                              </li>
                                                                     <li>
-                <a href="/web/20211105212204/https://www.health.govt.nz/our-work/emergency-management?mega=Our%20work&amp;title=Emergency%20management" class="menu-header">Emergency management</a>                              </li>
+                <a href="/web/20211104203147/https://www.health.govt.nz/our-work/emergency-management?mega=Our%20work&amp;title=Emergency%20management" class="menu-header">Emergency management</a>                              </li>
                                                                     <li>
-                <a href="/web/20211105212204/https://www.health.govt.nz/our-work/environmental-health?mega=Our%20work&amp;title=Environmental%20health" class="menu-header">Environmental health</a>                              </li>
+                <a href="/web/20211104203147/https://www.health.govt.nz/our-work/environmental-health?mega=Our%20work&amp;title=Environmental%20health" class="menu-header">Environmental health</a>                              </li>
                                                                     <li>
-                <a href="/web/20211105212204/https://www.health.govt.nz/our-work/preventative-health-wellness/family-violence?mega=Our%20work&amp;title=Family%20violence" class="menu-header">Family violence</a>                              </li>
+                <a href="/web/20211104203147/https://www.health.govt.nz/our-work/preventative-health-wellness/family-violence?mega=Our%20work&amp;title=Family%20violence" class="menu-header">Family violence</a>                              </li>
                                                                     <li>
-                <a href="/web/20211105212204/https://www.health.govt.nz/our-work/preventative-health-wellness/fluoride-and-oral-health?mega=Our%20work&amp;title=Fluoride%20and%20oral%20health" class="menu-header">Fluoride and oral health</a>                              </li>
+                <a href="/web/20211104203147/https://www.health.govt.nz/our-work/preventative-health-wellness/fluoride-and-oral-health?mega=Our%20work&amp;title=Fluoride%20and%20oral%20health" class="menu-header">Fluoride and oral health</a>                              </li>
                                                                     <li>
-                <a href="/web/20211105212204/https://www.health.govt.nz/our-work/health-identity?mega=Our%20work&amp;title=Health%20identity" class="menu-header">Health identity</a>                              </li>
+                <a href="/web/20211104203147/https://www.health.govt.nz/our-work/health-identity?mega=Our%20work&amp;title=Health%20identity" class="menu-header">Health identity</a>                              </li>
                                                                     <li>
-                <a href="/web/20211105212204/https://www.health.govt.nz/our-work/digital-health/digital-health-sector-architecture-standards-and-governance/health-information-standards-0?mega=Our%20work&amp;title=Health%20information%20standards" class="menu-header">Health information standards</a>                              </li>
+                <a href="/web/20211104203147/https://www.health.govt.nz/our-work/digital-health/digital-health-sector-architecture-standards-and-governance/health-information-standards-0?mega=Our%20work&amp;title=Health%20information%20standards" class="menu-header">Health information standards</a>                              </li>
                                                                     <li>
-                <a href="/web/20211105212204/https://www.health.govt.nz/our-work/health-infrastructure-unit-hiu?mega=Our%20work&amp;title=Health%20Infrastructure%20Unit" class="menu-header">Health Infrastructure Unit</a>                              </li>
+                <a href="/web/20211104203147/https://www.health.govt.nz/our-work/health-infrastructure-unit-hiu?mega=Our%20work&amp;title=Health%20Infrastructure%20Unit" class="menu-header">Health Infrastructure Unit</a>                              </li>
                                                                     <li>
-                <a href="/web/20211105212204/https://www.health.govt.nz/our-work/life-stages/health-older-people?mega=Our%20work&amp;title=Health%20of%20older%20people" class="menu-header">Health of older people</a>                              </li>
+                <a href="/web/20211104203147/https://www.health.govt.nz/our-work/life-stages/health-older-people?mega=Our%20work&amp;title=Health%20of%20older%20people" class="menu-header">Health of older people</a>                              </li>
                                                                     <li>
-                <a href="/web/20211105212204/https://www.health.govt.nz/our-work/health-workforce?mega=Our%20work&amp;title=Health%20workforce" class="menu-header">Health workforce</a>                              </li>
+                <a href="/web/20211104203147/https://www.health.govt.nz/our-work/health-workforce?mega=Our%20work&amp;title=Health%20workforce" class="menu-header">Health workforce</a>                              </li>
                                                                     <li>
-                <a href="/web/20211105212204/https://www.health.govt.nz/our-work/hospitals-and-specialist-care?mega=Our%20work&amp;title=Hospitals%20and%20specialist%20care" class="menu-header">Hospitals and specialist care</a>                              </li>
+                <a href="/web/20211104203147/https://www.health.govt.nz/our-work/hospitals-and-specialist-care?mega=Our%20work&amp;title=Hospitals%20and%20specialist%20care" class="menu-header">Hospitals and specialist care</a>                              </li>
                                                                 </ul>
                             <ul class="col list-unstyled no-menu-header">
                                                                                 <li>
-                <a href="/web/20211105212204/https://www.health.govt.nz/our-work/preventative-health-wellness/immunisation?mega=Our%20work&amp;title=Immunisation" class="menu-header">Immunisation</a>                              </li>
+                <a href="/web/20211104203147/https://www.health.govt.nz/our-work/preventative-health-wellness/immunisation?mega=Our%20work&amp;title=Immunisation" class="menu-header">Immunisation</a>                              </li>
                                                                     <li>
-                <a href="/web/20211105212204/https://www.health.govt.nz/our-work/ionising-radiation-safety?mega=Our%20work&amp;title=Ionising%20radiation%20safety" class="menu-header">Ionising radiation safety</a>                              </li>
+                <a href="/web/20211104203147/https://www.health.govt.nz/our-work/ionising-radiation-safety?mega=Our%20work&amp;title=Ionising%20radiation%20safety" class="menu-header">Ionising radiation safety</a>                              </li>
                                                                     <li>
-                <a href="/web/20211105212204/https://www.health.govt.nz/our-work/populations/maori-health?mega=Our%20work&amp;title=M%C4%81ori%20health" class="menu-header">Māori health</a>                              </li>
+                <a href="/web/20211104203147/https://www.health.govt.nz/our-work/populations/maori-health?mega=Our%20work&amp;title=M%C4%81ori%20health" class="menu-header">Māori health</a>                              </li>
                                                                     <li>
-                <a href="/web/20211105212204/https://www.health.govt.nz/our-work/life-stages/maternity-services?mega=Our%20work&amp;title=Maternity" class="menu-header">Maternity</a>                              </li>
+                <a href="/web/20211104203147/https://www.health.govt.nz/our-work/life-stages/maternity-services?mega=Our%20work&amp;title=Maternity" class="menu-header">Maternity</a>                              </li>
                                                                     <li>
-                <a href="/web/20211105212204/https://www.health.govt.nz/our-work/regulation-health-and-disability-system/medicinal-cannabis-agency?mega=Our%20work&amp;title=Medicinal%20Cannabis%20Agency" class="menu-header">Medicinal cannabis</a>                              </li>
+                <a href="/web/20211104203147/https://www.health.govt.nz/our-work/regulation-health-and-disability-system/medicinal-cannabis-agency?mega=Our%20work&amp;title=Medicinal%20Cannabis%20Agency" class="menu-header">Medicinal cannabis</a>                              </li>
                                                                     <li>
-                <a href="/web/20211105212204/https://www.health.govt.nz/our-work/regulation-health-and-disability-system/medicines-control?mega=Our%20work&amp;title=Medicines%20control" class="menu-header">Medicines control</a>                              </li>
+                <a href="/web/20211104203147/https://www.health.govt.nz/our-work/regulation-health-and-disability-system/medicines-control?mega=Our%20work&amp;title=Medicines%20control" class="menu-header">Medicines control</a>                              </li>
                                                                     <li>
-                <a href="/web/20211105212204/https://www.health.govt.nz/our-work/mental-health-and-addiction?mega=Our%20work&amp;title=Mental%20health%20and%20addiction" class="menu-header">Mental health and addiction</a>                              </li>
+                <a href="/web/20211104203147/https://www.health.govt.nz/our-work/mental-health-and-addiction?mega=Our%20work&amp;title=Mental%20health%20and%20addiction" class="menu-header">Mental health and addiction</a>                              </li>
                                                                     <li>
-                <a href="/web/20211105212204/https://www.health.govt.nz/our-work/nursing?mega=Our%20work&amp;title=Nursing" class="menu-header">Nursing</a>                              </li>
+                <a href="/web/20211104203147/https://www.health.govt.nz/our-work/nursing?mega=Our%20work&amp;title=Nursing" class="menu-header">Nursing</a>                              </li>
                                                                     <li>
-                <a href="/web/20211105212204/https://www.health.govt.nz/our-work/preventative-health-wellness/nutrition?mega=Our%20work&amp;title=Nutrition" class="menu-header">Nutrition</a>                              </li>
+                <a href="/web/20211104203147/https://www.health.govt.nz/our-work/preventative-health-wellness/nutrition?mega=Our%20work&amp;title=Nutrition" class="menu-header">Nutrition</a>                              </li>
                                                                     <li>
-                <a href="/web/20211105212204/https://www.health.govt.nz/our-work/preventative-health-wellness/oral-health?mega=Our%20work&amp;title=Oral%20health" class="menu-header">Oral health</a>                              </li>
+                <a href="/web/20211104203147/https://www.health.govt.nz/our-work/preventative-health-wellness/oral-health?mega=Our%20work&amp;title=Oral%20health" class="menu-header">Oral health</a>                              </li>
                                                                     <li>
-                <a href="/web/20211105212204/https://www.health.govt.nz/our-work/hospitals-and-specialist-care/organ-donation-and-transplantation?mega=Our%20work&amp;title=Organ%20donation%20and%20transplantation" class="menu-header">Organ donation and transplantation</a>                              </li>
+                <a href="/web/20211104203147/https://www.health.govt.nz/our-work/hospitals-and-specialist-care/organ-donation-and-transplantation?mega=Our%20work&amp;title=Organ%20donation%20and%20transplantation" class="menu-header">Organ donation and transplantation</a>                              </li>
                                                                     <li>
-                <a href="/web/20211105212204/https://www.health.govt.nz/our-work/populations/pacific-health?mega=Our%20work&amp;title=Pacific%20health" class="menu-header">Pacific health</a>                              </li>
+                <a href="/web/20211104203147/https://www.health.govt.nz/our-work/populations/pacific-health?mega=Our%20work&amp;title=Pacific%20health" class="menu-header">Pacific health</a>                              </li>
                                                                 </ul>
                             <ul class="col list-unstyled no-menu-header">
                                                                                 <li>
-                <a href="/web/20211105212204/https://www.health.govt.nz/new-zealand-health-system/pay-equity-settlements?mega=Our%20work&amp;title=Pay%20equity%20settlements" class="menu-header">Pay equity</a>                              </li>
+                <a href="/web/20211104203147/https://www.health.govt.nz/new-zealand-health-system/pay-equity-settlements?mega=Our%20work&amp;title=Pay%20equity%20settlements" class="menu-header">Pay equity</a>                              </li>
                                                                     <li>
-                <a href="/web/20211105212204/https://www.health.govt.nz/our-work/preventative-health-wellness/physical-activity?mega=Our%20work&amp;title=Physical%20activity" class="menu-header">Physical activity</a>                              </li>
+                <a href="/web/20211104203147/https://www.health.govt.nz/our-work/preventative-health-wellness/physical-activity?mega=Our%20work&amp;title=Physical%20activity" class="menu-header">Physical activity</a>                              </li>
                                                                     <li>
-                <a href="/web/20211105212204/https://www.health.govt.nz/our-work/hospitals-and-specialist-care/planned-care-services?mega=Our%20work&amp;title=Planned%20Care%20services" class="menu-header">Planned Care services</a>                              </li>
+                <a href="/web/20211104203147/https://www.health.govt.nz/our-work/hospitals-and-specialist-care/planned-care-services?mega=Our%20work&amp;title=Planned%20Care%20services" class="menu-header">Planned Care services</a>                              </li>
                                                                     <li>
-                <a href="/web/20211105212204/https://www.health.govt.nz/our-work/preventative-health-wellness?mega=Our%20work&amp;title=Preventative%20health/wellness" class="menu-header">Preventative health/wellness</a>                              </li>
+                <a href="/web/20211104203147/https://www.health.govt.nz/our-work/preventative-health-wellness?mega=Our%20work&amp;title=Preventative%20health/wellness" class="menu-header">Preventative health/wellness</a>                              </li>
                                                                     <li>
-                <a href="/web/20211105212204/https://www.health.govt.nz/our-work/primary-health-care?mega=Our%20work&amp;title=Primary%20health%20care" class="menu-header">Primary health care</a>                              </li>
+                <a href="/web/20211104203147/https://www.health.govt.nz/our-work/primary-health-care?mega=Our%20work&amp;title=Primary%20health%20care" class="menu-header">Primary health care</a>                              </li>
                                                                     <li>
-                <a href="/web/20211105212204/https://www.health.govt.nz/our-work/public-health-workforce-development?mega=Our%20work&amp;title=Public%20health%20workforce%20development" class="menu-header">Public health workforce</a>                              </li>
+                <a href="/web/20211104203147/https://www.health.govt.nz/our-work/public-health-workforce-development?mega=Our%20work&amp;title=Public%20health%20workforce%20development" class="menu-header">Public health workforce</a>                              </li>
                                                                     <li>
-                <a href="/web/20211105212204/https://www.health.govt.nz/our-work/regulation-health-and-disability-system?mega=Our%20work&amp;title=Regulation" class="menu-header">Regulation</a>                              </li>
+                <a href="/web/20211104203147/https://www.health.govt.nz/our-work/regulation-health-and-disability-system?mega=Our%20work&amp;title=Regulation" class="menu-header">Regulation</a>                              </li>
                                                                     <li>
-                <a href="/web/20211105212204/https://www.health.govt.nz/our-work/preventative-health-wellness/tobacco-control?mega=Our%20work&amp;title=Tobacco%20control" class="menu-header">Tobacco control</a>                              </li>
+                <a href="/web/20211104203147/https://www.health.govt.nz/our-work/preventative-health-wellness/tobacco-control?mega=Our%20work&amp;title=Tobacco%20control" class="menu-header">Tobacco control</a>                              </li>
                                                                     <li>
-                <a href="/web/20211105212204/https://www.health.govt.nz/our-work/regulation-health-and-disability-system/regulation-vaping-and-smokeless-tobacco-products?mega=Our%20work&amp;title=Vaping%20and%20smokeless%20tobacco%20products" class="menu-header">Vaping &amp; smokeless tobacco</a>                              </li>
+                <a href="/web/20211104203147/https://www.health.govt.nz/our-work/regulation-health-and-disability-system/regulation-vaping-and-smokeless-tobacco-products?mega=Our%20work&amp;title=Vaping%20and%20smokeless%20tobacco%20products" class="menu-header">Vaping &amp; smokeless tobacco</a>                              </li>
                                                                     <li>
-                <a href="/web/20211105212204/https://www.health.govt.nz/our-work/who-code-nz?mega=Our%20work&amp;title=WHO%20Code%20in%20NZ" class="menu-header">WHO Code in NZ</a>                              </li>
+                <a href="/web/20211104203147/https://www.health.govt.nz/our-work/who-code-nz?mega=Our%20work&amp;title=WHO%20Code%20in%20NZ" class="menu-header">WHO Code in NZ</a>                              </li>
                                                                     <li>
-                <a href="/web/20211105212204/https://www.health.govt.nz/our-work/life-stages/youth-health?mega=Our%20work&amp;title=Youth%20health" class="menu-header">Youth health</a>                              </li>
+                <a href="/web/20211104203147/https://www.health.govt.nz/our-work/life-stages/youth-health?mega=Our%20work&amp;title=Youth%20health" class="menu-header">Youth health</a>                              </li>
                       </ul>
               </div>
     </div>
     <div class="feature-links">
-      <a href="/web/20211105212204/https://www.health.govt.nz/our-work?mega=Our%20work&amp;title=A-Z">View the full A-Z</a>    </div>
+      <a href="/web/20211104203147/https://www.health.govt.nz/our-work?mega=Our%20work&amp;title=A-Z">View the full A-Z</a>    </div>
   </div>
 </li>
-<li class="dropdown"><a href="/web/20211105212204/https://www.health.govt.nz/nz-health-statistics" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="megamenu-dropdown-778">Health statistics <b class="caret"></b></a>
+<li class="dropdown"><a href="/web/20211104203147/https://www.health.govt.nz/nz-health-statistics" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="megamenu-dropdown-778">Health statistics <b class="caret"></b></a>
     <div id="megamenu-dropdown-778" class="dropdown-menu">
     <div class="yamm-content">
       <div class="row">
                             <div class="col">
-            <h3><a href="/web/20211105212204/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets?mega=Health%20statistics&amp;title=Health%20statistics%20and%20data%20sets" class="menu-header">Statistics by topic</a></h3>
+            <h3><a href="/web/20211104203147/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets?mega=Health%20statistics&amp;title=Health%20statistics%20and%20data%20sets" class="menu-header">Statistics by topic</a></h3>
             <ul class="list-unstyled">
-                                                <li><a href="/web/20211105212204/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/cancer-data-and-stats?mega=Health%20statistics&amp;title=Cancer">Cancer</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/diabetes-data-and-stats?mega=Health%20statistics&amp;title=Diabetes">Diabetes</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/mental-health-data-and-stats?mega=Health%20statistics&amp;title=Mental%20health">Mental health</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/maori-health-data-and-stats?mega=Health%20statistics&amp;title=M%C4%81ori%20health">Māori health</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/obesity-statistics?mega=Health%20statistics&amp;title=Obesity">Obesity</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/suicide-data-and-stats?mega=Health%20statistics&amp;title=Suicide">Suicide</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/tobacco-data-and-stats?mega=Health%20statistics&amp;title=Tobacco">Tobacco</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets?mega=Health%20statistics&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                                <li><a href="/web/20211104203147/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/cancer-data-and-stats?mega=Health%20statistics&amp;title=Cancer">Cancer</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/diabetes-data-and-stats?mega=Health%20statistics&amp;title=Diabetes">Diabetes</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/mental-health-data-and-stats?mega=Health%20statistics&amp;title=Mental%20health">Mental health</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/maori-health-data-and-stats?mega=Health%20statistics&amp;title=M%C4%81ori%20health">Māori health</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/obesity-statistics?mega=Health%20statistics&amp;title=Obesity">Obesity</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/suicide-data-and-stats?mega=Health%20statistics&amp;title=Suicide">Suicide</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/tobacco-data-and-stats?mega=Health%20statistics&amp;title=Tobacco">Tobacco</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets?mega=Health%20statistics&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
                                           </ul>
           </div>
                                       <div class="col">
-            <h3><a href="/web/20211105212204/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys?mega=Health%20statistics&amp;title=National%20collections%20and%20surveys" class="menu-header">About our surveys &amp; data collections</a></h3>
+            <h3><a href="/web/20211104203147/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys?mega=Health%20statistics&amp;title=National%20collections%20and%20surveys" class="menu-header">About our surveys &amp; data collections</a></h3>
             <ul class="list-unstyled">
-                                                <li><a href="/web/20211105212204/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/surveys/past-surveys/alcohol-and-drug-use-survey?mega=Health%20statistics&amp;title=Alcohol%20%26%20Drug%20Use%20Survey">Alcohol &amp; Drug Use Survey</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/national-collections-annual-maintenance-project?mega=Health%20statistics&amp;title=NCAMP">NCAMP</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/collections/new-zealand-cancer-registry-nzcr?mega=Health%20statistics&amp;title=NZ%20Cancer%20Registry">NZ Cancer Registry</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/surveys/new-zealand-health-survey?mega=Health%20statistics&amp;title=NZ%20Health%20Survey">NZ Health Survey</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/surveys/past-surveys/nutrition-survey?mega=Health%20statistics&amp;title=Nutrition%20Survey">Nutrition Survey</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/collections/primhd-mental-health-data?mega=Health%20statistics&amp;title=PRIMHD">PRIMHD</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys?mega=Health%20statistics&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                                <li><a href="/web/20211104203147/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/surveys/past-surveys/alcohol-and-drug-use-survey?mega=Health%20statistics&amp;title=Alcohol%20%26%20Drug%20Use%20Survey">Alcohol &amp; Drug Use Survey</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/national-collections-annual-maintenance-project?mega=Health%20statistics&amp;title=NCAMP">NCAMP</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/collections/new-zealand-cancer-registry-nzcr?mega=Health%20statistics&amp;title=NZ%20Cancer%20Registry">NZ Cancer Registry</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/surveys/new-zealand-health-survey?mega=Health%20statistics&amp;title=NZ%20Health%20Survey">NZ Health Survey</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/surveys/past-surveys/nutrition-survey?mega=Health%20statistics&amp;title=Nutrition%20Survey">Nutrition Survey</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys/collections/primhd-mental-health-data?mega=Health%20statistics&amp;title=PRIMHD">PRIMHD</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/nz-health-statistics/national-collections-and-surveys?mega=Health%20statistics&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
                                           </ul>
           </div>
                                       <div class="col">
-            <h3><a href="/web/20211105212204/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology?mega=Health%20statistics&amp;title=Classification%20and%20Terminology" class="menu-header">Classification &amp; terminology</a></h3>
+            <h3><a href="/web/20211104203147/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology?mega=Health%20statistics&amp;title=Classification%20and%20Terminology" class="menu-header">Classification &amp; terminology</a></h3>
             <ul class="list-unstyled">
-                                                <li><a href="/web/20211105212204/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology/using-icd-10-am-achi-acs/coding-queries/coding-query-database?mega=Health%20statistics&amp;title=Coding%20query%20database">Coding query database</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology/using-icd-10-am-achi-acs/courses-clinical-coding?mega=Health%20statistics&amp;title=Courses%20on%20clinical%20coding">Courses on clinical coding</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology/new-zealand-snomed-ct-national-release-centre?mega=Health%20statistics&amp;title=SNOMED%20CT">SNOMED CT</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology/using-icd-10-am-achi-acs?mega=Health%20statistics&amp;title=Using%20ICD-10-AM/ACHI/ACS">Using ICD-10-AM/ACHI/ACS</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology?mega=Health%20statistics&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                                <li><a href="/web/20211104203147/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology/using-icd-10-am-achi-acs/coding-queries/coding-query-database?mega=Health%20statistics&amp;title=Coding%20query%20database">Coding query database</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology/using-icd-10-am-achi-acs/courses-clinical-coding?mega=Health%20statistics&amp;title=Courses%20on%20clinical%20coding">Courses on clinical coding</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology/new-zealand-snomed-ct-national-release-centre?mega=Health%20statistics&amp;title=SNOMED%20CT">SNOMED CT</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology/using-icd-10-am-achi-acs?mega=Health%20statistics&amp;title=Using%20ICD-10-AM/ACHI/ACS">Using ICD-10-AM/ACHI/ACS</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/nz-health-statistics/classification-and-terminology?mega=Health%20statistics&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
                                           </ul>
           </div>
                                       <div class="col">
-            <h3><a href="/web/20211105212204/https://www.health.govt.nz/nz-health-statistics/data-references?mega=Health%20statistics&amp;title=Data%20references" class="menu-header">Data references</a></h3>
+            <h3><a href="/web/20211104203147/https://www.health.govt.nz/nz-health-statistics/data-references?mega=Health%20statistics&amp;title=Data%20references" class="menu-header">Data references</a></h3>
             <ul class="list-unstyled">
-                                                <li><a href="/web/20211105212204/https://www.health.govt.nz/nz-health-statistics/data-references/code-tables?mega=Health%20statistics&amp;title=Code%20tables">Code tables</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/nz-health-statistics/data-references/data-dictionaries?mega=Health%20statistics&amp;title=Data%20dictionaries">Data dictionaries</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/nz-health-statistics/data-references/diagnosis-related-groups?mega=Health%20statistics&amp;title=Diagnosis-related%20groups">Diagnosis-related groups</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/nz-health-statistics/data-references/code-tables/common-code-tables/domicile-code-table?mega=Health%20statistics&amp;title=Domicile%20code%20table">Domicile code table</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/nz-health-statistics/data-references/mapping-tools?mega=Health%20statistics&amp;title=ICD%20mapping%20tools">ICD mapping tools</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/nz-health-statistics/data-references/weighted-inlier-equivalent-separations?mega=Health%20statistics&amp;title=Weighted%20Inlier%20Equivalent%20Separations">Weighted Inlier Equivalent Separations</a></li>
-                                  <li><a href="/web/20211105212204/https://www.health.govt.nz/nz-health-statistics/data-references?mega=Health%20statistics&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
+                                                <li><a href="/web/20211104203147/https://www.health.govt.nz/nz-health-statistics/data-references/code-tables?mega=Health%20statistics&amp;title=Code%20tables">Code tables</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/nz-health-statistics/data-references/data-dictionaries?mega=Health%20statistics&amp;title=Data%20dictionaries">Data dictionaries</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/nz-health-statistics/data-references/diagnosis-related-groups?mega=Health%20statistics&amp;title=Diagnosis-related%20groups">Diagnosis-related groups</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/nz-health-statistics/data-references/code-tables/common-code-tables/domicile-code-table?mega=Health%20statistics&amp;title=Domicile%20code%20table">Domicile code table</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/nz-health-statistics/data-references/mapping-tools?mega=Health%20statistics&amp;title=ICD%20mapping%20tools">ICD mapping tools</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/nz-health-statistics/data-references/weighted-inlier-equivalent-separations?mega=Health%20statistics&amp;title=Weighted%20Inlier%20Equivalent%20Separations">Weighted Inlier Equivalent Separations</a></li>
+                                  <li><a href="/web/20211104203147/https://www.health.govt.nz/nz-health-statistics/data-references?mega=Health%20statistics&amp;title=See%20all" class="view-more"><span>See all</span></a></li>
                                           </ul>
           </div>
                         </div>
     </div>
     <div class="feature-links">
       <h3 class="sr-only">Other related resources</h3>
-      <a href="/web/20211105212204/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/tier-1-health-statistics-release-calendar?mega=Health%20statistics&amp;title=Tier%201%20calendar">Release calendar for our Tier 1 statistics</a> <a href="/web/20211105212204/https://www.health.govt.nz/nz-health-statistics/about-data-collection?mega=Health%20statistics&amp;title=Enquiries">Data and survey enquiries</a>    </div>
+      <a href="/web/20211104203147/https://www.health.govt.nz/nz-health-statistics/health-statistics-and-data-sets/tier-1-health-statistics-release-calendar?mega=Health%20statistics&amp;title=Tier%201%20calendar">Release calendar for our Tier 1 statistics</a> <a href="/web/20211104203147/https://www.health.govt.nz/nz-health-statistics/about-data-collection?mega=Health%20statistics&amp;title=Enquiries">Data and survey enquiries</a>    </div>
   </div>
 </li>
-<li class=""><a href="/web/20211105212204/https://www.health.govt.nz/publications" aria-haspopup="false">Publications</a></li>
-<li class=""><a href="/web/20211105212204/https://www.health.govt.nz/about-ministry" aria-haspopup="false">About us</a></li>
-<li class="visible-xs"><a href="/web/20211105212204/https://www.health.govt.nz/contactus" aria-haspopup="false">Contact us</a></li>
+<li class=""><a href="/web/20211104203147/https://www.health.govt.nz/publications" aria-haspopup="false">Publications</a></li>
+<li class=""><a href="/web/20211104203147/https://www.health.govt.nz/about-ministry" aria-haspopup="false">About us</a></li>
+<li class="visible-xs"><a href="/web/20211104203147/https://www.health.govt.nz/contactus" aria-haspopup="false">Contact us</a></li>
 </ul>
                                   </nav>
         </div>
@@ -542,7 +542,7 @@ __wm.bt(650,27,25,2,"web","https://www.health.govt.nz/our-work/diseases-and-cond
       <section class="col-sm-12">
                         <a id="main-content"></a>
                                                                             <div class="breadcrumbs">
-            <ul><li><a href="/web/20211105212204/https://www.health.govt.nz/">Home</a></li><li><a href="/web/20211105212204/https://www.health.govt.nz/our-work">Our work</a></li><li><a href="/web/20211105212204/https://www.health.govt.nz/our-work/diseases-and-conditions">Diseases and conditions</a></li><li><a href="/web/20211105212204/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished" data-is-top-level="1" title="">COVID-19</a></li><li><a href="/web/20211105212204/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics" class="menu-node-unpublished menu-node-unpublished">Data and statistics</a></li><li><span class="current-breadcrumb">Vaccine data</span></li></ul>          </div>
+            <ul><li><a href="/web/20211104203147/https://www.health.govt.nz/">Home</a></li><li><a href="/web/20211104203147/https://www.health.govt.nz/our-work">Our work</a></li><li><a href="/web/20211104203147/https://www.health.govt.nz/our-work/diseases-and-conditions">Diseases and conditions</a></li><li><a href="/web/20211104203147/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished" data-is-top-level="1" title="">COVID-19</a></li><li><a href="/web/20211104203147/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics" class="menu-node-unpublished menu-node-unpublished">Data and statistics</a></li><li><span class="current-breadcrumb">Vaccine data</span></li></ul>          </div>
 
 
 
@@ -555,29 +555,29 @@ __wm.bt(650,27,25,2,"web","https://www.health.govt.nz/our-work/diseases-and-cond
       <div class="row"> <!-- @TODO: Add extra classes -->
       <div class="panel-panel left col-xs-12 col-md-3 col-lg-3"><div class="panel-pane pane-block pane-menu-block-1 odd pane-top-link">
 
-        <span class="top-link"><a href="/web/20211105212204/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished active-trail" data-is-top-level="1">COVID-19</a></span>
+        <span class="top-link"><a href="/web/20211104203147/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished active-trail" data-is-top-level="1">COVID-19</a></span>
 
 
   <div class="pane-content">
         <div class="menu-block-wrapper menu-block-1 menu-name-main-menu parent-mlid-1445 menu-level-2">
-  <ul class="menu nav"><li class="first collapsed menu-mlid-10163 health-advice depth-4"><a href="/web/20211105212204/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-health-advice-public" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished">Health advice</a></li>
-<li class="collapsed menu-mlid-10630 covid-19-vaccines- depth-4 section-overview hide-children"><a href="/web/20211105212204/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-vaccines" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished" data-is-top-level="1" title="">COVID-19 vaccines </a></li>
-<li class="collapsed menu-mlid-9997 health-professionals depth-4"><a href="/web/20211105212204/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-information-health-professionals" class="menu-node-unpublished menu-node-unpublished">Health professionals</a></li>
-<li class="collapsed menu-mlid-10019 specific-audiences depth-4"><a href="/web/20211105212204/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-information-specific-audiences" class="menu-node-unpublished">Specific audiences</a></li>
-<li class="expanded active-trail menu-mlid-10096 data-and-statistics depth-4"><a href="/web/20211105212204/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics" class="menu-node-unpublished menu-node-unpublished active-trail">Data and statistics</a><ul class="menu nav"><li class="first leaf menu-mlid-10062 current-cases depth-5 same-level-as-node"><a href="/web/20211105212204/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-current-cases" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Current cases</a></li>
-<li class="leaf menu-mlid-10146 case-demographics depth-5 same-level-as-node"><a href="/web/20211105212204/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-case-demographics">Case demographics</a></li>
-<li class="leaf menu-mlid-10097 source-of-cases depth-5 same-level-as-node"><a href="/web/20211105212204/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-source-cases" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Source of cases</a></li>
-<li class="leaf menu-mlid-10119 testing-for-covid-19 depth-5 same-level-as-node"><a href="/web/20211105212204/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/testing-covid-19" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Testing for COVID-19</a></li>
-<li class="leaf menu-mlid-10371 nz-covid-tracer-app-data depth-5 same-level-as-node"><a href="/web/20211105212204/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-nz-covid-tracer-app-data" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">NZ COVID Tracer app data</a></li>
-<li class="expanded active-trail active menu-mlid-10584 active vaccine-data depth-5 same-level-as-node"><a href="/web/20211105212204/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished active-trail active">Vaccine data</a><ul class="menu nav"><li class="first leaf menu-mlid-10867 covid-19-vaccination-uptake-rates-across-nz depth-6"><a href="/web/20211105212204/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-across-nz" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">COVID-19 Vaccination uptake rates across NZ</a></li>
-<li class="leaf menu-mlid-10868 covid-19-vaccination-uptake-rates---māori depth-6"><a href="/web/20211105212204/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-maori-communities-across-nz" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">COVID-19 Vaccination uptake rates - Māori</a></li>
-<li class="last leaf menu-mlid-10869 covid-19-vaccination-uptake-rates---pacific depth-6"><a href="/web/20211105212204/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-pacific-communities-across-nz" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">COVID-19 Vaccination uptake rates - Pacific</a></li>
+  <ul class="menu nav"><li class="first collapsed menu-mlid-10163 health-advice depth-4"><a href="/web/20211104203147/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-health-advice-public" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished">Health advice</a></li>
+<li class="collapsed menu-mlid-10630 covid-19-vaccines- depth-4 section-overview hide-children"><a href="/web/20211104203147/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-vaccines" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished" data-is-top-level="1" title="">COVID-19 vaccines </a></li>
+<li class="collapsed menu-mlid-9997 health-professionals depth-4"><a href="/web/20211104203147/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-information-health-professionals" class="menu-node-unpublished menu-node-unpublished">Health professionals</a></li>
+<li class="collapsed menu-mlid-10019 specific-audiences depth-4"><a href="/web/20211104203147/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-information-specific-audiences" class="menu-node-unpublished">Specific audiences</a></li>
+<li class="expanded active-trail menu-mlid-10096 data-and-statistics depth-4"><a href="/web/20211104203147/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics" class="menu-node-unpublished menu-node-unpublished active-trail">Data and statistics</a><ul class="menu nav"><li class="first leaf menu-mlid-10062 current-cases depth-5 same-level-as-node"><a href="/web/20211104203147/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-current-cases" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Current cases</a></li>
+<li class="leaf menu-mlid-10146 case-demographics depth-5 same-level-as-node"><a href="/web/20211104203147/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-case-demographics">Case demographics</a></li>
+<li class="leaf menu-mlid-10097 source-of-cases depth-5 same-level-as-node"><a href="/web/20211104203147/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-source-cases" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Source of cases</a></li>
+<li class="leaf menu-mlid-10119 testing-for-covid-19 depth-5 same-level-as-node"><a href="/web/20211104203147/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/testing-covid-19" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Testing for COVID-19</a></li>
+<li class="leaf menu-mlid-10371 nz-covid-tracer-app-data depth-5 same-level-as-node"><a href="/web/20211104203147/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-nz-covid-tracer-app-data" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">NZ COVID Tracer app data</a></li>
+<li class="expanded active-trail active menu-mlid-10584 active vaccine-data depth-5 same-level-as-node"><a href="/web/20211104203147/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished active-trail active">Vaccine data</a><ul class="menu nav"><li class="first leaf menu-mlid-10867 covid-19-vaccination-uptake-rates-across-nz depth-6"><a href="/web/20211104203147/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-across-nz" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">COVID-19 Vaccination uptake rates across NZ</a></li>
+<li class="leaf menu-mlid-10868 covid-19-vaccination-uptake-rates---māori depth-6"><a href="/web/20211104203147/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-maori-communities-across-nz" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">COVID-19 Vaccination uptake rates - Māori</a></li>
+<li class="last leaf menu-mlid-10869 covid-19-vaccination-uptake-rates---pacific depth-6"><a href="/web/20211104203147/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-pacific-communities-across-nz" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">COVID-19 Vaccination uptake rates - Pacific</a></li>
 </ul></li>
-<li class="last leaf menu-mlid-10404 data-resources depth-5 same-level-as-node"><a href="/web/20211105212204/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-data-resources" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Data resources</a></li>
+<li class="last leaf menu-mlid-10404 data-resources depth-5 same-level-as-node"><a href="/web/20211104203147/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-data-resources" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Data resources</a></li>
 </ul></li>
-<li class="collapsed menu-mlid-10369 response-planning depth-4"><a href="/web/20211105212204/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-response-planning" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished" data-is-top-level="1" title="">Response planning</a></li>
-<li class="collapsed menu-mlid-10015 resources-and-tools depth-4"><a href="/web/20211105212204/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-resources-and-tools" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Resources and tools</a></li>
-<li class="last leaf menu-mlid-10004 news-and-media depth-4 section-overview hide-children"><a href="/web/20211105212204/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-news-and-media-updates" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">News and media</a></li>
+<li class="collapsed menu-mlid-10369 response-planning depth-4"><a href="/web/20211104203147/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-response-planning" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished" data-is-top-level="1" title="">Response planning</a></li>
+<li class="collapsed menu-mlid-10015 resources-and-tools depth-4"><a href="/web/20211104203147/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-resources-and-tools" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Resources and tools</a></li>
+<li class="last leaf menu-mlid-10004 news-and-media depth-4 section-overview hide-children"><a href="/web/20211104203147/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-news-and-media-updates" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">News and media</a></li>
 </ul></div>
   </div>
 
@@ -633,7 +633,7 @@ __wm.bt(650,27,25,2,"web","https://www.health.govt.nz/our-work/diseases-and-cond
 <h2><a id="daily" name="daily"></a>COVID-19 vaccinations: daily updates</h2>
 
 <div class="well well-sm">
-<p style="margin-top: 0"><strong>Data in this section is as at 11:59pm 04 November 2021 and is updated daily.</strong></p>
+<p style="margin-top: 0"><strong>Data in this section is as at 11:59pm 03 November 2021 and is updated daily.</strong></p>
 </div>
 
 <h3><a id="total-vaccinations" name="total-vaccinations"></a>Total Vaccinations</h3>
@@ -653,31 +653,31 @@ __wm.bt(650,27,25,2,"web","https://www.health.govt.nz/our-work/diseases-and-cond
 	<tbody>
 		<tr>
 			<th nowrap="nowrap">First dose</th>
-			<td style="text-align:right">6,646</td>
-			<td style="text-align:right">3,738,116</td>
+			<td style="text-align:right">6,659</td>
+			<td style="text-align:right">3,731,205</td>
 			<td style="text-align:right">89%</td>
 			<td style="text-align:right">75%</td>
-			<td style="text-align:right">3,747,175</td>
+			<td style="text-align:right">3,741,140</td>
 			<td style="text-align:right">89%</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">Second dose</th>
-			<td style="text-align:right">19,412</td>
-			<td style="text-align:right">3,241,509</td>
+			<td style="text-align:right">20,340</td>
+			<td style="text-align:right">3,221,787</td>
 			<td style="text-align:right">77%</td>
-			<td style="text-align:right">65%</td>
-			<td style="text-align:right">3,413,649</td>
+			<td style="text-align:right">64%</td>
+			<td style="text-align:right">3,405,565</td>
 			<td style="text-align:right">81%</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap"><strong>Total doses</strong></th>
-			<td style="text-align:right"><strong>26,058</strong></td>
-			<td style="text-align:right"><strong>6,979,625</strong></td>
+			<td style="text-align:right"><strong>26,999</strong></td>
+			<td style="text-align:right"><strong>6,952,992</strong></td>
 		</tr>
 	</tbody>
 </table>
 
-<figure class="image-captioned img-responsive"><img 761="" alt="Total vaccinations" class="img-responsive" height="253" src="/web/20211105212204im_/https://www.health.govt.nz/sites/default/files/images/uptake_summary_9.png" width="1500"/></figure>
+<figure class="image-captioned img-responsive"><img 761="" alt="Total vaccinations" class="img-responsive" height="900" src="/web/20211104203147im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_summary_15_0.png" width="5340"/></figure>
 
 <h5>Definitions</h5>
 
@@ -709,50 +709,50 @@ __wm.bt(650,27,25,2,"web","https://www.health.govt.nz/our-work/diseases-and-cond
 	<tbody>
 		<tr>
 			<th nowrap="nowrap">Māori</th>
-			<td style="text-align:right">419,075</td>
-			<td style="text-align:right">734</td>
-			<td style="text-align:right">314,484</td>
-			<td style="text-align:right">551</td>
+			<td style="text-align:right">416,945</td>
+			<td style="text-align:right">730</td>
+			<td style="text-align:right">310,950</td>
+			<td style="text-align:right">545</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">Pacific Peoples</th>
-			<td style="text-align:right">246,526</td>
-			<td style="text-align:right">860</td>
-			<td style="text-align:right">202,434</td>
-			<td style="text-align:right">706</td>
+			<td style="text-align:right">245,915</td>
+			<td style="text-align:right">858</td>
+			<td style="text-align:right">201,191</td>
+			<td style="text-align:right">702</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">Asian</th>
-			<td style="text-align:right">610,131</td>
+			<td style="text-align:right">609,620</td>
 			<td style="text-align:right">&gt;950</td>
-			<td style="text-align:right">553,361</td>
-			<td style="text-align:right">924</td>
+			<td style="text-align:right">551,111</td>
+			<td style="text-align:right">921</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">European / Other</th>
-			<td style="text-align:right">2,428,235</td>
-			<td style="text-align:right">889</td>
-			<td style="text-align:right">2,141,973</td>
-			<td style="text-align:right">784</td>
+			<td style="text-align:right">2,424,608</td>
+			<td style="text-align:right">888</td>
+			<td style="text-align:right">2,129,445</td>
+			<td style="text-align:right">780</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">Unknown</th>
-			<td style="text-align:right">34,149</td>
+			<td style="text-align:right">34,117</td>
 			<td style="text-align:right">-</td>
-			<td style="text-align:right">29,257</td>
+			<td style="text-align:right">29,090</td>
 			<td style="text-align:right">-</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap"><strong>Total</strong></th>
-			<td style="text-align:right"><strong>3,738,116</strong></td>
-			<td style="text-align:right"><strong>888</strong></td>
-			<td style="text-align:right"><strong>3,241,509</strong></td>
-			<td style="text-align:right"><strong>770</strong></td>
+			<td style="text-align:right"><strong>3,731,205</strong></td>
+			<td style="text-align:right"><strong>886</strong></td>
+			<td style="text-align:right"><strong>3,221,787</strong></td>
+			<td style="text-align:right"><strong>765</strong></td>
 		</tr>
 	</tbody>
 </table>
 
-<p><strong>*</strong> The prioritised ethnicity classification system allocates each person to a single ethnic group, based on the ethnic groups they identify with. Where people identify with more than one group, they are assigned in this order of priority: Māori, Pacific Peoples, Asian, and European/Other. So, if a person identifies as being Māori and New Zealand European, the person is counted as Māori. See <a href="/web/20211105212204/https://www.health.govt.nz/publication/hiso-100012017-ethnicity-data-protocols">Ethnicity Data Protocols</a> for further information.</p>
+<p><strong>*</strong> The prioritised ethnicity classification system allocates each person to a single ethnic group, based on the ethnic groups they identify with. Where people identify with more than one group, they are assigned in this order of priority: Māori, Pacific Peoples, Asian, and European/Other. So, if a person identifies as being Māori and New Zealand European, the person is counted as Māori. See <a href="/web/20211104203147/https://www.health.govt.nz/publication/hiso-100012017-ethnicity-data-protocols">Ethnicity Data Protocols</a> for further information.</p>
 
 <p>Ethnicity breakdown by DHB of residence is available in the downloadable spreadsheet at the bottom of the page.</p>
 
@@ -777,222 +777,222 @@ __wm.bt(650,27,25,2,"web","https://www.health.govt.nz/our-work/diseases-and-cond
 	<tbody>
 		<tr>
 			<th nowrap="nowrap">Northland</th>
-			<td style="text-align:right">129,508</td>
+			<td style="text-align:right">129,027</td>
 			<td style="text-align:right">80%</td>
-			<td style="text-align:right">15,680</td>
-			<td style="text-align:right">107,760</td>
-			<td style="text-align:right">67%</td>
-			<td style="text-align:right">37,428</td>
+			<td style="text-align:right">16,161</td>
+			<td style="text-align:right">106,740</td>
+			<td style="text-align:right">66%</td>
+			<td style="text-align:right">38,448</td>
 			<td style="text-align:right">161,320</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">Waitemata</th>
-			<td style="text-align:right">482,323</td>
+			<td style="text-align:right">481,759</td>
 			<td style="text-align:right">92%</td>
 			<td style="text-align:right">0</td>
-			<td style="text-align:right">432,382</td>
+			<td style="text-align:right">430,497</td>
 			<td style="text-align:right">82%</td>
-			<td style="text-align:right">41,096</td>
+			<td style="text-align:right">42,981</td>
 			<td style="text-align:right">526,087</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">Auckland</th>
-			<td style="text-align:right">400,119</td>
+			<td style="text-align:right">399,755</td>
 			<td style="text-align:right">94%</td>
 			<td style="text-align:right">0</td>
-			<td style="text-align:right">364,481</td>
+			<td style="text-align:right">363,131</td>
 			<td style="text-align:right">86%</td>
-			<td style="text-align:right">17,081</td>
+			<td style="text-align:right">18,431</td>
 			<td style="text-align:right">423,958</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">Counties Manukau</th>
-			<td style="text-align:right">432,521</td>
-			<td style="text-align:right">90%</td>
-			<td style="text-align:right">1,975</td>
-			<td style="text-align:right">380,135</td>
-			<td style="text-align:right">79%</td>
-			<td style="text-align:right">54,361</td>
+			<td style="text-align:right">431,883</td>
+			<td style="text-align:right">89%</td>
+			<td style="text-align:right">2,613</td>
+			<td style="text-align:right">378,471</td>
+			<td style="text-align:right">78%</td>
+			<td style="text-align:right">56,025</td>
 			<td style="text-align:right">482,773</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">Waikato</th>
-			<td style="text-align:right">312,617</td>
-			<td style="text-align:right">88%</td>
-			<td style="text-align:right">8,841</td>
-			<td style="text-align:right">266,000</td>
+			<td style="text-align:right">311,897</td>
+			<td style="text-align:right">87%</td>
+			<td style="text-align:right">9,561</td>
+			<td style="text-align:right">263,750</td>
 			<td style="text-align:right">74%</td>
-			<td style="text-align:right">55,458</td>
+			<td style="text-align:right">57,708</td>
 			<td style="text-align:right">357,176</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">Lakes</th>
-			<td style="text-align:right">77,008</td>
-			<td style="text-align:right">82%</td>
-			<td style="text-align:right">7,969</td>
-			<td style="text-align:right">63,973</td>
-			<td style="text-align:right">68%</td>
-			<td style="text-align:right">21,004</td>
+			<td style="text-align:right">76,834</td>
+			<td style="text-align:right">81%</td>
+			<td style="text-align:right">8,143</td>
+			<td style="text-align:right">63,513</td>
+			<td style="text-align:right">67%</td>
+			<td style="text-align:right">21,464</td>
 			<td style="text-align:right">94,419</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">Bay of Plenty</th>
-			<td style="text-align:right">181,957</td>
+			<td style="text-align:right">181,618</td>
 			<td style="text-align:right">84%</td>
-			<td style="text-align:right">13,290</td>
-			<td style="text-align:right">151,770</td>
+			<td style="text-align:right">13,629</td>
+			<td style="text-align:right">150,784</td>
 			<td style="text-align:right">70%</td>
-			<td style="text-align:right">43,477</td>
+			<td style="text-align:right">44,463</td>
 			<td style="text-align:right">216,941</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">Tairawhiti</th>
-			<td style="text-align:right">33,377</td>
-			<td style="text-align:right">80%</td>
-			<td style="text-align:right">4,392</td>
-			<td style="text-align:right">27,407</td>
+			<td style="text-align:right">33,228</td>
+			<td style="text-align:right">79%</td>
+			<td style="text-align:right">4,540</td>
+			<td style="text-align:right">27,229</td>
 			<td style="text-align:right">65%</td>
-			<td style="text-align:right">10,362</td>
+			<td style="text-align:right">10,540</td>
 			<td style="text-align:right">41,965</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">Taranaki</th>
-			<td style="text-align:right">86,738</td>
+			<td style="text-align:right">86,549</td>
 			<td style="text-align:right">85%</td>
-			<td style="text-align:right">5,194</td>
-			<td style="text-align:right">70,091</td>
-			<td style="text-align:right">69%</td>
-			<td style="text-align:right">21,841</td>
+			<td style="text-align:right">5,383</td>
+			<td style="text-align:right">69,391</td>
+			<td style="text-align:right">68%</td>
+			<td style="text-align:right">22,541</td>
 			<td style="text-align:right">102,147</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">Hawkes Bay</th>
-			<td style="text-align:right">124,237</td>
+			<td style="text-align:right">123,888</td>
 			<td style="text-align:right">85%</td>
-			<td style="text-align:right">6,777</td>
-			<td style="text-align:right">105,893</td>
-			<td style="text-align:right">73%</td>
-			<td style="text-align:right">25,121</td>
+			<td style="text-align:right">7,126</td>
+			<td style="text-align:right">105,279</td>
+			<td style="text-align:right">72%</td>
+			<td style="text-align:right">25,735</td>
 			<td style="text-align:right">145,571</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">MidCentral</th>
-			<td style="text-align:right">132,630</td>
+			<td style="text-align:right">132,338</td>
 			<td style="text-align:right">87%</td>
-			<td style="text-align:right">4,442</td>
-			<td style="text-align:right">112,968</td>
+			<td style="text-align:right">4,734</td>
+			<td style="text-align:right">112,336</td>
 			<td style="text-align:right">74%</td>
-			<td style="text-align:right">24,104</td>
+			<td style="text-align:right">24,736</td>
 			<td style="text-align:right">152,302</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">Whanganui</th>
-			<td style="text-align:right">46,655</td>
+			<td style="text-align:right">46,498</td>
 			<td style="text-align:right">81%</td>
-			<td style="text-align:right">4,867</td>
-			<td style="text-align:right">40,012</td>
-			<td style="text-align:right">70%</td>
-			<td style="text-align:right">11,510</td>
+			<td style="text-align:right">5,024</td>
+			<td style="text-align:right">39,670</td>
+			<td style="text-align:right">69%</td>
+			<td style="text-align:right">11,852</td>
 			<td style="text-align:right">57,247</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">Capital and Coast</th>
-			<td style="text-align:right">251,135</td>
+			<td style="text-align:right">250,856</td>
 			<td style="text-align:right">93%</td>
 			<td style="text-align:right">0</td>
-			<td style="text-align:right">223,367</td>
+			<td style="text-align:right">221,996</td>
 			<td style="text-align:right">82%</td>
-			<td style="text-align:right">20,690</td>
+			<td style="text-align:right">22,061</td>
 			<td style="text-align:right">271,174</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">Hutt Valley</th>
-			<td style="text-align:right">115,453</td>
-			<td style="text-align:right">89%</td>
-			<td style="text-align:right">1,762</td>
-			<td style="text-align:right">99,897</td>
-			<td style="text-align:right">77%</td>
-			<td style="text-align:right">17,318</td>
+			<td style="text-align:right">115,248</td>
+			<td style="text-align:right">88%</td>
+			<td style="text-align:right">1,967</td>
+			<td style="text-align:right">99,048</td>
+			<td style="text-align:right">76%</td>
+			<td style="text-align:right">18,167</td>
 			<td style="text-align:right">130,239</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">Wairarapa</th>
-			<td style="text-align:right">35,736</td>
+			<td style="text-align:right">35,683</td>
 			<td style="text-align:right">86%</td>
-			<td style="text-align:right">1,548</td>
-			<td style="text-align:right">30,671</td>
+			<td style="text-align:right">1,601</td>
+			<td style="text-align:right">30,538</td>
 			<td style="text-align:right">74%</td>
-			<td style="text-align:right">6,613</td>
+			<td style="text-align:right">6,746</td>
 			<td style="text-align:right">41,427</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">Nelson Marlborough</th>
-			<td style="text-align:right">118,751</td>
+			<td style="text-align:right">118,577</td>
 			<td style="text-align:right">87%</td>
-			<td style="text-align:right">3,418</td>
-			<td style="text-align:right">104,740</td>
+			<td style="text-align:right">3,592</td>
+			<td style="text-align:right">104,399</td>
 			<td style="text-align:right">77%</td>
-			<td style="text-align:right">17,429</td>
+			<td style="text-align:right">17,770</td>
 			<td style="text-align:right">135,743</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">West Coast</th>
-			<td style="text-align:right">23,060</td>
-			<td style="text-align:right">83%</td>
-			<td style="text-align:right">2,055</td>
-			<td style="text-align:right">19,274</td>
+			<td style="text-align:right">23,017</td>
+			<td style="text-align:right">82%</td>
+			<td style="text-align:right">2,098</td>
+			<td style="text-align:right">19,163</td>
 			<td style="text-align:right">69%</td>
-			<td style="text-align:right">5,841</td>
+			<td style="text-align:right">5,952</td>
 			<td style="text-align:right">27,906</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">Canterbury</th>
-			<td style="text-align:right">444,833</td>
+			<td style="text-align:right">443,844</td>
 			<td style="text-align:right">92%</td>
 			<td style="text-align:right">0</td>
-			<td style="text-align:right">370,400</td>
-			<td style="text-align:right">77%</td>
-			<td style="text-align:right">64,201</td>
+			<td style="text-align:right">367,016</td>
+			<td style="text-align:right">76%</td>
+			<td style="text-align:right">67,585</td>
 			<td style="text-align:right">482,890</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">South Canterbury</th>
-			<td style="text-align:right">45,975</td>
+			<td style="text-align:right">45,898</td>
 			<td style="text-align:right">87%</td>
-			<td style="text-align:right">1,351</td>
-			<td style="text-align:right">40,170</td>
+			<td style="text-align:right">1,428</td>
+			<td style="text-align:right">40,025</td>
 			<td style="text-align:right">76%</td>
-			<td style="text-align:right">7,156</td>
+			<td style="text-align:right">7,301</td>
 			<td style="text-align:right">52,584</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">Southern</th>
-			<td style="text-align:right">261,441</td>
+			<td style="text-align:right">260,752</td>
 			<td style="text-align:right">91%</td>
 			<td style="text-align:right">0</td>
-			<td style="text-align:right">228,407</td>
+			<td style="text-align:right">227,111</td>
 			<td style="text-align:right">79%</td>
-			<td style="text-align:right">30,806</td>
+			<td style="text-align:right">32,102</td>
 			<td style="text-align:right">288,015</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">Overseas / Unknown</th>
-			<td style="text-align:right">2,042</td>
+			<td style="text-align:right">2,056</td>
 			<td style="text-align:right">12%</td>
-			<td style="text-align:right">13,414</td>
-			<td style="text-align:right">1,711</td>
+			<td style="text-align:right">13,400</td>
+			<td style="text-align:right">1,700</td>
 			<td style="text-align:right">10%</td>
-			<td style="text-align:right">13,745</td>
+			<td style="text-align:right">13,756</td>
 			<td style="text-align:right">17,173</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap"><strong>Total</strong></th>
-			<td style="text-align:right"><strong>3,738,116</strong></td>
+			<td style="text-align:right"><strong>3,731,205</strong></td>
 			<td style="text-align:right"><strong>89%</strong></td>
-			<td style="text-align:right"><strong>50,035</strong></td>
-			<td style="text-align:right"><strong>3,241,509</strong></td>
+			<td style="text-align:right"><strong>56,946</strong></td>
+			<td style="text-align:right"><strong>3,221,787</strong></td>
 			<td style="text-align:right"><strong>77%</strong></td>
-			<td style="text-align:right"><strong>546,642</strong></td>
+			<td style="text-align:right"><strong>566,364</strong></td>
 			<td style="text-align:right"><strong>4,209,057</strong></td>
 		</tr>
 	</tbody>
@@ -1018,209 +1018,209 @@ __wm.bt(650,27,25,2,"web","https://www.health.govt.nz/our-work/diseases-and-cond
 	<tbody>
 		<tr>
 			<th nowrap="nowrap">Northland</th>
-			<td style="text-align:right">34,853</td>
+			<td style="text-align:right">34,596</td>
 			<td style="text-align:right">69%</td>
-			<td style="text-align:right">10,586</td>
-			<td style="text-align:right">25,311</td>
-			<td style="text-align:right">50%</td>
-			<td style="text-align:right">20,128</td>
+			<td style="text-align:right">10,843</td>
+			<td style="text-align:right">24,895</td>
+			<td style="text-align:right">49%</td>
+			<td style="text-align:right">20,544</td>
 			<td style="text-align:right">50,488</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">Waitemata</th>
-			<td style="text-align:right">33,356</td>
+			<td style="text-align:right">33,268</td>
 			<td style="text-align:right">81%</td>
-			<td style="text-align:right">3,646</td>
-			<td style="text-align:right">26,537</td>
-			<td style="text-align:right">65%</td>
-			<td style="text-align:right">10,465</td>
+			<td style="text-align:right">3,734</td>
+			<td style="text-align:right">26,317</td>
+			<td style="text-align:right">64%</td>
+			<td style="text-align:right">10,685</td>
 			<td style="text-align:right">41,113</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">Auckland</th>
-			<td style="text-align:right">23,263</td>
-			<td style="text-align:right">84%</td>
-			<td style="text-align:right">1,750</td>
-			<td style="text-align:right">18,913</td>
+			<td style="text-align:right">23,191</td>
+			<td style="text-align:right">83%</td>
+			<td style="text-align:right">1,822</td>
+			<td style="text-align:right">18,771</td>
 			<td style="text-align:right">68%</td>
-			<td style="text-align:right">6,100</td>
+			<td style="text-align:right">6,242</td>
 			<td style="text-align:right">27,792</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">Counties Manukau</th>
-			<td style="text-align:right">47,675</td>
+			<td style="text-align:right">47,494</td>
 			<td style="text-align:right">75%</td>
-			<td style="text-align:right">9,469</td>
-			<td style="text-align:right">35,628</td>
+			<td style="text-align:right">9,650</td>
+			<td style="text-align:right">35,287</td>
 			<td style="text-align:right">56%</td>
-			<td style="text-align:right">21,516</td>
+			<td style="text-align:right">21,857</td>
 			<td style="text-align:right">63,493</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">Waikato</th>
-			<td style="text-align:right">52,023</td>
-			<td style="text-align:right">75%</td>
-			<td style="text-align:right">10,713</td>
-			<td style="text-align:right">37,950</td>
+			<td style="text-align:right">51,713</td>
+			<td style="text-align:right">74%</td>
+			<td style="text-align:right">11,023</td>
+			<td style="text-align:right">37,384</td>
 			<td style="text-align:right">54%</td>
-			<td style="text-align:right">24,786</td>
+			<td style="text-align:right">25,352</td>
 			<td style="text-align:right">69,707</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">Lakes</th>
-			<td style="text-align:right">20,243</td>
+			<td style="text-align:right">20,137</td>
 			<td style="text-align:right">67%</td>
-			<td style="text-align:right">6,834</td>
-			<td style="text-align:right">14,722</td>
+			<td style="text-align:right">6,940</td>
+			<td style="text-align:right">14,592</td>
 			<td style="text-align:right">49%</td>
-			<td style="text-align:right">12,354</td>
+			<td style="text-align:right">12,484</td>
 			<td style="text-align:right">30,085</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">Bay of Plenty</th>
-			<td style="text-align:right">31,346</td>
-			<td style="text-align:right">66%</td>
-			<td style="text-align:right">11,615</td>
-			<td style="text-align:right">22,850</td>
-			<td style="text-align:right">48%</td>
-			<td style="text-align:right">20,111</td>
+			<td style="text-align:right">31,191</td>
+			<td style="text-align:right">65%</td>
+			<td style="text-align:right">11,770</td>
+			<td style="text-align:right">22,619</td>
+			<td style="text-align:right">47%</td>
+			<td style="text-align:right">20,342</td>
 			<td style="text-align:right">47,734</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">Tairawhiti</th>
-			<td style="text-align:right">13,877</td>
-			<td style="text-align:right">70%</td>
-			<td style="text-align:right">3,978</td>
-			<td style="text-align:right">10,372</td>
+			<td style="text-align:right">13,772</td>
+			<td style="text-align:right">69%</td>
+			<td style="text-align:right">4,083</td>
+			<td style="text-align:right">10,272</td>
 			<td style="text-align:right">52%</td>
-			<td style="text-align:right">7,483</td>
+			<td style="text-align:right">7,583</td>
 			<td style="text-align:right">19,839</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">Taranaki</th>
-			<td style="text-align:right">11,113</td>
-			<td style="text-align:right">70%</td>
-			<td style="text-align:right">3,201</td>
-			<td style="text-align:right">7,754</td>
-			<td style="text-align:right">49%</td>
-			<td style="text-align:right">6,560</td>
+			<td style="text-align:right">11,043</td>
+			<td style="text-align:right">69%</td>
+			<td style="text-align:right">3,271</td>
+			<td style="text-align:right">7,642</td>
+			<td style="text-align:right">48%</td>
+			<td style="text-align:right">6,672</td>
 			<td style="text-align:right">15,904</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">Hawkes Bay</th>
-			<td style="text-align:right">23,441</td>
-			<td style="text-align:right">69%</td>
-			<td style="text-align:right">7,212</td>
-			<td style="text-align:right">17,167</td>
+			<td style="text-align:right">23,280</td>
+			<td style="text-align:right">68%</td>
+			<td style="text-align:right">7,373</td>
+			<td style="text-align:right">16,980</td>
 			<td style="text-align:right">50%</td>
-			<td style="text-align:right">13,486</td>
+			<td style="text-align:right">13,673</td>
 			<td style="text-align:right">34,059</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">MidCentral</th>
-			<td style="text-align:right">17,721</td>
+			<td style="text-align:right">17,639</td>
 			<td style="text-align:right">73%</td>
-			<td style="text-align:right">4,082</td>
-			<td style="text-align:right">13,075</td>
+			<td style="text-align:right">4,164</td>
+			<td style="text-align:right">12,974</td>
 			<td style="text-align:right">54%</td>
-			<td style="text-align:right">8,728</td>
+			<td style="text-align:right">8,828</td>
 			<td style="text-align:right">24,225</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">Whanganui</th>
-			<td style="text-align:right">9,032</td>
-			<td style="text-align:right">67%</td>
-			<td style="text-align:right">3,129</td>
-			<td style="text-align:right">6,938</td>
+			<td style="text-align:right">8,970</td>
+			<td style="text-align:right">66%</td>
+			<td style="text-align:right">3,191</td>
+			<td style="text-align:right">6,826</td>
 			<td style="text-align:right">51%</td>
-			<td style="text-align:right">5,223</td>
+			<td style="text-align:right">5,335</td>
 			<td style="text-align:right">13,512</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">Capital and Coast</th>
-			<td style="text-align:right">21,826</td>
+			<td style="text-align:right">21,748</td>
 			<td style="text-align:right">81%</td>
-			<td style="text-align:right">2,444</td>
-			<td style="text-align:right">17,510</td>
-			<td style="text-align:right">65%</td>
-			<td style="text-align:right">6,760</td>
+			<td style="text-align:right">2,522</td>
+			<td style="text-align:right">17,339</td>
+			<td style="text-align:right">64%</td>
+			<td style="text-align:right">6,931</td>
 			<td style="text-align:right">26,967</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">Hutt Valley</th>
-			<td style="text-align:right">14,264</td>
-			<td style="text-align:right">75%</td>
-			<td style="text-align:right">2,947</td>
-			<td style="text-align:right">10,987</td>
+			<td style="text-align:right">14,196</td>
+			<td style="text-align:right">74%</td>
+			<td style="text-align:right">3,015</td>
+			<td style="text-align:right">10,821</td>
 			<td style="text-align:right">57%</td>
-			<td style="text-align:right">6,224</td>
+			<td style="text-align:right">6,390</td>
 			<td style="text-align:right">19,123</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">Wairarapa</th>
-			<td style="text-align:right">4,524</td>
+			<td style="text-align:right">4,506</td>
 			<td style="text-align:right">72%</td>
-			<td style="text-align:right">1,148</td>
-			<td style="text-align:right">3,285</td>
+			<td style="text-align:right">1,166</td>
+			<td style="text-align:right">3,261</td>
 			<td style="text-align:right">52%</td>
-			<td style="text-align:right">2,387</td>
+			<td style="text-align:right">2,411</td>
 			<td style="text-align:right">6,302</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">Nelson Marlborough</th>
-			<td style="text-align:right">8,104</td>
+			<td style="text-align:right">8,074</td>
 			<td style="text-align:right">72%</td>
-			<td style="text-align:right">2,019</td>
-			<td style="text-align:right">6,212</td>
+			<td style="text-align:right">2,049</td>
+			<td style="text-align:right">6,174</td>
 			<td style="text-align:right">55%</td>
-			<td style="text-align:right">3,911</td>
+			<td style="text-align:right">3,949</td>
 			<td style="text-align:right">11,248</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">West Coast</th>
-			<td style="text-align:right">2,057</td>
+			<td style="text-align:right">2,049</td>
 			<td style="text-align:right">74%</td>
-			<td style="text-align:right">432</td>
-			<td style="text-align:right">1,541</td>
-			<td style="text-align:right">56%</td>
-			<td style="text-align:right">948</td>
+			<td style="text-align:right">440</td>
+			<td style="text-align:right">1,531</td>
+			<td style="text-align:right">55%</td>
+			<td style="text-align:right">958</td>
 			<td style="text-align:right">2,765</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">Canterbury</th>
-			<td style="text-align:right">29,239</td>
+			<td style="text-align:right">29,093</td>
 			<td style="text-align:right">79%</td>
-			<td style="text-align:right">4,033</td>
-			<td style="text-align:right">21,287</td>
-			<td style="text-align:right">58%</td>
-			<td style="text-align:right">11,985</td>
+			<td style="text-align:right">4,179</td>
+			<td style="text-align:right">21,005</td>
+			<td style="text-align:right">57%</td>
+			<td style="text-align:right">12,267</td>
 			<td style="text-align:right">36,969</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">South Canterbury</th>
-			<td style="text-align:right">2,524</td>
-			<td style="text-align:right">74%</td>
-			<td style="text-align:right">561</td>
-			<td style="text-align:right">1,911</td>
-			<td style="text-align:right">56%</td>
-			<td style="text-align:right">1,174</td>
+			<td style="text-align:right">2,507</td>
+			<td style="text-align:right">73%</td>
+			<td style="text-align:right">578</td>
+			<td style="text-align:right">1,894</td>
+			<td style="text-align:right">55%</td>
+			<td style="text-align:right">1,191</td>
 			<td style="text-align:right">3,428</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">Southern</th>
-			<td style="text-align:right">18,403</td>
-			<td style="text-align:right">78%</td>
-			<td style="text-align:right">2,878</td>
-			<td style="text-align:right">14,395</td>
-			<td style="text-align:right">61%</td>
-			<td style="text-align:right">6,886</td>
+			<td style="text-align:right">18,286</td>
+			<td style="text-align:right">77%</td>
+			<td style="text-align:right">2,995</td>
+			<td style="text-align:right">14,227</td>
+			<td style="text-align:right">60%</td>
+			<td style="text-align:right">7,054</td>
 			<td style="text-align:right">23,646</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">Overseas / Unknown</th>
-			<td style="text-align:right">191</td>
+			<td style="text-align:right">192</td>
 			<td style="text-align:right">7%</td>
-			<td style="text-align:right">2,197</td>
+			<td style="text-align:right">2,196</td>
 			<td style="text-align:right">139</td>
 			<td style="text-align:right">5%</td>
 			<td style="text-align:right">2,249</td>
@@ -1228,12 +1228,12 @@ __wm.bt(650,27,25,2,"web","https://www.health.govt.nz/our-work/diseases-and-cond
 		</tr>
 		<tr>
 			<th nowrap="nowrap"><strong>Total</strong></th>
-			<td style="text-align:right"><strong>419,075</strong></td>
+			<td style="text-align:right"><strong>416,945</strong></td>
 			<td style="text-align:right"><strong>73%</strong></td>
-			<td style="text-align:right"><strong>94,872</strong></td>
-			<td style="text-align:right"><strong>314,484</strong></td>
-			<td style="text-align:right"><strong>55%</strong></td>
-			<td style="text-align:right"><strong>199,463</strong></td>
+			<td style="text-align:right"><strong>97,002</strong></td>
+			<td style="text-align:right"><strong>310,950</strong></td>
+			<td style="text-align:right"><strong>54%</strong></td>
+			<td style="text-align:right"><strong>202,997</strong></td>
 			<td style="text-align:right"><strong>571,052</strong></td>
 		</tr>
 	</tbody>
@@ -1257,160 +1257,160 @@ __wm.bt(650,27,25,2,"web","https://www.health.govt.nz/our-work/diseases-and-cond
 	<tbody>
 		<tr>
 			<th nowrap="nowrap">Northland</th>
-			<td style="text-align:right">2,418</td>
+			<td style="text-align:right">2,407</td>
 			<td style="text-align:right">82%</td>
-			<td style="text-align:right">223</td>
-			<td style="text-align:right">1,842</td>
-			<td style="text-align:right">63%</td>
-			<td style="text-align:right">799</td>
+			<td style="text-align:right">234</td>
+			<td style="text-align:right">1,818</td>
+			<td style="text-align:right">62%</td>
+			<td style="text-align:right">823</td>
 			<td style="text-align:right">2,934</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">Waitemata</th>
-			<td style="text-align:right">32,401</td>
+			<td style="text-align:right">32,332</td>
 			<td style="text-align:right">86%</td>
-			<td style="text-align:right">1,415</td>
-			<td style="text-align:right">26,854</td>
+			<td style="text-align:right">1,484</td>
+			<td style="text-align:right">26,695</td>
 			<td style="text-align:right">71%</td>
-			<td style="text-align:right">6,962</td>
+			<td style="text-align:right">7,121</td>
 			<td style="text-align:right">37,573</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">Auckland</th>
-			<td style="text-align:right">39,963</td>
+			<td style="text-align:right">39,877</td>
 			<td style="text-align:right">85%</td>
-			<td style="text-align:right">2,216</td>
-			<td style="text-align:right">33,200</td>
-			<td style="text-align:right">71%</td>
-			<td style="text-align:right">8,979</td>
+			<td style="text-align:right">2,302</td>
+			<td style="text-align:right">33,020</td>
+			<td style="text-align:right">70%</td>
+			<td style="text-align:right">9,159</td>
 			<td style="text-align:right">46,866</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">Counties Manukau</th>
-			<td style="text-align:right">98,113</td>
+			<td style="text-align:right">97,908</td>
 			<td style="text-align:right">84%</td>
-			<td style="text-align:right">6,735</td>
-			<td style="text-align:right">80,813</td>
+			<td style="text-align:right">6,940</td>
+			<td style="text-align:right">80,389</td>
 			<td style="text-align:right">69%</td>
-			<td style="text-align:right">24,035</td>
+			<td style="text-align:right">24,459</td>
 			<td style="text-align:right">116,498</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">Waikato</th>
-			<td style="text-align:right">9,272</td>
+			<td style="text-align:right">9,249</td>
 			<td style="text-align:right">87%</td>
-			<td style="text-align:right">342</td>
-			<td style="text-align:right">7,578</td>
-			<td style="text-align:right">71%</td>
-			<td style="text-align:right">2,036</td>
+			<td style="text-align:right">365</td>
+			<td style="text-align:right">7,513</td>
+			<td style="text-align:right">70%</td>
+			<td style="text-align:right">2,101</td>
 			<td style="text-align:right">10,682</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">Lakes</th>
-			<td style="text-align:right">1,848</td>
+			<td style="text-align:right">1,842</td>
 			<td style="text-align:right">81%</td>
-			<td style="text-align:right">209</td>
-			<td style="text-align:right">1,488</td>
+			<td style="text-align:right">215</td>
+			<td style="text-align:right">1,475</td>
 			<td style="text-align:right">65%</td>
-			<td style="text-align:right">569</td>
+			<td style="text-align:right">582</td>
 			<td style="text-align:right">2,286</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">Bay of Plenty</th>
-			<td style="text-align:right">4,091</td>
+			<td style="text-align:right">4,078</td>
 			<td style="text-align:right">&gt;95%</td>
 			<td style="text-align:right">0</td>
-			<td style="text-align:right">3,273</td>
-			<td style="text-align:right">89%</td>
-			<td style="text-align:right">38</td>
+			<td style="text-align:right">3,252</td>
+			<td style="text-align:right">88%</td>
+			<td style="text-align:right">59</td>
 			<td style="text-align:right">3,679</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">Tairawhiti</th>
-			<td style="text-align:right">891</td>
+			<td style="text-align:right">885</td>
 			<td style="text-align:right">92%</td>
 			<td style="text-align:right">0</td>
-			<td style="text-align:right">697</td>
-			<td style="text-align:right">72%</td>
-			<td style="text-align:right">172</td>
+			<td style="text-align:right">687</td>
+			<td style="text-align:right">71%</td>
+			<td style="text-align:right">182</td>
 			<td style="text-align:right">965</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">Taranaki</th>
-			<td style="text-align:right">1,076</td>
-			<td style="text-align:right">85%</td>
-			<td style="text-align:right">67</td>
-			<td style="text-align:right">828</td>
+			<td style="text-align:right">1,072</td>
+			<td style="text-align:right">84%</td>
+			<td style="text-align:right">71</td>
+			<td style="text-align:right">821</td>
 			<td style="text-align:right">65%</td>
-			<td style="text-align:right">315</td>
+			<td style="text-align:right">322</td>
 			<td style="text-align:right">1,270</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">Hawkes Bay</th>
-			<td style="text-align:right">5,200</td>
+			<td style="text-align:right">5,175</td>
 			<td style="text-align:right">&gt;95%</td>
 			<td style="text-align:right">0</td>
-			<td style="text-align:right">4,294</td>
-			<td style="text-align:right">86%</td>
-			<td style="text-align:right">224</td>
+			<td style="text-align:right">4,269</td>
+			<td style="text-align:right">85%</td>
+			<td style="text-align:right">249</td>
 			<td style="text-align:right">5,020</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">MidCentral</th>
-			<td style="text-align:right">3,837</td>
-			<td style="text-align:right">86%</td>
-			<td style="text-align:right">184</td>
-			<td style="text-align:right">3,029</td>
-			<td style="text-align:right">68%</td>
-			<td style="text-align:right">992</td>
+			<td style="text-align:right">3,818</td>
+			<td style="text-align:right">85%</td>
+			<td style="text-align:right">203</td>
+			<td style="text-align:right">3,000</td>
+			<td style="text-align:right">67%</td>
+			<td style="text-align:right">1,021</td>
 			<td style="text-align:right">4,468</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">Whanganui</th>
-			<td style="text-align:right">1,063</td>
+			<td style="text-align:right">1,057</td>
 			<td style="text-align:right">77%</td>
-			<td style="text-align:right">180</td>
-			<td style="text-align:right">864</td>
-			<td style="text-align:right">63%</td>
-			<td style="text-align:right">379</td>
+			<td style="text-align:right">186</td>
+			<td style="text-align:right">853</td>
+			<td style="text-align:right">62%</td>
+			<td style="text-align:right">390</td>
 			<td style="text-align:right">1,381</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">Capital and Coast</th>
-			<td style="text-align:right">15,853</td>
-			<td style="text-align:right">83%</td>
-			<td style="text-align:right">1,406</td>
-			<td style="text-align:right">13,005</td>
-			<td style="text-align:right">68%</td>
-			<td style="text-align:right">4,254</td>
+			<td style="text-align:right">15,815</td>
+			<td style="text-align:right">82%</td>
+			<td style="text-align:right">1,444</td>
+			<td style="text-align:right">12,905</td>
+			<td style="text-align:right">67%</td>
+			<td style="text-align:right">4,354</td>
 			<td style="text-align:right">19,177</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">Hutt Valley</th>
-			<td style="text-align:right">8,077</td>
-			<td style="text-align:right">82%</td>
-			<td style="text-align:right">828</td>
-			<td style="text-align:right">6,610</td>
-			<td style="text-align:right">67%</td>
-			<td style="text-align:right">2,295</td>
+			<td style="text-align:right">8,042</td>
+			<td style="text-align:right">81%</td>
+			<td style="text-align:right">863</td>
+			<td style="text-align:right">6,549</td>
+			<td style="text-align:right">66%</td>
+			<td style="text-align:right">2,356</td>
 			<td style="text-align:right">9,894</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">Wairarapa</th>
-			<td style="text-align:right">702</td>
+			<td style="text-align:right">701</td>
 			<td style="text-align:right">84%</td>
-			<td style="text-align:right">51</td>
-			<td style="text-align:right">577</td>
+			<td style="text-align:right">52</td>
+			<td style="text-align:right">576</td>
 			<td style="text-align:right">69%</td>
-			<td style="text-align:right">176</td>
+			<td style="text-align:right">177</td>
 			<td style="text-align:right">837</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">Nelson Marlborough</th>
-			<td style="text-align:right">3,652</td>
+			<td style="text-align:right">3,647</td>
 			<td style="text-align:right">&gt;95%</td>
 			<td style="text-align:right">0</td>
-			<td style="text-align:right">3,209</td>
+			<td style="text-align:right">3,201</td>
 			<td style="text-align:right">&gt;95%</td>
 			<td style="text-align:right">0</td>
 			<td style="text-align:right">2,115</td>
@@ -1420,46 +1420,46 @@ __wm.bt(650,27,25,2,"web","https://www.health.govt.nz/our-work/diseases-and-cond
 			<td style="text-align:right">235</td>
 			<td style="text-align:right">83%</td>
 			<td style="text-align:right">19</td>
-			<td style="text-align:right">185</td>
-			<td style="text-align:right">66%</td>
-			<td style="text-align:right">69</td>
+			<td style="text-align:right">184</td>
+			<td style="text-align:right">65%</td>
+			<td style="text-align:right">70</td>
 			<td style="text-align:right">282</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">Canterbury</th>
-			<td style="text-align:right">10,991</td>
+			<td style="text-align:right">10,951</td>
 			<td style="text-align:right">86%</td>
-			<td style="text-align:right">472</td>
-			<td style="text-align:right">8,467</td>
+			<td style="text-align:right">512</td>
+			<td style="text-align:right">8,392</td>
 			<td style="text-align:right">66%</td>
-			<td style="text-align:right">2,996</td>
+			<td style="text-align:right">3,071</td>
 			<td style="text-align:right">12,737</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">South Canterbury</th>
-			<td style="text-align:right">810</td>
+			<td style="text-align:right">808</td>
 			<td style="text-align:right">&gt;95%</td>
 			<td style="text-align:right">0</td>
-			<td style="text-align:right">650</td>
-			<td style="text-align:right">78%</td>
-			<td style="text-align:right">103</td>
+			<td style="text-align:right">647</td>
+			<td style="text-align:right">77%</td>
+			<td style="text-align:right">106</td>
 			<td style="text-align:right">837</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">Southern</th>
-			<td style="text-align:right">5,699</td>
+			<td style="text-align:right">5,680</td>
 			<td style="text-align:right">94%</td>
 			<td style="text-align:right">0</td>
-			<td style="text-align:right">4,670</td>
+			<td style="text-align:right">4,644</td>
 			<td style="text-align:right">77%</td>
-			<td style="text-align:right">758</td>
+			<td style="text-align:right">784</td>
 			<td style="text-align:right">6,031</td>
 		</tr>
 		<tr>
 			<th nowrap="nowrap">Overseas / Unknown</th>
-			<td style="text-align:right">334</td>
+			<td style="text-align:right">336</td>
 			<td style="text-align:right">29%</td>
-			<td style="text-align:right">700</td>
+			<td style="text-align:right">698</td>
 			<td style="text-align:right">301</td>
 			<td style="text-align:right">26%</td>
 			<td style="text-align:right">733</td>
@@ -1467,12 +1467,12 @@ __wm.bt(650,27,25,2,"web","https://www.health.govt.nz/our-work/diseases-and-cond
 		</tr>
 		<tr>
 			<th nowrap="nowrap"><strong>Total</strong></th>
-			<td style="text-align:right"><strong>246,526</strong></td>
+			<td style="text-align:right"><strong>245,915</strong></td>
 			<td style="text-align:right"><strong>86%</strong></td>
-			<td style="text-align:right"><strong>11,487</strong></td>
-			<td style="text-align:right"><strong>202,434</strong></td>
-			<td style="text-align:right"><strong>71%</strong></td>
-			<td style="text-align:right"><strong>55,579</strong></td>
+			<td style="text-align:right"><strong>12,098</strong></td>
+			<td style="text-align:right"><strong>201,191</strong></td>
+			<td style="text-align:right"><strong>70%</strong></td>
+			<td style="text-align:right"><strong>56,822</strong></td>
 			<td style="text-align:right"><strong>286,681</strong></td>
 		</tr>
 	</tbody>
@@ -1488,7 +1488,7 @@ __wm.bt(650,27,25,2,"web","https://www.health.govt.nz/our-work/diseases-and-cond
 
 <h3><a id="model" model="" name="id="></a>Cumulative vaccinations</h3>
 
-<figure class="image-captioned img-responsive"><img 761="" alt="Vaccination doses administered compared to plan doses" class="img-responsive" height="830" src="/web/20211105212204im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/vaccineplanmodel_14.png" width="1780"/></figure>
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccination doses administered compared to plan doses" class="img-responsive" height="830" src="/web/20211104203147im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/vaccineplanmodel_14.png" width="1780"/></figure>
 
 <p>Production plan figures are the volumes agreed with DHBs and national providers for expected vaccinations. These figures have been matched with expected supply. Detailed plans are available in the Excel file at the bottom of this page.</p>
 
@@ -1508,14 +1508,14 @@ __wm.bt(650,27,25,2,"web","https://www.health.govt.nz/our-work/diseases-and-cond
 <p>Maps and data related to uptake rates of the COVID-19 vaccine across the country are available on the pages linked below. These show&nbsp;vaccination records aggregated by area of residence for all New Zealand residents, Māori communities, and Pacific communities.</p>
 
 <ul>
-	<li><a href="/web/20211105212204/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-across-nz">COVID-19 Vaccination uptake rates across NZ</a></li>
-	<li><a href="/web/20211105212204/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-maori-communities-across-nz">COVID-19 Vaccination uptake rates within Māori communities across NZ</a></li>
-	<li><a href="/web/20211105212204/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-pacific-communities-across-nz">COVID-19 Vaccination uptake rates within Pacific communities across NZ</a></li>
+	<li><a href="/web/20211104203147/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-across-nz">COVID-19 Vaccination uptake rates across NZ</a></li>
+	<li><a href="/web/20211104203147/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-maori-communities-across-nz">COVID-19 Vaccination uptake rates within Māori communities across NZ</a></li>
+	<li><a href="/web/20211104203147/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-pacific-communities-across-nz">COVID-19 Vaccination uptake rates within Pacific communities across NZ</a></li>
 </ul>
 
 <h4><a id="uptake" name="uptake"></a>Vaccine uptake per rate ratio (unadjusted) Māori and Pacific compared with Non-Māori non-Pacific</h4>
 
-<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine Uptake per 1,000 (HSU) Rate Ratio, Showing Prioritised Ethnicity, vs Non-Māori Non-Pacific, By Age Band" class="img-responsive" height="830" src="/web/20211105212204im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_mix_9.png" width="1780"/></figure>
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine Uptake per 1,000 (HSU) Rate Ratio, Showing Prioritised Ethnicity, vs Non-Māori Non-Pacific, By Age Band" class="img-responsive" height="830" src="/web/20211104203147im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_mix_9.png" width="1780"/></figure>
 
 <p>In the Chart above, rate ratios tell us the rate Māori or Pacific People per population are being vaccinated compared with non-Māori non-Pacific. This comparison can be split by age group.</p>
 
@@ -2114,22 +2114,22 @@ __wm.bt(650,27,25,2,"web","https://www.health.govt.nz/our-work/diseases-and-cond
 <p>This table shows the rate of doses administered (per 1,000 population) to Māori or Pacific Peoples, relative to the rate of doses for Non-Māori and Non-Pacific groups. Less than one means the group is receiving a lower proportion of doses than would be expected if equity is being achieved. More than one means they are receiving a higher proportion of doses than would be expected if equity is being achieved. Exactly one means doses administered are in line with their proportion of population.</p>
 
 <ul>
-	<li><a download="" href="/web/20211105212204/https://www.health.govt.nz/system/files/documents/pages/rateratioexplainer_3.docx">Rate Ratio Explainer (Word, 434 KB)</a></li>
+	<li><a download="" href="/web/20211104203147/https://www.health.govt.nz/system/files/documents/pages/rateratioexplainer_3.docx">Rate Ratio Explainer (Word, 434 KB)</a></li>
 </ul>
 
 <p>At all ages the size (weightings) of the age groups becomes a major contributing factor to comparative ratios, which is why the all ages (12+) figure may not appear to be in line with the age splits.</p>
 
 <h4><a id="uptake" name="uptake"></a>Vaccine uptake per 1,000 people by ethnicity</h4>
 
-<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine uptake per 1,000 people by ethnicity" class="img-responsive" height="830" src="/web/20211105212204im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_eth_9.png" width="1780"/></figure>
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine uptake per 1,000 people by ethnicity" class="img-responsive" height="830" src="/web/20211104203147im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_eth_9.png" width="1780"/></figure>
 
 <h4><a id="uptake" name="uptake"></a>Vaccine uptake per 1,000 people by age band</h4>
 
-<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine uptake per 1,000 people by age band" class="img-responsive" height="1030" src="/web/20211105212204im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_age_10.png" width="1780"/></figure>
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine uptake per 1,000 people by age band" class="img-responsive" height="1030" src="/web/20211104203147im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_age_10.png" width="1780"/></figure>
 
 <h4><a id="uptake" name="location"></a>Vaccine uptake per 1,000 people by DHB of residence</h4>
 
-<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine uptake per 1,000 people by DHB of residence" class="img-responsive" height="1030" src="/web/20211105212204im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_dhb_5.png" width="1780"/></figure>
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine uptake per 1,000 people by DHB of residence" class="img-responsive" height="1030" src="/web/20211104203147im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/uptake_dhb_5.png" width="1780"/></figure>
 <!--
 <hr />
 <h3><a id="by_dhb_plan" name="dhb_plan"></a>Cumulative vaccination plan for DHBs</h3>
@@ -2175,30 +2175,30 @@ __wm.bt(650,27,25,2,"web","https://www.health.govt.nz/our-work/diseases-and-cond
 <hr/>
 <h3><a id="by_dhb" name="location"></a>Cumulative vaccinations by DHB</h3>
 
-<figure class="image-captioned img-responsive"><img 761="" alt="Cumulative vaccinations for DHBs" class="img-responsive" height="830" src="/web/20211105212204im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/dhbstacked_13.png" width="1780"/></figure>
+<figure class="image-captioned img-responsive"><img 761="" alt="Cumulative vaccinations for DHBs" class="img-responsive" height="830" src="/web/20211104203147im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/dhbstacked_13.png" width="1780"/></figure>
 
 <hr/>
 <h3><a id="by-day" name="by-day"></a>Vaccinations by day</h3>
 
-<figure class="image-captioned img-responsive"><img alt="Vaccination doses administered per day" class="img-responsive" height="830" src="/web/20211105212204im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/vaccinebyday_13.png" width="1780"/></figure>
+<figure class="image-captioned img-responsive"><img alt="Vaccination doses administered per day" class="img-responsive" height="830" src="/web/20211104203147im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/vaccinebyday_13.png" width="1780"/></figure>
 
 <p>This chart shows the count of vaccinations administered on a given day from the COVID-19 Immunisation Register. Note some records are entered in the register at a later date than the immunisation was received. This means that the figures for a given date may move for some time after that date.</p>
 
 <hr/>
 <h3><a id="by_soh" name="stockonhand"></a>Vaccine available for distribution at week end</h3>
 
-<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine available for distribution at week end" class="img-responsive" height="830" src="/web/20211105212204im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/stockonhand_14.png" width="1780"/></figure>
+<figure class="image-captioned img-responsive"><img 761="" alt="Vaccine available for distribution at week end" class="img-responsive" height="830" src="/web/20211104203147im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/stockonhand_14.png" width="1780"/></figure>
 
 <p>Vaccine available for distribution is stock (in doses) held at central warehouses. It does not include stock in transit or available at sites ready for use.</p>
 
 <hr/>
 <h3><a id="by_eth" name="ethnicity"></a>Total cumulative doses per 1,000 people by ethnicity</h3>
 
-<figure class="image-captioned img-responsive"><img 761="" alt="Total cumulative doses per 1,000 people by ethnicity" class="img-responsive" height="830" src="/web/20211105212204im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/ethnicity_13.png" width="1780"/></figure>
+<figure class="image-captioned img-responsive"><img 761="" alt="Total cumulative doses per 1,000 people by ethnicity" class="img-responsive" height="830" src="/web/20211104203147im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/ethnicity_13.png" width="1780"/></figure>
 
 <p>This chart shows both first and second doses. As a result this chart may exceed 1,000 doses per 1,000 people.</p>
 
-<p><strong>*</strong> The prioritised ethnicity classification system allocates each person to a single ethnic group, based on the ethnic groups they identify with. Where people identify with more than one group, they are assigned in this order of priority: Māori, Pacific Peoples, Asian, and European/Other. So, if a person identifies as being Māori and New Zealand European, the person is counted as Māori. See <a href="/web/20211105212204/https://www.health.govt.nz/publication/hiso-100012017-ethnicity-data-protocols">Ethnicity Data Protocols</a> for further information.</p>
+<p><strong>*</strong> The prioritised ethnicity classification system allocates each person to a single ethnic group, based on the ethnic groups they identify with. Where people identify with more than one group, they are assigned in this order of priority: Māori, Pacific Peoples, Asian, and European/Other. So, if a person identifies as being Māori and New Zealand European, the person is counted as Māori. See <a href="/web/20211104203147/https://www.health.govt.nz/publication/hiso-100012017-ethnicity-data-protocols">Ethnicity Data Protocols</a> for further information.</p>
 
 <p>Ethnicity breakdown by DHB of residence is available in the downloadable spreadsheet at the bottom of the page.</p>
 
@@ -2266,7 +2266,7 @@ __wm.bt(650,27,25,2,"web","https://www.health.govt.nz/our-work/diseases-and-cond
 <hr/>
 <h3><a id="workforce" name="workforce"></a>Trained vaccinators and active vaccinators</h3>
 
-<figure class="image-captioned img-responsive"><img 761="" alt="Trained vaccinators and active vaccinators" class="img-responsive" height="830" src="/web/20211105212204im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/workforce_13.png" width="1780"/></figure>
+<figure class="image-captioned img-responsive"><img 761="" alt="Trained vaccinators and active vaccinators" class="img-responsive" height="830" src="/web/20211104203147im_/https://www.health.govt.nz/sites/default/files/images/our-work/diseases-conditions/covid19/vaccine-data/workforce_13.png" width="1780"/></figure>
 
 <p><strong>Trained vaccinators</strong> are individuals who have completed the COVID-19 training. Many trained people are only able to offer a small number of hours to the COVID-19 vaccination programme.</p>
 
@@ -2298,18 +2298,18 @@ __wm.bt(650,27,25,2,"web","https://www.health.govt.nz/our-work/diseases-and-cond
 
 <p>Download a spreadsheet containing key vaccination data. This includes HSU based population estimates for calculating vaccine uptake rates.</p>
 
-<p><a download="" href="/web/20211105212204/https://www.health.govt.nz/system/files/documents/pages/covid_vaccinations_02_11_2021.xlsx">COVID-19 vaccination data through 02 Nov 2021 (Excel, 300 KB)</a></p>
+<p><a download="" href="/web/20211104203147/https://www.health.govt.nz/system/files/documents/pages/covid_vaccinations_02_11_2021.xlsx">COVID-19 vaccination data through 02 Nov 2021 (Excel, 300 KB)</a></p>
 
 <p>This spreadsheet is based on the information made available at the time of publishing and may be subject to changes. Please take note of any notes and caveats on each sheet.</p>
 
 <p>The below attachments provide some analysis on our progress on equity. The two PDF files are high level summaries of overall progress. The Excel documents are interactive and provides the ability to delve further into those overall numbers. NB: These Excel workbooks use features that are non-compatible with versions of MS Office 2016 and earlier.</p>
 
 <ul>
-	<li><a download="" href="/web/20211105212204/https://www.health.govt.nz/system/files/documents/pages/211031_-_cvip_equity_-_rate_ratios_by_ethnicity_ageband_and_dhb.pdf">Covid-19 Vaccine Rate Ratios by Ethnicity, Ageband and DHB (PDF, 642 KB)</a></li>
-	<li><a download="" href="/web/20211105212204/https://www.health.govt.nz/system/files/documents/pages/211031_-_cvip_equity_-_uptake_by_ethnicity_ageband_and_dhb.pdf">Covid-19 Vaccine Uptake by Ethnicity, Ageband and DHB (PDF, 550 KB)</a></li>
-	<li><a download="" href="/web/20211105212204/https://www.health.govt.nz/system/files/documents/pages/211031_-_cvip_equity_-_level_1_ethnicity_uptake_and_rate_ratios.xlsx">Covid-19 Vaccine Equity - Level 1 Ethnicity Uptake and Rate Ratios (Excel, 153 KB)</a></li>
-	<li><a download="" href="/web/20211105212204/https://www.health.govt.nz/system/files/documents/pages/211031_-_cvip_equity_-_level_2_ethnicity_uptake_and_rate_ratios.xlsx">Covid-19 Vaccine Equity - Level 2 Ethnicity Uptake and Rate Ratios (Excel, 379 KB)</a></li>
-	<li><a download="" href="/web/20211105212204/https://www.health.govt.nz/system/files/documents/pages/211031_-_cvip_equity_-_rate_ratios_and_uptake_over_time.xlsx">Rate Ratios and Uptake Over Time (Excel, 1.1 MB)</a></li>
+	<li><a download="" href="/web/20211104203147/https://www.health.govt.nz/system/files/documents/pages/211031_-_cvip_equity_-_rate_ratios_by_ethnicity_ageband_and_dhb.pdf">Covid-19 Vaccine Rate Ratios by Ethnicity, Ageband and DHB (PDF, 642 KB)</a></li>
+	<li><a download="" href="/web/20211104203147/https://www.health.govt.nz/system/files/documents/pages/211031_-_cvip_equity_-_uptake_by_ethnicity_ageband_and_dhb.pdf">Covid-19 Vaccine Uptake by Ethnicity, Ageband and DHB (PDF, 550 KB)</a></li>
+	<li><a download="" href="/web/20211104203147/https://www.health.govt.nz/system/files/documents/pages/211031_-_cvip_equity_-_level_1_ethnicity_uptake_and_rate_ratios.xlsx">Covid-19 Vaccine Equity - Level 1 Ethnicity Uptake and Rate Ratios (Excel, 153 KB)</a></li>
+	<li><a download="" href="/web/20211104203147/https://www.health.govt.nz/system/files/documents/pages/211031_-_cvip_equity_-_level_2_ethnicity_uptake_and_rate_ratios.xlsx">Covid-19 Vaccine Equity - Level 2 Ethnicity Uptake and Rate Ratios (Excel, 379 KB)</a></li>
+	<li><a download="" href="/web/20211104203147/https://www.health.govt.nz/system/files/documents/pages/211031_-_cvip_equity_-_rate_ratios_and_uptake_over_time.xlsx">Rate Ratios and Uptake Over Time (Excel, 1.1 MB)</a></li>
 </ul>
 
 <hr/>
@@ -2317,9 +2317,9 @@ __wm.bt(650,27,25,2,"web","https://www.health.govt.nz/our-work/diseases-and-cond
 
 <p>Like all medicines, the COVID-19 vaccine may cause side effects in some people. These are common, are usually mild, don&rsquo;t last long and won&rsquo;t stop people from having the second dose or going about daily life. Serious allergic reactions do occur but are extremely rare.</p>
 
-<p>Suspected AEFI to COVID-19 vaccines are reported to the <a href="https://web.archive.org/web/20211105212204/https://nzphvc.otago.ac.nz/">Centre for Adverse Reactions Monitoring</a> (CARM).&nbsp;<a href="https://web.archive.org/web/20211105212204/https://www.medsafe.govt.nz/">Medsafe</a> is closely monitoring the AEFI reported from the use of the COVID-19 vaccine and will report regularly on their findings.&nbsp;</p>
+<p>Suspected AEFI to COVID-19 vaccines are reported to the <a href="https://web.archive.org/web/20211104203147/https://nzphvc.otago.ac.nz/">Centre for Adverse Reactions Monitoring</a> (CARM).&nbsp;<a href="https://web.archive.org/web/20211104203147/https://www.medsafe.govt.nz/">Medsafe</a> is closely monitoring the AEFI reported from the use of the COVID-19 vaccine and will report regularly on their findings.&nbsp;</p>
 
-<p><a href="https://web.archive.org/web/20211105212204/https://www.medsafe.govt.nz/COVID-19/vaccine-report-overview.asp">View Medsafe data on COVID-19 vaccine adverse effects following immunisation</a></p>
+<p><a href="https://web.archive.org/web/20211104203147/https://www.medsafe.govt.nz/COVID-19/vaccine-report-overview.asp">View Medsafe data on COVID-19 vaccine adverse effects following immunisation</a></p>
 </div></div></div>    </article>
   </div>
 
@@ -2341,7 +2341,7 @@ __wm.bt(650,27,25,2,"web","https://www.health.govt.nz/our-work/diseases-and-cond
 
 
   <div class="pane-content">
-        <div class="view view-sub-pages view-id-sub_pages view-display-id-block view-dom-id-a6f6c154cff4e62ad545b86e27fadffd">
+        <div class="view view-sub-pages view-id-sub_pages view-display-id-block view-dom-id-f8b490c6264b71871d337fc3cae99803">
 
 
 
@@ -2350,29 +2350,29 @@ __wm.bt(650,27,25,2,"web","https://www.health.govt.nz/our-work/diseases-and-cond
   <div class="views-field views-field-title">        <div class="field-content">
 <div class="views-field views-field-title">
   <h3 class="field-content">
-    <a href="/web/20211105212204/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-across-nz">COVID-19 Vaccination uptake rates across NZ</a>  </h3>
+    <a href="/web/20211104203147/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-across-nz">COVID-19 Vaccination uptake rates across NZ</a>  </h3>
 </div></div>  </div>
   <span class="views-field views-field-body">        <span class="field-content">This page provides information related to uptake rates of the COVID-19 vaccine across the country.
 </span>  </span>
-  <span class="views-field views-field-view-node">        <span class="field-content"><a href="/web/20211105212204/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-across-nz">Read more</a></span>  </span></li>
+  <span class="views-field views-field-view-node">        <span class="field-content"><a href="/web/20211104203147/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-across-nz">Read more</a></span>  </span></li>
           <li class="views-row views-row-2 views-row-even">
   <div class="views-field views-field-title">        <div class="field-content">
 <div class="views-field views-field-title">
   <h3 class="field-content">
-    <a href="/web/20211105212204/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-maori-communities-across-nz">COVID-19 Vaccination uptake rates within Māori communities across NZ</a>  </h3>
+    <a href="/web/20211104203147/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-maori-communities-across-nz">COVID-19 Vaccination uptake rates within Māori communities across NZ</a>  </h3>
 </div></div>  </div>
   <span class="views-field views-field-body">        <span class="field-content">This page provides information related to uptake rates of the COVID-19 vaccine within Māori communities across New Zealand.
 </span>  </span>
-  <span class="views-field views-field-view-node">        <span class="field-content"><a href="/web/20211105212204/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-maori-communities-across-nz">Read more</a></span>  </span></li>
+  <span class="views-field views-field-view-node">        <span class="field-content"><a href="/web/20211104203147/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-maori-communities-across-nz">Read more</a></span>  </span></li>
           <li class="views-row views-row-3 views-row-odd views-row-last">
   <div class="views-field views-field-title">        <div class="field-content">
 <div class="views-field views-field-title">
   <h3 class="field-content">
-    <a href="/web/20211105212204/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-pacific-communities-across-nz">COVID-19 Vaccination uptake rates within Pacific communities across NZ</a>  </h3>
+    <a href="/web/20211104203147/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-pacific-communities-across-nz">COVID-19 Vaccination uptake rates within Pacific communities across NZ</a>  </h3>
 </div></div>  </div>
   <span class="views-field views-field-body">        <span class="field-content">This page provides information related to uptake rates of the COVID-19 vaccine within Pacific communities across New Zealand.
 </span>  </span>
-  <span class="views-field views-field-view-node">        <span class="field-content"><a href="/web/20211105212204/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-pacific-communities-across-nz">Read more</a></span>  </span></li>
+  <span class="views-field views-field-view-node">        <span class="field-content"><a href="/web/20211104203147/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data/covid-19-vaccination-uptake-rates-within-pacific-communities-across-nz">Read more</a></span>  </span></li>
       </ul></div>    </div>
 
 
@@ -2396,11 +2396,11 @@ __wm.bt(650,27,25,2,"web","https://www.health.govt.nz/our-work/diseases-and-cond
     </div>
     <div id="content-footer-wrapper" class="clearfix">
       <div id="content-footer" class="clearfix">
-                  <p class="page_updated">Page last updated: <span class="date">05 November 2021</span></p>                  <div class="region region-content-footer">
+                  <p class="page_updated">Page last updated: <span class="date">04 November 2021</span></p>                  <div class="region region-content-footer">
     <section id="block-moh-tools-page-tools" class="block block-moh-tools clearfix">
   <a href="#" data-placement="top" data-title="Share this content." data-html="true" data-content="<p>Share this page on some of the most popular social networking and content sites on the internet.</p><div class='service-links'><ul><li><a href='https://twitter.com/share?url=https%3A//www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data&amp;text=COVID-19%3A%20Vaccine%20data' title='Share this on Twitter' class='service-links-twitter' rel='nofollow'><img typeof='foaf:Image' class='img-responsive' src='https://www.health.govt.nz/sites/all/modules/contrib/service_links/images/twitter.png' alt='Twitter' /> Twitter</a></li>
 <li><a href='https://www.facebook.com/sharer.php?u=https%3A//www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data&amp;t=COVID-19%3A%20Vaccine%20data' title='Share on Facebook' class='service-links-facebook' rel='nofollow'><img typeof='foaf:Image' class='img-responsive' src='https://www.health.govt.nz/sites/all/modules/contrib/service_links/images/facebook.png' alt='Facebook' /> Facebook</a></li>
-</ul></div>" class="share-this-content"><i class="fa fa-share"></i> Share</a><a href="#" title="print this page" class="print"><i class="fa fa-print"></i> Print</a><a href="https://web.archive.org/web/20211105212204/https://www.health.govt.nz/forward?path=node/12052" title="Email this page" class="email"><i class="fa fa-envelope"></i> Email</a><a href="/web/20211105212204/https://www.health.govt.nz/feedback?ref=https%3A//www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="Feedback" class="rss"><i class="fa fa-comment"></i> Feedback</a></section>
+</ul></div>" class="share-this-content"><i class="fa fa-share"></i> Share</a><a href="#" title="print this page" class="print"><i class="fa fa-print"></i> Print</a><a href="https://web.archive.org/web/20211104203147/https://www.health.govt.nz/forward?path=node/12052" title="Email this page" class="email"><i class="fa fa-envelope"></i> Email</a><a href="/web/20211104203147/https://www.health.govt.nz/feedback?ref=https%3A//www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data" title="Feedback" class="rss"><i class="fa fa-comment"></i> Feedback</a></section>
 
   </div>
       </div>
@@ -2413,7 +2413,7 @@ __wm.bt(650,27,25,2,"web","https://www.health.govt.nz/our-work/diseases-and-cond
       <div class="row">
         <div class="col-sm-6 col-md-6">
           <div class="field field-name-field-tax-first-column-links">
-            <ul class="field-items"><li class="field-item"><a href="https://web.archive.org/web/20211105212204/https://www.health.govt.nz/node/492" class="">About this site</a></li><li class="field-item"><a href="https://web.archive.org/web/20211105212204/https://www.health.govt.nz/node/524" class="">Contact us</a></li><li class="field-item"><a href="https://web.archive.org/web/20211105212204/https://www.health.govt.nz/node/488" class="">Other Ministry of Health websites</a></li><li class="field-item"><a href="https://web.archive.org/web/20211105212204/https://www.health.govt.nz/node/7497" class="">Official Information Act requests</a></li><li class="field-item"><a href="https://web.archive.org/web/20211105212204/https://www.health.govt.nz/about-ministry/information-releases" class="">Information releases</a></li><li class="field-item"><a href="https://web.archive.org/web/20211105212204/https://consult.health.govt.nz/" class="">Consultations</a></li></ul>
+            <ul class="field-items"><li class="field-item"><a href="https://web.archive.org/web/20211104203147/https://www.health.govt.nz/node/492" class="">About this site</a></li><li class="field-item"><a href="https://web.archive.org/web/20211104203147/https://www.health.govt.nz/node/524" class="">Contact us</a></li><li class="field-item"><a href="https://web.archive.org/web/20211104203147/https://www.health.govt.nz/node/488" class="">Other Ministry of Health websites</a></li><li class="field-item"><a href="https://web.archive.org/web/20211104203147/https://www.health.govt.nz/node/7497" class="">Official Information Act requests</a></li><li class="field-item"><a href="https://web.archive.org/web/20211104203147/https://www.health.govt.nz/about-ministry/information-releases" class="">Information releases</a></li><li class="field-item"><a href="https://web.archive.org/web/20211104203147/https://consult.health.govt.nz/" class="">Consultations</a></li></ul>
           </div>
         </div>
         <div class="col-sm-6 col-md-6">
@@ -2435,7 +2435,7 @@ __wm.bt(650,27,25,2,"web","https://www.health.govt.nz/our-work/diseases-and-cond
 		</tr>
 		<tr>
 			<th scope="row">Mental health crisis</th>
-			<td><strong><a href="/web/20211105212204/https://www.health.govt.nz/your-health/services-and-support/health-care-services/mental-health-services/crisis-assessment-teams">Emergency contact numbers</a></strong></td>
+			<td><strong><a href="/web/20211104203147/https://www.health.govt.nz/your-health/services-and-support/health-care-services/mental-health-services/crisis-assessment-teams">Emergency contact numbers</a></strong></td>
 		</tr>
 	</tbody>
 </table>
@@ -2444,12 +2444,12 @@ __wm.bt(650,27,25,2,"web","https://www.health.govt.nz/our-work/diseases-and-cond
       <div class="row">
         <div class="sub-footer">
           <div class="column col-sm-12 col-md-3">
-            <a href="https://web.archive.org/web/20211105212204/https://www.govt.nz/">
-              <img src="/web/20211105212204im_/https://www.health.govt.nz/sites/all/themes/mohpub_bootstrap/images/nzgovtlogo-te-kawanatanga-white.png" width="230" height="52" alt="govt.nz - connecting you to New Zealand central &amp; local government services" title="govt.nz - connecting you to New Zealand central &amp; local government services"/>
+            <a href="https://web.archive.org/web/20211104203147/https://www.govt.nz/">
+              <img src="/web/20211104203147im_/https://www.health.govt.nz/sites/all/themes/mohpub_bootstrap/images/nzgovtlogo-te-kawanatanga-white.png" width="230" height="52" alt="govt.nz - connecting you to New Zealand central &amp; local government services" title="govt.nz - connecting you to New Zealand central &amp; local government services"/>
             </a>
           </div>
           <div class="column col-sm-12 col-md-9">
-          <span class="bottom-menu-moh with-v-divider">&copy; Ministry of Health – Manatū Hauora</span><ul class="bottom-menu-list"><li class="bottom-menu-list-item with-v-divider"><a href="https://web.archive.org/web/20211105212204/https://www.health.govt.nz/sitemap" class="">Site map</a></li><li class="bottom-menu-list-item with-v-divider"><a href="https://web.archive.org/web/20211105212204/https://www.health.govt.nz/about-site/privacy-and-security" class="">Privacy &amp; security</a></li><li class="bottom-menu-list-item with-v-divider"><a href="https://web.archive.org/web/20211105212204/https://www.health.govt.nz/about-site/copyright" class="">Copyright</a></li></ul>          </div>
+          <span class="bottom-menu-moh with-v-divider">&copy; Ministry of Health – Manatū Hauora</span><ul class="bottom-menu-list"><li class="bottom-menu-list-item with-v-divider"><a href="https://web.archive.org/web/20211104203147/https://www.health.govt.nz/sitemap" class="">Site map</a></li><li class="bottom-menu-list-item with-v-divider"><a href="https://web.archive.org/web/20211104203147/https://www.health.govt.nz/about-site/privacy-and-security" class="">Privacy &amp; security</a></li><li class="bottom-menu-list-item with-v-divider"><a href="https://web.archive.org/web/20211104203147/https://www.health.govt.nz/about-site/copyright" class="">Copyright</a></li></ul>          </div>
         </div>
       </div>
     </div>
@@ -2457,12 +2457,12 @@ __wm.bt(650,27,25,2,"web","https://www.health.govt.nz/our-work/diseases-and-cond
   </footer>
   <a class="scrollToTop">Back to top <i class="fas fa-arrow-up"></i></a>
 </div>
-  <script src="https://web.archive.org/web/20211105212204js_/https://www.health.govt.nz/sites/default/files/js/js_akZOsKtodu3PdnQzY3_ElOfujkLxJcowmaWgHTBBLOE.js"></script>
+  <script src="https://web.archive.org/web/20211104203147js_/https://www.health.govt.nz/sites/default/files/js/js_akZOsKtodu3PdnQzY3_ElOfujkLxJcowmaWgHTBBLOE.js"></script>
 </body>
 </html>
 <!--
-     FILE ARCHIVED ON 21:22:04 Nov 05, 2021 AND RETRIEVED FROM THE
-     INTERNET ARCHIVE ON 03:10:31 Nov 07, 2021.
+     FILE ARCHIVED ON 20:31:47 Nov 04, 2021 AND RETRIEVED FROM THE
+     INTERNET ARCHIVE ON 03:11:55 Nov 07, 2021.
      JAVASCRIPT APPENDED BY WAYBACK MACHINE, COPYRIGHT INTERNET ARCHIVE.
 
      ALL OTHER CONTENT MAY ALSO BE PROTECTED BY COPYRIGHT (17 U.S.C.
@@ -2470,14 +2470,14 @@ __wm.bt(650,27,25,2,"web","https://www.health.govt.nz/our-work/diseases-and-cond
 -->
 <!--
 playback timings (ms):
-  captures_list: 111.157
-  exclusion.robots: 0.201
-  exclusion.robots.policy: 0.194
-  RedisCDXSource: 2.849
-  esindex: 0.011
-  LoadShardBlock: 61.339 (3)
-  PetaboxLoader3.datanode: 91.813 (4)
-  CDXLines.iter: 31.532 (3)
-  load_resource: 101.912
-  PetaboxLoader3.resolve: 27.788
+  RedisCDXSource: 5.136
+  LoadShardBlock: 94.263 (3)
+  PetaboxLoader3.resolve: 91.667
+  load_resource: 130.649
+  exclusion.robots: 0.443
+  CDXLines.iter: 27.952 (3)
+  captures_list: 144.484
+  esindex: 0.012
+  exclusion.robots.policy: 0.432
+  PetaboxLoader3.datanode: 75.132 (4)
 -->


### PR DESCRIPTION
### Changes
- Used https://web.archive.org/web/*/https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data to get historical versions of the MoH page. 
- I only went back to 22nd Oct as before that time the Vaccinations per DHB were not updated daily. 
- Also had to re-get 4th of November as it was added but then prettier had ran over it and it makes the regex break. 
- Added a prettier ignore so none of the new ones get formatted. 