### PR TITLE
Store created + updated date as part of VaccineData files (also includes ability to regen vaccine data files)

### DIFF
--- a/app/propsGenerators/indexPagePropsGenerator.ts
+++ b/app/propsGenerators/indexPagePropsGenerator.ts
@@ -23,10 +23,12 @@ export default async function fetchIndexPageProps(): Promise<IndexPageProps> {
 
   return {
     allDhbsVaccineDoseData: generateAllDhbsVaccineDoseData(
-      latestData.vaccinationsPerDhb,
-      yesterdayData.vaccinationsPerDhb
+      latestData.data.vaccinationsPerDhb,
+      yesterdayData.data.vaccinationsPerDhb
     ),
-    dataValidAsAtTimeUtc: DateTime.fromISO(latestData.dataValidAsAtNzTimeIso)
+    dataValidAsAtTimeUtc: DateTime.fromISO(
+      latestData.data.dataValidAsAtNzTimeIso
+    )
       .toUTC()
       .toISO(),
   };

--- a/data/vaccineData/2021-10-22.json
+++ b/data/vaccineData/2021-10-22.json
@@ -1,5 +1,5 @@
 {
-  "metaData": {
+  "metadata": {
     "createdAtUtcTimeIso": "2021-11-07T05:46:24.785Z",
     "updatedAtUtcTimeIso": "2021-11-07T05:46:24.785Z"
   },

--- a/data/vaccineData/2021-10-22.json
+++ b/data/vaccineData/2021-10-22.json
@@ -1,0 +1,221 @@
+{
+  "metaData": {
+    "createdAtUtcTimeIso": "2021-11-07T05:46:24.785Z",
+    "updatedAtUtcTimeIso": "2021-11-07T05:46:24.785Z"
+  },
+  "data": {
+    "vaccinationsPerDhb": [
+      {
+        "dhbName": "Northland",
+        "firstDoses": 124581,
+        "firstDosesPercentage": 0.77,
+        "firstDosesTo90Percent": 20607,
+        "secondDoses": 98596,
+        "secondDosesPercentage": 0.61,
+        "secondDosesTo90Percent": 46592,
+        "totalPopulation": 161320
+      },
+      {
+        "dhbName": "Waitemata",
+        "firstDoses": 472845,
+        "firstDosesPercentage": 0.9,
+        "firstDosesTo90Percent": 633,
+        "secondDoses": 393932,
+        "secondDosesPercentage": 0.75,
+        "secondDosesTo90Percent": 79546,
+        "totalPopulation": 526087
+      },
+      {
+        "dhbName": "Auckland",
+        "firstDoses": 393369,
+        "firstDosesPercentage": 0.93,
+        "firstDosesTo90Percent": 0,
+        "secondDoses": 337329,
+        "secondDosesPercentage": 0.8,
+        "secondDosesTo90Percent": 44233,
+        "totalPopulation": 423958
+      },
+      {
+        "dhbName": "Counties Manukau",
+        "firstDoses": 420059,
+        "firstDosesPercentage": 0.87,
+        "firstDosesTo90Percent": 14437,
+        "secondDoses": 347137,
+        "secondDosesPercentage": 0.72,
+        "secondDosesTo90Percent": 87359,
+        "totalPopulation": 482773
+      },
+      {
+        "dhbName": "Waikato",
+        "firstDoses": 302169,
+        "firstDosesPercentage": 0.85,
+        "firstDosesTo90Percent": 19289,
+        "secondDoses": 241318,
+        "secondDosesPercentage": 0.68,
+        "secondDosesTo90Percent": 80140,
+        "totalPopulation": 357176
+      },
+      {
+        "dhbName": "Lakes",
+        "firstDoses": 73975,
+        "firstDosesPercentage": 0.78,
+        "firstDosesTo90Percent": 11002,
+        "secondDoses": 57433,
+        "secondDosesPercentage": 0.61,
+        "secondDosesTo90Percent": 27544,
+        "totalPopulation": 94419
+      },
+      {
+        "dhbName": "Bay of Plenty",
+        "firstDoses": 176124,
+        "firstDosesPercentage": 0.81,
+        "firstDosesTo90Percent": 19123,
+        "secondDoses": 133220,
+        "secondDosesPercentage": 0.61,
+        "secondDosesTo90Percent": 62027,
+        "totalPopulation": 216941
+      },
+      {
+        "dhbName": "Tairawhiti",
+        "firstDoses": 31756,
+        "firstDosesPercentage": 0.76,
+        "firstDosesTo90Percent": 6012,
+        "secondDoses": 25265,
+        "secondDosesPercentage": 0.6,
+        "secondDosesTo90Percent": 12504,
+        "totalPopulation": 41965
+      },
+      {
+        "dhbName": "Taranaki",
+        "firstDoses": 83776,
+        "firstDosesPercentage": 0.82,
+        "firstDosesTo90Percent": 8156,
+        "secondDoses": 62349,
+        "secondDosesPercentage": 0.61,
+        "secondDosesTo90Percent": 29583,
+        "totalPopulation": 102147
+      },
+      {
+        "dhbName": "Hawkes Bay",
+        "firstDoses": 120053,
+        "firstDosesPercentage": 0.82,
+        "firstDosesTo90Percent": 10961,
+        "secondDoses": 97596,
+        "secondDosesPercentage": 0.67,
+        "secondDosesTo90Percent": 33418,
+        "totalPopulation": 145571
+      },
+      {
+        "dhbName": "MidCentral",
+        "firstDoses": 128334,
+        "firstDosesPercentage": 0.84,
+        "firstDosesTo90Percent": 8738,
+        "secondDoses": 103512,
+        "secondDosesPercentage": 0.68,
+        "secondDosesTo90Percent": 33560,
+        "totalPopulation": 152302
+      },
+      {
+        "dhbName": "Whanganui",
+        "firstDoses": 44985,
+        "firstDosesPercentage": 0.79,
+        "firstDosesTo90Percent": 6537,
+        "secondDoses": 37155,
+        "secondDosesPercentage": 0.65,
+        "secondDosesTo90Percent": 14367,
+        "totalPopulation": 57247
+      },
+      {
+        "dhbName": "Capital and Coast",
+        "firstDoses": 246756,
+        "firstDosesPercentage": 0.91,
+        "firstDosesTo90Percent": 0,
+        "secondDoses": 203157,
+        "secondDosesPercentage": 0.75,
+        "secondDosesTo90Percent": 40900,
+        "totalPopulation": 271174
+      },
+      {
+        "dhbName": "Hutt Valley",
+        "firstDoses": 112335,
+        "firstDosesPercentage": 0.86,
+        "firstDosesTo90Percent": 4880,
+        "secondDoses": 89431,
+        "secondDosesPercentage": 0.69,
+        "secondDosesTo90Percent": 27784,
+        "totalPopulation": 130239
+      },
+      {
+        "dhbName": "Wairarapa",
+        "firstDoses": 34631,
+        "firstDosesPercentage": 0.84,
+        "firstDosesTo90Percent": 2653,
+        "secondDoses": 28309,
+        "secondDosesPercentage": 0.68,
+        "secondDosesTo90Percent": 8975,
+        "totalPopulation": 41427
+      },
+      {
+        "dhbName": "Nelson Marlborough",
+        "firstDoses": 114814,
+        "firstDosesPercentage": 0.85,
+        "firstDosesTo90Percent": 7355,
+        "secondDoses": 98763,
+        "secondDosesPercentage": 0.73,
+        "secondDosesTo90Percent": 23406,
+        "totalPopulation": 135743
+      },
+      {
+        "dhbName": "West Coast",
+        "firstDoses": 21893,
+        "firstDosesPercentage": 0.78,
+        "firstDosesTo90Percent": 3222,
+        "secondDoses": 17447,
+        "secondDosesPercentage": 0.63,
+        "secondDosesTo90Percent": 7668,
+        "totalPopulation": 27906
+      },
+      {
+        "dhbName": "Canterbury",
+        "firstDoses": 424841,
+        "firstDosesPercentage": 0.88,
+        "firstDosesTo90Percent": 9760,
+        "secondDoses": 315638,
+        "secondDosesPercentage": 0.65,
+        "secondDosesTo90Percent": 118963,
+        "totalPopulation": 482890
+      },
+      {
+        "dhbName": "South Canterbury",
+        "firstDoses": 44119,
+        "firstDosesPercentage": 0.84,
+        "firstDosesTo90Percent": 3207,
+        "secondDoses": 36547,
+        "secondDosesPercentage": 0.7,
+        "secondDosesTo90Percent": 10779,
+        "totalPopulation": 52584
+      },
+      {
+        "dhbName": "Southern",
+        "firstDoses": 252587,
+        "firstDosesPercentage": 0.88,
+        "firstDosesTo90Percent": 6626,
+        "secondDoses": 210004,
+        "secondDosesPercentage": 0.73,
+        "secondDosesTo90Percent": 49210,
+        "totalPopulation": 288015
+      },
+      {
+        "dhbName": "Overseas / Unknown",
+        "firstDoses": 2017,
+        "firstDosesPercentage": 0.12,
+        "firstDosesTo90Percent": 13439,
+        "secondDoses": 1574,
+        "secondDosesPercentage": 0.09,
+        "secondDosesTo90Percent": 13882,
+        "totalPopulation": 17173
+      }
+    ],
+    "dataValidAsAtNzTimeIso": "2021-10-22T23:59:00.000+13:00"
+  }
+}

--- a/data/vaccineData/2021-10-23.json
+++ b/data/vaccineData/2021-10-23.json
@@ -1,5 +1,5 @@
 {
-  "metaData": {
+  "metadata": {
     "createdAtUtcTimeIso": "2021-11-07T05:46:24.787Z",
     "updatedAtUtcTimeIso": "2021-11-07T05:46:24.787Z"
   },

--- a/data/vaccineData/2021-10-23.json
+++ b/data/vaccineData/2021-10-23.json
@@ -1,0 +1,221 @@
+{
+  "metaData": {
+    "createdAtUtcTimeIso": "2021-11-07T05:46:24.787Z",
+    "updatedAtUtcTimeIso": "2021-11-07T05:46:24.787Z"
+  },
+  "data": {
+    "vaccinationsPerDhb": [
+      {
+        "dhbName": "Northland",
+        "firstDoses": 125110,
+        "firstDosesPercentage": 0.78,
+        "firstDosesTo90Percent": 20078,
+        "secondDoses": 99242,
+        "secondDosesPercentage": 0.62,
+        "secondDosesTo90Percent": 45946,
+        "totalPopulation": 161320
+      },
+      {
+        "dhbName": "Waitemata",
+        "firstDoses": 474237,
+        "firstDosesPercentage": 0.9,
+        "firstDosesTo90Percent": 0,
+        "secondDoses": 399271,
+        "secondDosesPercentage": 0.76,
+        "secondDosesTo90Percent": 74207,
+        "totalPopulation": 526087
+      },
+      {
+        "dhbName": "Auckland",
+        "firstDoses": 394356,
+        "firstDosesPercentage": 0.93,
+        "firstDosesTo90Percent": 0,
+        "secondDoses": 340978,
+        "secondDosesPercentage": 0.8,
+        "secondDosesTo90Percent": 40584,
+        "totalPopulation": 423958
+      },
+      {
+        "dhbName": "Counties Manukau",
+        "firstDoses": 422073,
+        "firstDosesPercentage": 0.87,
+        "firstDosesTo90Percent": 12423,
+        "secondDoses": 352246,
+        "secondDosesPercentage": 0.73,
+        "secondDosesTo90Percent": 82250,
+        "totalPopulation": 482773
+      },
+      {
+        "dhbName": "Waikato",
+        "firstDoses": 303212,
+        "firstDosesPercentage": 0.85,
+        "firstDosesTo90Percent": 18246,
+        "secondDoses": 242948,
+        "secondDosesPercentage": 0.68,
+        "secondDosesTo90Percent": 78510,
+        "totalPopulation": 357176
+      },
+      {
+        "dhbName": "Lakes",
+        "firstDoses": 74241,
+        "firstDosesPercentage": 0.79,
+        "firstDosesTo90Percent": 10736,
+        "secondDoses": 58047,
+        "secondDosesPercentage": 0.61,
+        "secondDosesTo90Percent": 26930,
+        "totalPopulation": 94419
+      },
+      {
+        "dhbName": "Bay of Plenty",
+        "firstDoses": 176661,
+        "firstDosesPercentage": 0.81,
+        "firstDosesTo90Percent": 18586,
+        "secondDoses": 134657,
+        "secondDosesPercentage": 0.62,
+        "secondDosesTo90Percent": 60590,
+        "totalPopulation": 216941
+      },
+      {
+        "dhbName": "Tairawhiti",
+        "firstDoses": 31882,
+        "firstDosesPercentage": 0.76,
+        "firstDosesTo90Percent": 5886,
+        "secondDoses": 25408,
+        "secondDosesPercentage": 0.61,
+        "secondDosesTo90Percent": 12360,
+        "totalPopulation": 41965
+      },
+      {
+        "dhbName": "Taranaki",
+        "firstDoses": 84042,
+        "firstDosesPercentage": 0.82,
+        "firstDosesTo90Percent": 7890,
+        "secondDoses": 62810,
+        "secondDosesPercentage": 0.61,
+        "secondDosesTo90Percent": 29122,
+        "totalPopulation": 102147
+      },
+      {
+        "dhbName": "Hawkes Bay",
+        "firstDoses": 120259,
+        "firstDosesPercentage": 0.83,
+        "firstDosesTo90Percent": 10755,
+        "secondDoses": 97891,
+        "secondDosesPercentage": 0.67,
+        "secondDosesTo90Percent": 33123,
+        "totalPopulation": 145571
+      },
+      {
+        "dhbName": "MidCentral",
+        "firstDoses": 128749,
+        "firstDosesPercentage": 0.85,
+        "firstDosesTo90Percent": 8323,
+        "secondDoses": 104271,
+        "secondDosesPercentage": 0.68,
+        "secondDosesTo90Percent": 32801,
+        "totalPopulation": 152302
+      },
+      {
+        "dhbName": "Whanganui",
+        "firstDoses": 45151,
+        "firstDosesPercentage": 0.79,
+        "firstDosesTo90Percent": 6371,
+        "secondDoses": 37379,
+        "secondDosesPercentage": 0.65,
+        "secondDosesTo90Percent": 14143,
+        "totalPopulation": 57247
+      },
+      {
+        "dhbName": "Capital and Coast",
+        "firstDoses": 247213,
+        "firstDosesPercentage": 0.91,
+        "firstDosesTo90Percent": 0,
+        "secondDoses": 205103,
+        "secondDosesPercentage": 0.76,
+        "secondDosesTo90Percent": 38954,
+        "totalPopulation": 271174
+      },
+      {
+        "dhbName": "Hutt Valley",
+        "firstDoses": 112688,
+        "firstDosesPercentage": 0.87,
+        "firstDosesTo90Percent": 4527,
+        "secondDoses": 90348,
+        "secondDosesPercentage": 0.69,
+        "secondDosesTo90Percent": 26867,
+        "totalPopulation": 130239
+      },
+      {
+        "dhbName": "Wairarapa",
+        "firstDoses": 34777,
+        "firstDosesPercentage": 0.84,
+        "firstDosesTo90Percent": 2507,
+        "secondDoses": 28612,
+        "secondDosesPercentage": 0.69,
+        "secondDosesTo90Percent": 8672,
+        "totalPopulation": 41427
+      },
+      {
+        "dhbName": "Nelson Marlborough",
+        "firstDoses": 115274,
+        "firstDosesPercentage": 0.85,
+        "firstDosesTo90Percent": 6895,
+        "secondDoses": 99293,
+        "secondDosesPercentage": 0.73,
+        "secondDosesTo90Percent": 22876,
+        "totalPopulation": 135743
+      },
+      {
+        "dhbName": "West Coast",
+        "firstDoses": 21896,
+        "firstDosesPercentage": 0.78,
+        "firstDosesTo90Percent": 3219,
+        "secondDoses": 17459,
+        "secondDosesPercentage": 0.63,
+        "secondDosesTo90Percent": 7656,
+        "totalPopulation": 27906
+      },
+      {
+        "dhbName": "Canterbury",
+        "firstDoses": 426711,
+        "firstDosesPercentage": 0.88,
+        "firstDosesTo90Percent": 7890,
+        "secondDoses": 320705,
+        "secondDosesPercentage": 0.66,
+        "secondDosesTo90Percent": 113896,
+        "totalPopulation": 482890
+      },
+      {
+        "dhbName": "South Canterbury",
+        "firstDoses": 44237,
+        "firstDosesPercentage": 0.84,
+        "firstDosesTo90Percent": 3089,
+        "secondDoses": 36797,
+        "secondDosesPercentage": 0.7,
+        "secondDosesTo90Percent": 10529,
+        "totalPopulation": 52584
+      },
+      {
+        "dhbName": "Southern",
+        "firstDoses": 253136,
+        "firstDosesPercentage": 0.88,
+        "firstDosesTo90Percent": 6078,
+        "secondDoses": 211433,
+        "secondDosesPercentage": 0.73,
+        "secondDosesTo90Percent": 47780,
+        "totalPopulation": 288015
+      },
+      {
+        "dhbName": "Overseas / Unknown",
+        "firstDoses": 2032,
+        "firstDosesPercentage": 0.12,
+        "firstDosesTo90Percent": 13424,
+        "secondDoses": 1576,
+        "secondDosesPercentage": 0.09,
+        "secondDosesTo90Percent": 13880,
+        "totalPopulation": 17173
+      }
+    ],
+    "dataValidAsAtNzTimeIso": "2021-10-23T23:59:00.000+13:00"
+  }
+}

--- a/data/vaccineData/2021-10-24.json
+++ b/data/vaccineData/2021-10-24.json
@@ -1,5 +1,5 @@
 {
-  "metaData": {
+  "metadata": {
     "createdAtUtcTimeIso": "2021-11-07T05:46:24.788Z",
     "updatedAtUtcTimeIso": "2021-11-07T05:46:24.788Z"
   },

--- a/data/vaccineData/2021-10-24.json
+++ b/data/vaccineData/2021-10-24.json
@@ -1,0 +1,221 @@
+{
+  "metaData": {
+    "createdAtUtcTimeIso": "2021-11-07T05:46:24.788Z",
+    "updatedAtUtcTimeIso": "2021-11-07T05:46:24.788Z"
+  },
+  "data": {
+    "vaccinationsPerDhb": [
+      {
+        "dhbName": "Northland",
+        "firstDoses": 125366,
+        "firstDosesPercentage": 0.78,
+        "firstDosesTo90Percent": 19822,
+        "secondDoses": 99390,
+        "secondDosesPercentage": 0.62,
+        "secondDosesTo90Percent": 45798,
+        "totalPopulation": 161320
+      },
+      {
+        "dhbName": "Waitemata",
+        "firstDoses": 474876,
+        "firstDosesPercentage": 0.9,
+        "firstDosesTo90Percent": 0,
+        "secondDoses": 401992,
+        "secondDosesPercentage": 0.76,
+        "secondDosesTo90Percent": 71486,
+        "totalPopulation": 526087
+      },
+      {
+        "dhbName": "Auckland",
+        "firstDoses": 394775,
+        "firstDosesPercentage": 0.93,
+        "firstDosesTo90Percent": 0,
+        "secondDoses": 342646,
+        "secondDosesPercentage": 0.81,
+        "secondDosesTo90Percent": 38916,
+        "totalPopulation": 423958
+      },
+      {
+        "dhbName": "Counties Manukau",
+        "firstDoses": 422768,
+        "firstDosesPercentage": 0.88,
+        "firstDosesTo90Percent": 11728,
+        "secondDoses": 354096,
+        "secondDosesPercentage": 0.73,
+        "secondDosesTo90Percent": 80400,
+        "totalPopulation": 482773
+      },
+      {
+        "dhbName": "Waikato",
+        "firstDoses": 303569,
+        "firstDosesPercentage": 0.85,
+        "firstDosesTo90Percent": 17889,
+        "secondDoses": 243584,
+        "secondDosesPercentage": 0.68,
+        "secondDosesTo90Percent": 77874,
+        "totalPopulation": 357176
+      },
+      {
+        "dhbName": "Lakes",
+        "firstDoses": 74339,
+        "firstDosesPercentage": 0.79,
+        "firstDosesTo90Percent": 10638,
+        "secondDoses": 58126,
+        "secondDosesPercentage": 0.62,
+        "secondDosesTo90Percent": 26851,
+        "totalPopulation": 94419
+      },
+      {
+        "dhbName": "Bay of Plenty",
+        "firstDoses": 176973,
+        "firstDosesPercentage": 0.82,
+        "firstDosesTo90Percent": 18274,
+        "secondDoses": 135695,
+        "secondDosesPercentage": 0.63,
+        "secondDosesTo90Percent": 59552,
+        "totalPopulation": 216941
+      },
+      {
+        "dhbName": "Tairawhiti",
+        "firstDoses": 31934,
+        "firstDosesPercentage": 0.76,
+        "firstDosesTo90Percent": 5834,
+        "secondDoses": 25450,
+        "secondDosesPercentage": 0.61,
+        "secondDosesTo90Percent": 12318,
+        "totalPopulation": 41965
+      },
+      {
+        "dhbName": "Taranaki",
+        "firstDoses": 84213,
+        "firstDosesPercentage": 0.82,
+        "firstDosesTo90Percent": 7719,
+        "secondDoses": 63070,
+        "secondDosesPercentage": 0.62,
+        "secondDosesTo90Percent": 28862,
+        "totalPopulation": 102147
+      },
+      {
+        "dhbName": "Hawkes Bay",
+        "firstDoses": 120565,
+        "firstDosesPercentage": 0.83,
+        "firstDosesTo90Percent": 10449,
+        "secondDoses": 98167,
+        "secondDosesPercentage": 0.67,
+        "secondDosesTo90Percent": 32847,
+        "totalPopulation": 145571
+      },
+      {
+        "dhbName": "MidCentral",
+        "firstDoses": 128938,
+        "firstDosesPercentage": 0.85,
+        "firstDosesTo90Percent": 8134,
+        "secondDoses": 104765,
+        "secondDosesPercentage": 0.69,
+        "secondDosesTo90Percent": 32307,
+        "totalPopulation": 152302
+      },
+      {
+        "dhbName": "Whanganui",
+        "firstDoses": 45245,
+        "firstDosesPercentage": 0.79,
+        "firstDosesTo90Percent": 6277,
+        "secondDoses": 37431,
+        "secondDosesPercentage": 0.65,
+        "secondDosesTo90Percent": 14091,
+        "totalPopulation": 57247
+      },
+      {
+        "dhbName": "Capital and Coast",
+        "firstDoses": 247361,
+        "firstDosesPercentage": 0.91,
+        "firstDosesTo90Percent": 0,
+        "secondDoses": 205814,
+        "secondDosesPercentage": 0.76,
+        "secondDosesTo90Percent": 38243,
+        "totalPopulation": 271174
+      },
+      {
+        "dhbName": "Hutt Valley",
+        "firstDoses": 112876,
+        "firstDosesPercentage": 0.87,
+        "firstDosesTo90Percent": 4339,
+        "secondDoses": 90958,
+        "secondDosesPercentage": 0.7,
+        "secondDosesTo90Percent": 26257,
+        "totalPopulation": 130239
+      },
+      {
+        "dhbName": "Wairarapa",
+        "firstDoses": 34797,
+        "firstDosesPercentage": 0.84,
+        "firstDosesTo90Percent": 2487,
+        "secondDoses": 28628,
+        "secondDosesPercentage": 0.69,
+        "secondDosesTo90Percent": 8656,
+        "totalPopulation": 41427
+      },
+      {
+        "dhbName": "Nelson Marlborough",
+        "firstDoses": 115507,
+        "firstDosesPercentage": 0.85,
+        "firstDosesTo90Percent": 6662,
+        "secondDoses": 99502,
+        "secondDosesPercentage": 0.73,
+        "secondDosesTo90Percent": 22667,
+        "totalPopulation": 135743
+      },
+      {
+        "dhbName": "West Coast",
+        "firstDoses": 21906,
+        "firstDosesPercentage": 0.78,
+        "firstDosesTo90Percent": 3209,
+        "secondDoses": 17464,
+        "secondDosesPercentage": 0.63,
+        "secondDosesTo90Percent": 7651,
+        "totalPopulation": 27906
+      },
+      {
+        "dhbName": "Canterbury",
+        "firstDoses": 427556,
+        "firstDosesPercentage": 0.89,
+        "firstDosesTo90Percent": 7045,
+        "secondDoses": 322775,
+        "secondDosesPercentage": 0.67,
+        "secondDosesTo90Percent": 111826,
+        "totalPopulation": 482890
+      },
+      {
+        "dhbName": "South Canterbury",
+        "firstDoses": 44294,
+        "firstDosesPercentage": 0.84,
+        "firstDosesTo90Percent": 3032,
+        "secondDoses": 36940,
+        "secondDosesPercentage": 0.7,
+        "secondDosesTo90Percent": 10386,
+        "totalPopulation": 52584
+      },
+      {
+        "dhbName": "Southern",
+        "firstDoses": 253461,
+        "firstDosesPercentage": 0.88,
+        "firstDosesTo90Percent": 5752,
+        "secondDoses": 212084,
+        "secondDosesPercentage": 0.74,
+        "secondDosesTo90Percent": 47130,
+        "totalPopulation": 288015
+      },
+      {
+        "dhbName": "Overseas / Unknown",
+        "firstDoses": 2018,
+        "firstDosesPercentage": 0.12,
+        "firstDosesTo90Percent": 13438,
+        "secondDoses": 1586,
+        "secondDosesPercentage": 0.09,
+        "secondDosesTo90Percent": 13870,
+        "totalPopulation": 17173
+      }
+    ],
+    "dataValidAsAtNzTimeIso": "2021-10-24T23:59:00.000+13:00"
+  }
+}

--- a/data/vaccineData/2021-10-25.json
+++ b/data/vaccineData/2021-10-25.json
@@ -1,0 +1,221 @@
+{
+  "metaData": {
+    "createdAtUtcTimeIso": "2021-11-07T05:46:24.788Z",
+    "updatedAtUtcTimeIso": "2021-11-07T05:46:24.788Z"
+  },
+  "data": {
+    "vaccinationsPerDhb": [
+      {
+        "dhbName": "Northland",
+        "firstDoses": 125549,
+        "firstDosesPercentage": 0.78,
+        "firstDosesTo90Percent": 19639,
+        "secondDoses": 99525,
+        "secondDosesPercentage": 0.62,
+        "secondDosesTo90Percent": 45663,
+        "totalPopulation": 161320
+      },
+      {
+        "dhbName": "Waitemata",
+        "firstDoses": 475288,
+        "firstDosesPercentage": 0.9,
+        "firstDosesTo90Percent": 0,
+        "secondDoses": 403225,
+        "secondDosesPercentage": 0.77,
+        "secondDosesTo90Percent": 70253,
+        "totalPopulation": 526087
+      },
+      {
+        "dhbName": "Auckland",
+        "firstDoses": 395070,
+        "firstDosesPercentage": 0.93,
+        "firstDosesTo90Percent": 0,
+        "secondDoses": 343631,
+        "secondDosesPercentage": 0.81,
+        "secondDosesTo90Percent": 37931,
+        "totalPopulation": 423958
+      },
+      {
+        "dhbName": "Counties Manukau",
+        "firstDoses": 423476,
+        "firstDosesPercentage": 0.88,
+        "firstDosesTo90Percent": 11020,
+        "secondDoses": 355419,
+        "secondDosesPercentage": 0.74,
+        "secondDosesTo90Percent": 79077,
+        "totalPopulation": 482773
+      },
+      {
+        "dhbName": "Waikato",
+        "firstDoses": 303882,
+        "firstDosesPercentage": 0.85,
+        "firstDosesTo90Percent": 17576,
+        "secondDoses": 243990,
+        "secondDosesPercentage": 0.68,
+        "secondDosesTo90Percent": 77468,
+        "totalPopulation": 357176
+      },
+      {
+        "dhbName": "Lakes",
+        "firstDoses": 74378,
+        "firstDosesPercentage": 0.79,
+        "firstDosesTo90Percent": 10599,
+        "secondDoses": 58176,
+        "secondDosesPercentage": 0.62,
+        "secondDosesTo90Percent": 26801,
+        "totalPopulation": 94419
+      },
+      {
+        "dhbName": "Bay of Plenty",
+        "firstDoses": 177197,
+        "firstDosesPercentage": 0.82,
+        "firstDosesTo90Percent": 18050,
+        "secondDoses": 136449,
+        "secondDosesPercentage": 0.63,
+        "secondDosesTo90Percent": 58798,
+        "totalPopulation": 216941
+      },
+      {
+        "dhbName": "Tairawhiti",
+        "firstDoses": 31992,
+        "firstDosesPercentage": 0.76,
+        "firstDosesTo90Percent": 5776,
+        "secondDoses": 25536,
+        "secondDosesPercentage": 0.61,
+        "secondDosesTo90Percent": 12232,
+        "totalPopulation": 41965
+      },
+      {
+        "dhbName": "Taranaki",
+        "firstDoses": 84318,
+        "firstDosesPercentage": 0.83,
+        "firstDosesTo90Percent": 7614,
+        "secondDoses": 63283,
+        "secondDosesPercentage": 0.62,
+        "secondDosesTo90Percent": 28649,
+        "totalPopulation": 102147
+      },
+      {
+        "dhbName": "Hawkes Bay",
+        "firstDoses": 120676,
+        "firstDosesPercentage": 0.83,
+        "firstDosesTo90Percent": 10338,
+        "secondDoses": 98275,
+        "secondDosesPercentage": 0.68,
+        "secondDosesTo90Percent": 32739,
+        "totalPopulation": 145571
+      },
+      {
+        "dhbName": "MidCentral",
+        "firstDoses": 129085,
+        "firstDosesPercentage": 0.85,
+        "firstDosesTo90Percent": 7987,
+        "secondDoses": 104889,
+        "secondDosesPercentage": 0.69,
+        "secondDosesTo90Percent": 32183,
+        "totalPopulation": 152302
+      },
+      {
+        "dhbName": "Whanganui",
+        "firstDoses": 45281,
+        "firstDosesPercentage": 0.79,
+        "firstDosesTo90Percent": 6241,
+        "secondDoses": 37454,
+        "secondDosesPercentage": 0.65,
+        "secondDosesTo90Percent": 14068,
+        "totalPopulation": 57247
+      },
+      {
+        "dhbName": "Capital and Coast",
+        "firstDoses": 247452,
+        "firstDosesPercentage": 0.91,
+        "firstDosesTo90Percent": 0,
+        "secondDoses": 206021,
+        "secondDosesPercentage": 0.76,
+        "secondDosesTo90Percent": 38036,
+        "totalPopulation": 271174
+      },
+      {
+        "dhbName": "Hutt Valley",
+        "firstDoses": 112960,
+        "firstDosesPercentage": 0.87,
+        "firstDosesTo90Percent": 4255,
+        "secondDoses": 91128,
+        "secondDosesPercentage": 0.7,
+        "secondDosesTo90Percent": 26087,
+        "totalPopulation": 130239
+      },
+      {
+        "dhbName": "Wairarapa",
+        "firstDoses": 34817,
+        "firstDosesPercentage": 0.84,
+        "firstDosesTo90Percent": 2467,
+        "secondDoses": 28656,
+        "secondDosesPercentage": 0.69,
+        "secondDosesTo90Percent": 8628,
+        "totalPopulation": 41427
+      },
+      {
+        "dhbName": "Nelson Marlborough",
+        "firstDoses": 115720,
+        "firstDosesPercentage": 0.85,
+        "firstDosesTo90Percent": 6449,
+        "secondDoses": 99728,
+        "secondDosesPercentage": 0.73,
+        "secondDosesTo90Percent": 22441,
+        "totalPopulation": 135743
+      },
+      {
+        "dhbName": "West Coast",
+        "firstDoses": 21911,
+        "firstDosesPercentage": 0.79,
+        "firstDosesTo90Percent": 3204,
+        "secondDoses": 17471,
+        "secondDosesPercentage": 0.63,
+        "secondDosesTo90Percent": 7644,
+        "totalPopulation": 27906
+      },
+      {
+        "dhbName": "Canterbury",
+        "firstDoses": 427948,
+        "firstDosesPercentage": 0.89,
+        "firstDosesTo90Percent": 6653,
+        "secondDoses": 323698,
+        "secondDosesPercentage": 0.67,
+        "secondDosesTo90Percent": 110903,
+        "totalPopulation": 482890
+      },
+      {
+        "dhbName": "South Canterbury",
+        "firstDoses": 44293,
+        "firstDosesPercentage": 0.84,
+        "firstDosesTo90Percent": 3033,
+        "secondDoses": 36942,
+        "secondDosesPercentage": 0.7,
+        "secondDosesTo90Percent": 10384,
+        "totalPopulation": 52584
+      },
+      {
+        "dhbName": "Southern",
+        "firstDoses": 253558,
+        "firstDosesPercentage": 0.88,
+        "firstDosesTo90Percent": 5656,
+        "secondDoses": 212301,
+        "secondDosesPercentage": 0.74,
+        "secondDosesTo90Percent": 46912,
+        "totalPopulation": 288015
+      },
+      {
+        "dhbName": "Overseas / Unknown",
+        "firstDoses": 2018,
+        "firstDosesPercentage": 0.12,
+        "firstDosesTo90Percent": 13438,
+        "secondDoses": 1592,
+        "secondDosesPercentage": 0.09,
+        "secondDosesTo90Percent": 13864,
+        "totalPopulation": 17173
+      }
+    ],
+    "dataValidAsAtNzTimeIso": "2021-10-25T23:59:00.000+13:00"
+  }
+}

--- a/data/vaccineData/2021-10-25.json
+++ b/data/vaccineData/2021-10-25.json
@@ -1,5 +1,5 @@
 {
-  "metaData": {
+  "metadata": {
     "createdAtUtcTimeIso": "2021-11-07T05:46:24.788Z",
     "updatedAtUtcTimeIso": "2021-11-07T05:46:24.788Z"
   },

--- a/data/vaccineData/2021-10-26.json
+++ b/data/vaccineData/2021-10-26.json
@@ -1,0 +1,221 @@
+{
+  "metaData": {
+    "createdAtUtcTimeIso": "2021-11-07T05:46:24.786Z",
+    "updatedAtUtcTimeIso": "2021-11-07T05:46:24.786Z"
+  },
+  "data": {
+    "vaccinationsPerDhb": [
+      {
+        "dhbName": "Northland",
+        "firstDoses": 126113,
+        "firstDosesPercentage": 0.78,
+        "firstDosesTo90Percent": 19075,
+        "secondDoses": 100405,
+        "secondDosesPercentage": 0.62,
+        "secondDosesTo90Percent": 44783,
+        "totalPopulation": 161320
+      },
+      {
+        "dhbName": "Waitemata",
+        "firstDoses": 476318,
+        "firstDosesPercentage": 0.91,
+        "firstDosesTo90Percent": 0,
+        "secondDoses": 407232,
+        "secondDosesPercentage": 0.77,
+        "secondDosesTo90Percent": 66246,
+        "totalPopulation": 526087
+      },
+      {
+        "dhbName": "Auckland",
+        "firstDoses": 395771,
+        "firstDosesPercentage": 0.93,
+        "firstDosesTo90Percent": 0,
+        "secondDoses": 346533,
+        "secondDosesPercentage": 0.82,
+        "secondDosesTo90Percent": 35029,
+        "totalPopulation": 423958
+      },
+      {
+        "dhbName": "Counties Manukau",
+        "firstDoses": 424592,
+        "firstDosesPercentage": 0.88,
+        "firstDosesTo90Percent": 9904,
+        "secondDoses": 358286,
+        "secondDosesPercentage": 0.74,
+        "secondDosesTo90Percent": 76210,
+        "totalPopulation": 482773
+      },
+      {
+        "dhbName": "Waikato",
+        "firstDoses": 305128,
+        "firstDosesPercentage": 0.85,
+        "firstDosesTo90Percent": 16330,
+        "secondDoses": 246417,
+        "secondDosesPercentage": 0.69,
+        "secondDosesTo90Percent": 75041,
+        "totalPopulation": 357176
+      },
+      {
+        "dhbName": "Lakes",
+        "firstDoses": 74708,
+        "firstDosesPercentage": 0.79,
+        "firstDosesTo90Percent": 10269,
+        "secondDoses": 58905,
+        "secondDosesPercentage": 0.62,
+        "secondDosesTo90Percent": 26072,
+        "totalPopulation": 94419
+      },
+      {
+        "dhbName": "Bay of Plenty",
+        "firstDoses": 177852,
+        "firstDosesPercentage": 0.82,
+        "firstDosesTo90Percent": 17395,
+        "secondDoses": 138563,
+        "secondDosesPercentage": 0.64,
+        "secondDosesTo90Percent": 56684,
+        "totalPopulation": 216941
+      },
+      {
+        "dhbName": "Tairawhiti",
+        "firstDoses": 32115,
+        "firstDosesPercentage": 0.77,
+        "firstDosesTo90Percent": 5654,
+        "secondDoses": 25714,
+        "secondDosesPercentage": 0.61,
+        "secondDosesTo90Percent": 12054,
+        "totalPopulation": 41965
+      },
+      {
+        "dhbName": "Taranaki",
+        "firstDoses": 84620,
+        "firstDosesPercentage": 0.83,
+        "firstDosesTo90Percent": 7312,
+        "secondDoses": 63991,
+        "secondDosesPercentage": 0.63,
+        "secondDosesTo90Percent": 27941,
+        "totalPopulation": 102147
+      },
+      {
+        "dhbName": "Hawkes Bay",
+        "firstDoses": 120998,
+        "firstDosesPercentage": 0.83,
+        "firstDosesTo90Percent": 10016,
+        "secondDoses": 99150,
+        "secondDosesPercentage": 0.68,
+        "secondDosesTo90Percent": 31864,
+        "totalPopulation": 145571
+      },
+      {
+        "dhbName": "MidCentral",
+        "firstDoses": 129489,
+        "firstDosesPercentage": 0.85,
+        "firstDosesTo90Percent": 7583,
+        "secondDoses": 105954,
+        "secondDosesPercentage": 0.7,
+        "secondDosesTo90Percent": 31118,
+        "totalPopulation": 152302
+      },
+      {
+        "dhbName": "Whanganui",
+        "firstDoses": 45437,
+        "firstDosesPercentage": 0.79,
+        "firstDosesTo90Percent": 6085,
+        "secondDoses": 37709,
+        "secondDosesPercentage": 0.66,
+        "secondDosesTo90Percent": 13813,
+        "totalPopulation": 57247
+      },
+      {
+        "dhbName": "Capital and Coast",
+        "firstDoses": 247969,
+        "firstDosesPercentage": 0.91,
+        "firstDosesTo90Percent": 0,
+        "secondDoses": 208626,
+        "secondDosesPercentage": 0.77,
+        "secondDosesTo90Percent": 35431,
+        "totalPopulation": 271174
+      },
+      {
+        "dhbName": "Hutt Valley",
+        "firstDoses": 113246,
+        "firstDosesPercentage": 0.87,
+        "firstDosesTo90Percent": 3969,
+        "secondDoses": 92134,
+        "secondDosesPercentage": 0.71,
+        "secondDosesTo90Percent": 25081,
+        "totalPopulation": 130239
+      },
+      {
+        "dhbName": "Wairarapa",
+        "firstDoses": 34941,
+        "firstDosesPercentage": 0.84,
+        "firstDosesTo90Percent": 2343,
+        "secondDoses": 28946,
+        "secondDosesPercentage": 0.7,
+        "secondDosesTo90Percent": 8338,
+        "totalPopulation": 41427
+      },
+      {
+        "dhbName": "Nelson Marlborough",
+        "firstDoses": 116158,
+        "firstDosesPercentage": 0.86,
+        "firstDosesTo90Percent": 6011,
+        "secondDoses": 100452,
+        "secondDosesPercentage": 0.74,
+        "secondDosesTo90Percent": 21717,
+        "totalPopulation": 135743
+      },
+      {
+        "dhbName": "West Coast",
+        "firstDoses": 22120,
+        "firstDosesPercentage": 0.79,
+        "firstDosesTo90Percent": 2995,
+        "secondDoses": 17733,
+        "secondDosesPercentage": 0.64,
+        "secondDosesTo90Percent": 7382,
+        "totalPopulation": 27906
+      },
+      {
+        "dhbName": "Canterbury",
+        "firstDoses": 429514,
+        "firstDosesPercentage": 0.89,
+        "firstDosesTo90Percent": 5087,
+        "secondDoses": 328695,
+        "secondDosesPercentage": 0.68,
+        "secondDosesTo90Percent": 105906,
+        "totalPopulation": 482890
+      },
+      {
+        "dhbName": "South Canterbury",
+        "firstDoses": 44441,
+        "firstDosesPercentage": 0.85,
+        "firstDosesTo90Percent": 2885,
+        "secondDoses": 37256,
+        "secondDosesPercentage": 0.71,
+        "secondDosesTo90Percent": 10070,
+        "totalPopulation": 52584
+      },
+      {
+        "dhbName": "Southern",
+        "firstDoses": 254414,
+        "firstDosesPercentage": 0.88,
+        "firstDosesTo90Percent": 4800,
+        "secondDoses": 214523,
+        "secondDosesPercentage": 0.74,
+        "secondDosesTo90Percent": 44690,
+        "totalPopulation": 288015
+      },
+      {
+        "dhbName": "Overseas / Unknown",
+        "firstDoses": 2026,
+        "firstDosesPercentage": 0.12,
+        "firstDosesTo90Percent": 13430,
+        "secondDoses": 1606,
+        "secondDosesPercentage": 0.09,
+        "secondDosesTo90Percent": 13850,
+        "totalPopulation": 17173
+      }
+    ],
+    "dataValidAsAtNzTimeIso": "2021-10-26T23:59:00.000+13:00"
+  }
+}

--- a/data/vaccineData/2021-10-26.json
+++ b/data/vaccineData/2021-10-26.json
@@ -1,5 +1,5 @@
 {
-  "metaData": {
+  "metadata": {
     "createdAtUtcTimeIso": "2021-11-07T05:46:24.786Z",
     "updatedAtUtcTimeIso": "2021-11-07T05:46:24.786Z"
   },

--- a/data/vaccineData/2021-10-27.json
+++ b/data/vaccineData/2021-10-27.json
@@ -1,5 +1,5 @@
 {
-  "metaData": {
+  "metadata": {
     "createdAtUtcTimeIso": "2021-11-07T05:46:24.786Z",
     "updatedAtUtcTimeIso": "2021-11-07T05:46:24.786Z"
   },

--- a/data/vaccineData/2021-10-27.json
+++ b/data/vaccineData/2021-10-27.json
@@ -1,0 +1,221 @@
+{
+  "metaData": {
+    "createdAtUtcTimeIso": "2021-11-07T05:46:24.786Z",
+    "updatedAtUtcTimeIso": "2021-11-07T05:46:24.786Z"
+  },
+  "data": {
+    "vaccinationsPerDhb": [
+      {
+        "dhbName": "Northland",
+        "firstDoses": 126580,
+        "firstDosesPercentage": 0.78,
+        "firstDosesTo90Percent": 18608,
+        "secondDoses": 101394,
+        "secondDosesPercentage": 0.63,
+        "secondDosesTo90Percent": 43794,
+        "totalPopulation": 161320
+      },
+      {
+        "dhbName": "Waitemata",
+        "firstDoses": 477145,
+        "firstDosesPercentage": 0.91,
+        "firstDosesTo90Percent": 0,
+        "secondDoses": 410477,
+        "secondDosesPercentage": 0.78,
+        "secondDosesTo90Percent": 63001,
+        "totalPopulation": 526087
+      },
+      {
+        "dhbName": "Auckland",
+        "firstDoses": 396425,
+        "firstDosesPercentage": 0.94,
+        "firstDosesTo90Percent": 0,
+        "secondDoses": 348980,
+        "secondDosesPercentage": 0.82,
+        "secondDosesTo90Percent": 32582,
+        "totalPopulation": 423958
+      },
+      {
+        "dhbName": "Counties Manukau",
+        "firstDoses": 425796,
+        "firstDosesPercentage": 0.88,
+        "firstDosesTo90Percent": 8700,
+        "secondDoses": 360825,
+        "secondDosesPercentage": 0.75,
+        "secondDosesTo90Percent": 73671,
+        "totalPopulation": 482773
+      },
+      {
+        "dhbName": "Waikato",
+        "firstDoses": 306361,
+        "firstDosesPercentage": 0.86,
+        "firstDosesTo90Percent": 15097,
+        "secondDoses": 248743,
+        "secondDosesPercentage": 0.7,
+        "secondDosesTo90Percent": 72715,
+        "totalPopulation": 357176
+      },
+      {
+        "dhbName": "Lakes",
+        "firstDoses": 75016,
+        "firstDosesPercentage": 0.79,
+        "firstDosesTo90Percent": 9961,
+        "secondDoses": 59563,
+        "secondDosesPercentage": 0.63,
+        "secondDosesTo90Percent": 25414,
+        "totalPopulation": 94419
+      },
+      {
+        "dhbName": "Bay of Plenty",
+        "firstDoses": 178418,
+        "firstDosesPercentage": 0.82,
+        "firstDosesTo90Percent": 16829,
+        "secondDoses": 140261,
+        "secondDosesPercentage": 0.65,
+        "secondDosesTo90Percent": 54986,
+        "totalPopulation": 216941
+      },
+      {
+        "dhbName": "Tairawhiti",
+        "firstDoses": 32294,
+        "firstDosesPercentage": 0.77,
+        "firstDosesTo90Percent": 5474,
+        "secondDoses": 25934,
+        "secondDosesPercentage": 0.62,
+        "secondDosesTo90Percent": 11834,
+        "totalPopulation": 41965
+      },
+      {
+        "dhbName": "Taranaki",
+        "firstDoses": 84995,
+        "firstDosesPercentage": 0.83,
+        "firstDosesTo90Percent": 6937,
+        "secondDoses": 64699,
+        "secondDosesPercentage": 0.63,
+        "secondDosesTo90Percent": 27233,
+        "totalPopulation": 102147
+      },
+      {
+        "dhbName": "Hawkes Bay",
+        "firstDoses": 121407,
+        "firstDosesPercentage": 0.83,
+        "firstDosesTo90Percent": 9607,
+        "secondDoses": 100094,
+        "secondDosesPercentage": 0.69,
+        "secondDosesTo90Percent": 30920,
+        "totalPopulation": 145571
+      },
+      {
+        "dhbName": "MidCentral",
+        "firstDoses": 130001,
+        "firstDosesPercentage": 0.85,
+        "firstDosesTo90Percent": 7071,
+        "secondDoses": 107033,
+        "secondDosesPercentage": 0.7,
+        "secondDosesTo90Percent": 30039,
+        "totalPopulation": 152302
+      },
+      {
+        "dhbName": "Whanganui",
+        "firstDoses": 45595,
+        "firstDosesPercentage": 0.8,
+        "firstDosesTo90Percent": 5927,
+        "secondDoses": 37894,
+        "secondDosesPercentage": 0.66,
+        "secondDosesTo90Percent": 13628,
+        "totalPopulation": 57247
+      },
+      {
+        "dhbName": "Capital and Coast",
+        "firstDoses": 248425,
+        "firstDosesPercentage": 0.92,
+        "firstDosesTo90Percent": 0,
+        "secondDoses": 210931,
+        "secondDosesPercentage": 0.78,
+        "secondDosesTo90Percent": 33126,
+        "totalPopulation": 271174
+      },
+      {
+        "dhbName": "Hutt Valley",
+        "firstDoses": 113578,
+        "firstDosesPercentage": 0.87,
+        "firstDosesTo90Percent": 3637,
+        "secondDoses": 93251,
+        "secondDosesPercentage": 0.72,
+        "secondDosesTo90Percent": 23964,
+        "totalPopulation": 130239
+      },
+      {
+        "dhbName": "Wairarapa",
+        "firstDoses": 35045,
+        "firstDosesPercentage": 0.85,
+        "firstDosesTo90Percent": 2239,
+        "secondDoses": 29159,
+        "secondDosesPercentage": 0.7,
+        "secondDosesTo90Percent": 8125,
+        "totalPopulation": 41427
+      },
+      {
+        "dhbName": "Nelson Marlborough",
+        "firstDoses": 116601,
+        "firstDosesPercentage": 0.86,
+        "firstDosesTo90Percent": 5568,
+        "secondDoses": 100969,
+        "secondDosesPercentage": 0.74,
+        "secondDosesTo90Percent": 21200,
+        "totalPopulation": 135743
+      },
+      {
+        "dhbName": "West Coast",
+        "firstDoses": 22281,
+        "firstDosesPercentage": 0.8,
+        "firstDosesTo90Percent": 2834,
+        "secondDoses": 17917,
+        "secondDosesPercentage": 0.64,
+        "secondDosesTo90Percent": 7198,
+        "totalPopulation": 27906
+      },
+      {
+        "dhbName": "Canterbury",
+        "firstDoses": 431211,
+        "firstDosesPercentage": 0.89,
+        "firstDosesTo90Percent": 3390,
+        "secondDoses": 333247,
+        "secondDosesPercentage": 0.69,
+        "secondDosesTo90Percent": 101354,
+        "totalPopulation": 482890
+      },
+      {
+        "dhbName": "South Canterbury",
+        "firstDoses": 44649,
+        "firstDosesPercentage": 0.85,
+        "firstDosesTo90Percent": 2677,
+        "secondDoses": 37775,
+        "secondDosesPercentage": 0.72,
+        "secondDosesTo90Percent": 9551,
+        "totalPopulation": 52584
+      },
+      {
+        "dhbName": "Southern",
+        "firstDoses": 255355,
+        "firstDosesPercentage": 0.89,
+        "firstDosesTo90Percent": 3858,
+        "secondDoses": 216761,
+        "secondDosesPercentage": 0.75,
+        "secondDosesTo90Percent": 42452,
+        "totalPopulation": 288015
+      },
+      {
+        "dhbName": "Overseas / Unknown",
+        "firstDoses": 2038,
+        "firstDosesPercentage": 0.12,
+        "firstDosesTo90Percent": 13418,
+        "secondDoses": 1617,
+        "secondDosesPercentage": 0.09,
+        "secondDosesTo90Percent": 13839,
+        "totalPopulation": 17173
+      }
+    ],
+    "dataValidAsAtNzTimeIso": "2021-10-27T23:59:00.000+13:00"
+  }
+}

--- a/data/vaccineData/2021-10-28.json
+++ b/data/vaccineData/2021-10-28.json
@@ -1,215 +1,217 @@
 {
-  "vaccinationsPerDhb": [
-    {
-      "dhbName": "Northland",
-      "firstDoses": 126991,
-      "firstDosesPercentage": 0.79,
-      "firstDosesTo90Percent": 18197,
-      "secondDoses": 102266,
-      "secondDosesPercentage": 0.63,
-      "secondDosesTo90Percent": 42922,
-      "totalPopulation": 161320
-    },
-    {
-      "dhbName": "Waitemata",
-      "firstDoses": 477971,
-      "firstDosesPercentage": 0.91,
-      "firstDosesTo90Percent": 0,
-      "secondDoses": 413561,
-      "secondDosesPercentage": 0.79,
-      "secondDosesTo90Percent": 59917,
-      "totalPopulation": 526087
-    },
-    {
-      "dhbName": "Auckland",
-      "firstDoses": 397001,
-      "firstDosesPercentage": 0.94,
-      "firstDosesTo90Percent": 0,
-      "secondDoses": 351361,
-      "secondDosesPercentage": 0.83,
-      "secondDosesTo90Percent": 30201,
-      "totalPopulation": 423958
-    },
-    {
-      "dhbName": "Counties Manukau",
-      "firstDoses": 426789,
-      "firstDosesPercentage": 0.88,
-      "firstDosesTo90Percent": 7707,
-      "secondDoses": 363479,
-      "secondDosesPercentage": 0.75,
-      "secondDosesTo90Percent": 71017,
-      "totalPopulation": 482773
-    },
-    {
-      "dhbName": "Waikato",
-      "firstDoses": 307533,
-      "firstDosesPercentage": 0.86,
-      "firstDosesTo90Percent": 13925,
-      "secondDoses": 251626,
-      "secondDosesPercentage": 0.7,
-      "secondDosesTo90Percent": 69832,
-      "totalPopulation": 357176
-    },
-    {
-      "dhbName": "Lakes",
-      "firstDoses": 75347,
-      "firstDosesPercentage": 0.8,
-      "firstDosesTo90Percent": 9630,
-      "secondDoses": 60243,
-      "secondDosesPercentage": 0.64,
-      "secondDosesTo90Percent": 24734,
-      "totalPopulation": 94419
-    },
-    {
-      "dhbName": "Bay of Plenty",
-      "firstDoses": 178935,
-      "firstDosesPercentage": 0.82,
-      "firstDosesTo90Percent": 16312,
-      "secondDoses": 141800,
-      "secondDosesPercentage": 0.65,
-      "secondDosesTo90Percent": 53447,
-      "totalPopulation": 216941
-    },
-    {
-      "dhbName": "Tairawhiti",
-      "firstDoses": 32492,
-      "firstDosesPercentage": 0.77,
-      "firstDosesTo90Percent": 5276,
-      "secondDoses": 26146,
-      "secondDosesPercentage": 0.62,
-      "secondDosesTo90Percent": 11622,
-      "totalPopulation": 41965
-    },
-    {
-      "dhbName": "Taranaki",
-      "firstDoses": 85347,
-      "firstDosesPercentage": 0.84,
-      "firstDosesTo90Percent": 6585,
-      "secondDoses": 65454,
-      "secondDosesPercentage": 0.64,
-      "secondDosesTo90Percent": 26478,
-      "totalPopulation": 102147
-    },
-    {
-      "dhbName": "Hawkes Bay",
-      "firstDoses": 121965,
-      "firstDosesPercentage": 0.84,
-      "firstDosesTo90Percent": 9049,
-      "secondDoses": 101011,
-      "secondDosesPercentage": 0.69,
-      "secondDosesTo90Percent": 30003,
-      "totalPopulation": 145571
-    },
-    {
-      "dhbName": "MidCentral",
-      "firstDoses": 130464,
-      "firstDosesPercentage": 0.86,
-      "firstDosesTo90Percent": 6608,
-      "secondDoses": 107890,
-      "secondDosesPercentage": 0.71,
-      "secondDosesTo90Percent": 29182,
-      "totalPopulation": 152302
-    },
-    {
-      "dhbName": "Whanganui",
-      "firstDoses": 45804,
-      "firstDosesPercentage": 0.8,
-      "firstDosesTo90Percent": 5718,
-      "secondDoses": 38369,
-      "secondDosesPercentage": 0.67,
-      "secondDosesTo90Percent": 13153,
-      "totalPopulation": 57247
-    },
-    {
-      "dhbName": "Capital and Coast",
-      "firstDoses": 248949,
-      "firstDosesPercentage": 0.92,
-      "firstDosesTo90Percent": 0,
-      "secondDoses": 213148,
-      "secondDosesPercentage": 0.79,
-      "secondDosesTo90Percent": 30909,
-      "totalPopulation": 271174
-    },
-    {
-      "dhbName": "Hutt Valley",
-      "firstDoses": 113951,
-      "firstDosesPercentage": 0.87,
-      "firstDosesTo90Percent": 3264,
-      "secondDoses": 94440,
-      "secondDosesPercentage": 0.73,
-      "secondDosesTo90Percent": 22775,
-      "totalPopulation": 130239
-    },
-    {
-      "dhbName": "Wairarapa",
-      "firstDoses": 35155,
-      "firstDosesPercentage": 0.85,
-      "firstDosesTo90Percent": 2129,
-      "secondDoses": 29380,
-      "secondDosesPercentage": 0.71,
-      "secondDosesTo90Percent": 7904,
-      "totalPopulation": 41427
-    },
-    {
-      "dhbName": "Nelson Marlborough",
-      "firstDoses": 116995,
-      "firstDosesPercentage": 0.86,
-      "firstDosesTo90Percent": 5174,
-      "secondDoses": 101527,
-      "secondDosesPercentage": 0.75,
-      "secondDosesTo90Percent": 20642,
-      "totalPopulation": 135743
-    },
-    {
-      "dhbName": "West Coast",
-      "firstDoses": 22411,
-      "firstDosesPercentage": 0.8,
-      "firstDosesTo90Percent": 2704,
-      "secondDoses": 18122,
-      "secondDosesPercentage": 0.65,
-      "secondDosesTo90Percent": 6993,
-      "totalPopulation": 27906
-    },
-    {
-      "dhbName": "Canterbury",
-      "firstDoses": 434574,
-      "firstDosesPercentage": 0.9,
-      "firstDosesTo90Percent": 27,
-      "secondDoses": 340807,
-      "secondDosesPercentage": 0.71,
-      "secondDosesTo90Percent": 93794,
-      "totalPopulation": 482890
-    },
-    {
-      "dhbName": "South Canterbury",
-      "firstDoses": 44901,
-      "firstDosesPercentage": 0.85,
-      "firstDosesTo90Percent": 2425,
-      "secondDoses": 38211,
-      "secondDosesPercentage": 0.73,
-      "secondDosesTo90Percent": 9115,
-      "totalPopulation": 52584
-    },
-    {
-      "dhbName": "Southern",
-      "firstDoses": 256602,
-      "firstDosesPercentage": 0.89,
-      "firstDosesTo90Percent": 2612,
-      "secondDoses": 219241,
-      "secondDosesPercentage": 0.76,
-      "secondDosesTo90Percent": 39972,
-      "totalPopulation": 288015
-    },
-    {
-      "dhbName": "Overseas / Unknown",
-      "firstDoses": 2036,
-      "firstDosesPercentage": 0.12,
-      "firstDosesTo90Percent": 13420,
-      "secondDoses": 1635,
-      "secondDosesPercentage": 0.1,
-      "secondDosesTo90Percent": 13821,
-      "totalPopulation": 17173
-    }
-  ],
-  "dataValidAsAtNzTimeIso": "2021-10-28T23:59:00.000+13:00"
+  "data": {
+    "vaccinationsPerDhb": [
+      {
+        "dhbName": "Northland",
+        "firstDoses": 126991,
+        "firstDosesPercentage": 0.79,
+        "firstDosesTo90Percent": 18197,
+        "secondDoses": 102266,
+        "secondDosesPercentage": 0.63,
+        "secondDosesTo90Percent": 42922,
+        "totalPopulation": 161320
+      },
+      {
+        "dhbName": "Waitemata",
+        "firstDoses": 477971,
+        "firstDosesPercentage": 0.91,
+        "firstDosesTo90Percent": 0,
+        "secondDoses": 413561,
+        "secondDosesPercentage": 0.79,
+        "secondDosesTo90Percent": 59917,
+        "totalPopulation": 526087
+      },
+      {
+        "dhbName": "Auckland",
+        "firstDoses": 397001,
+        "firstDosesPercentage": 0.94,
+        "firstDosesTo90Percent": 0,
+        "secondDoses": 351361,
+        "secondDosesPercentage": 0.83,
+        "secondDosesTo90Percent": 30201,
+        "totalPopulation": 423958
+      },
+      {
+        "dhbName": "Counties Manukau",
+        "firstDoses": 426789,
+        "firstDosesPercentage": 0.88,
+        "firstDosesTo90Percent": 7707,
+        "secondDoses": 363479,
+        "secondDosesPercentage": 0.75,
+        "secondDosesTo90Percent": 71017,
+        "totalPopulation": 482773
+      },
+      {
+        "dhbName": "Waikato",
+        "firstDoses": 307533,
+        "firstDosesPercentage": 0.86,
+        "firstDosesTo90Percent": 13925,
+        "secondDoses": 251626,
+        "secondDosesPercentage": 0.7,
+        "secondDosesTo90Percent": 69832,
+        "totalPopulation": 357176
+      },
+      {
+        "dhbName": "Lakes",
+        "firstDoses": 75347,
+        "firstDosesPercentage": 0.8,
+        "firstDosesTo90Percent": 9630,
+        "secondDoses": 60243,
+        "secondDosesPercentage": 0.64,
+        "secondDosesTo90Percent": 24734,
+        "totalPopulation": 94419
+      },
+      {
+        "dhbName": "Bay of Plenty",
+        "firstDoses": 178935,
+        "firstDosesPercentage": 0.82,
+        "firstDosesTo90Percent": 16312,
+        "secondDoses": 141800,
+        "secondDosesPercentage": 0.65,
+        "secondDosesTo90Percent": 53447,
+        "totalPopulation": 216941
+      },
+      {
+        "dhbName": "Tairawhiti",
+        "firstDoses": 32492,
+        "firstDosesPercentage": 0.77,
+        "firstDosesTo90Percent": 5276,
+        "secondDoses": 26146,
+        "secondDosesPercentage": 0.62,
+        "secondDosesTo90Percent": 11622,
+        "totalPopulation": 41965
+      },
+      {
+        "dhbName": "Taranaki",
+        "firstDoses": 85347,
+        "firstDosesPercentage": 0.84,
+        "firstDosesTo90Percent": 6585,
+        "secondDoses": 65454,
+        "secondDosesPercentage": 0.64,
+        "secondDosesTo90Percent": 26478,
+        "totalPopulation": 102147
+      },
+      {
+        "dhbName": "Hawkes Bay",
+        "firstDoses": 121965,
+        "firstDosesPercentage": 0.84,
+        "firstDosesTo90Percent": 9049,
+        "secondDoses": 101011,
+        "secondDosesPercentage": 0.69,
+        "secondDosesTo90Percent": 30003,
+        "totalPopulation": 145571
+      },
+      {
+        "dhbName": "MidCentral",
+        "firstDoses": 130464,
+        "firstDosesPercentage": 0.86,
+        "firstDosesTo90Percent": 6608,
+        "secondDoses": 107890,
+        "secondDosesPercentage": 0.71,
+        "secondDosesTo90Percent": 29182,
+        "totalPopulation": 152302
+      },
+      {
+        "dhbName": "Whanganui",
+        "firstDoses": 45804,
+        "firstDosesPercentage": 0.8,
+        "firstDosesTo90Percent": 5718,
+        "secondDoses": 38369,
+        "secondDosesPercentage": 0.67,
+        "secondDosesTo90Percent": 13153,
+        "totalPopulation": 57247
+      },
+      {
+        "dhbName": "Capital and Coast",
+        "firstDoses": 248949,
+        "firstDosesPercentage": 0.92,
+        "firstDosesTo90Percent": 0,
+        "secondDoses": 213148,
+        "secondDosesPercentage": 0.79,
+        "secondDosesTo90Percent": 30909,
+        "totalPopulation": 271174
+      },
+      {
+        "dhbName": "Hutt Valley",
+        "firstDoses": 113951,
+        "firstDosesPercentage": 0.87,
+        "firstDosesTo90Percent": 3264,
+        "secondDoses": 94440,
+        "secondDosesPercentage": 0.73,
+        "secondDosesTo90Percent": 22775,
+        "totalPopulation": 130239
+      },
+      {
+        "dhbName": "Wairarapa",
+        "firstDoses": 35155,
+        "firstDosesPercentage": 0.85,
+        "firstDosesTo90Percent": 2129,
+        "secondDoses": 29380,
+        "secondDosesPercentage": 0.71,
+        "secondDosesTo90Percent": 7904,
+        "totalPopulation": 41427
+      },
+      {
+        "dhbName": "Nelson Marlborough",
+        "firstDoses": 116995,
+        "firstDosesPercentage": 0.86,
+        "firstDosesTo90Percent": 5174,
+        "secondDoses": 101527,
+        "secondDosesPercentage": 0.75,
+        "secondDosesTo90Percent": 20642,
+        "totalPopulation": 135743
+      },
+      {
+        "dhbName": "West Coast",
+        "firstDoses": 22411,
+        "firstDosesPercentage": 0.8,
+        "firstDosesTo90Percent": 2704,
+        "secondDoses": 18122,
+        "secondDosesPercentage": 0.65,
+        "secondDosesTo90Percent": 6993,
+        "totalPopulation": 27906
+      },
+      {
+        "dhbName": "Canterbury",
+        "firstDoses": 434574,
+        "firstDosesPercentage": 0.9,
+        "firstDosesTo90Percent": 27,
+        "secondDoses": 340807,
+        "secondDosesPercentage": 0.71,
+        "secondDosesTo90Percent": 93794,
+        "totalPopulation": 482890
+      },
+      {
+        "dhbName": "South Canterbury",
+        "firstDoses": 44901,
+        "firstDosesPercentage": 0.85,
+        "firstDosesTo90Percent": 2425,
+        "secondDoses": 38211,
+        "secondDosesPercentage": 0.73,
+        "secondDosesTo90Percent": 9115,
+        "totalPopulation": 52584
+      },
+      {
+        "dhbName": "Southern",
+        "firstDoses": 256602,
+        "firstDosesPercentage": 0.89,
+        "firstDosesTo90Percent": 2612,
+        "secondDoses": 219241,
+        "secondDosesPercentage": 0.76,
+        "secondDosesTo90Percent": 39972,
+        "totalPopulation": 288015
+      },
+      {
+        "dhbName": "Overseas / Unknown",
+        "firstDoses": 2036,
+        "firstDosesPercentage": 0.12,
+        "firstDosesTo90Percent": 13420,
+        "secondDoses": 1635,
+        "secondDosesPercentage": 0.1,
+        "secondDosesTo90Percent": 13821,
+        "totalPopulation": 17173
+      }
+    ],
+    "dataValidAsAtNzTimeIso": "2021-10-28T23:59:00.000+13:00"
+  }
 }

--- a/data/vaccineData/2021-10-28.json
+++ b/data/vaccineData/2021-10-28.json
@@ -1,5 +1,5 @@
 {
-  "metaData": {
+  "metadata": {
     "createdAtUtcTimeIso": "2021-11-07T05:46:24.786Z",
     "updatedAtUtcTimeIso": "2021-11-07T05:46:24.786Z"
   },

--- a/data/vaccineData/2021-10-28.json
+++ b/data/vaccineData/2021-10-28.json
@@ -1,4 +1,8 @@
 {
+  "metaData": {
+    "createdAtUtcTimeIso": "2021-11-07T05:46:24.786Z",
+    "updatedAtUtcTimeIso": "2021-11-07T05:46:24.786Z"
+  },
   "data": {
     "vaccinationsPerDhb": [
       {

--- a/data/vaccineData/2021-10-29.json
+++ b/data/vaccineData/2021-10-29.json
@@ -1,215 +1,217 @@
 {
-  "vaccinationsPerDhb": [
-    {
-      "dhbName": "Northland",
-      "firstDoses": 127447,
-      "firstDosesPercentage": 0.79,
-      "firstDosesTo90Percent": 17741,
-      "secondDoses": 103000,
-      "secondDosesPercentage": 0.64,
-      "secondDosesTo90Percent": 42188,
-      "totalPopulation": 161320
-    },
-    {
-      "dhbName": "Waitemata",
-      "firstDoses": 478860,
-      "firstDosesPercentage": 0.91,
-      "firstDosesTo90Percent": 0,
-      "secondDoses": 417802,
-      "secondDosesPercentage": 0.79,
-      "secondDosesTo90Percent": 55676,
-      "totalPopulation": 526087
-    },
-    {
-      "dhbName": "Auckland",
-      "firstDoses": 397623,
-      "firstDosesPercentage": 0.94,
-      "firstDosesTo90Percent": 0,
-      "secondDoses": 354251,
-      "secondDosesPercentage": 0.84,
-      "secondDosesTo90Percent": 27311,
-      "totalPopulation": 423958
-    },
-    {
-      "dhbName": "Counties Manukau",
-      "firstDoses": 427835,
-      "firstDosesPercentage": 0.89,
-      "firstDosesTo90Percent": 6661,
-      "secondDoses": 366733,
-      "secondDosesPercentage": 0.76,
-      "secondDosesTo90Percent": 67763,
-      "totalPopulation": 482773
-    },
-    {
-      "dhbName": "Waikato",
-      "firstDoses": 308535,
-      "firstDosesPercentage": 0.86,
-      "firstDosesTo90Percent": 12923,
-      "secondDoses": 254507,
-      "secondDosesPercentage": 0.71,
-      "secondDosesTo90Percent": 66951,
-      "totalPopulation": 357176
-    },
-    {
-      "dhbName": "Lakes",
-      "firstDoses": 75641,
-      "firstDosesPercentage": 0.8,
-      "firstDosesTo90Percent": 9336,
-      "secondDoses": 61016,
-      "secondDosesPercentage": 0.65,
-      "secondDosesTo90Percent": 23961,
-      "totalPopulation": 94419
-    },
-    {
-      "dhbName": "Bay of Plenty",
-      "firstDoses": 179551,
-      "firstDosesPercentage": 0.83,
-      "firstDosesTo90Percent": 15696,
-      "secondDoses": 143827,
-      "secondDosesPercentage": 0.66,
-      "secondDosesTo90Percent": 51420,
-      "totalPopulation": 216941
-    },
-    {
-      "dhbName": "Tairawhiti",
-      "firstDoses": 32626,
-      "firstDosesPercentage": 0.78,
-      "firstDosesTo90Percent": 5142,
-      "secondDoses": 26373,
-      "secondDosesPercentage": 0.63,
-      "secondDosesTo90Percent": 11396,
-      "totalPopulation": 41965
-    },
-    {
-      "dhbName": "Taranaki",
-      "firstDoses": 85658,
-      "firstDosesPercentage": 0.84,
-      "firstDosesTo90Percent": 6274,
-      "secondDoses": 66348,
-      "secondDosesPercentage": 0.65,
-      "secondDosesTo90Percent": 25584,
-      "totalPopulation": 102147
-    },
-    {
-      "dhbName": "Hawkes Bay",
-      "firstDoses": 122399,
-      "firstDosesPercentage": 0.84,
-      "firstDosesTo90Percent": 8615,
-      "secondDoses": 102181,
-      "secondDosesPercentage": 0.7,
-      "secondDosesTo90Percent": 28833,
-      "totalPopulation": 145571
-    },
-    {
-      "dhbName": "MidCentral",
-      "firstDoses": 130862,
-      "firstDosesPercentage": 0.86,
-      "firstDosesTo90Percent": 6210,
-      "secondDoses": 108830,
-      "secondDosesPercentage": 0.71,
-      "secondDosesTo90Percent": 28242,
-      "totalPopulation": 152302
-    },
-    {
-      "dhbName": "Whanganui",
-      "firstDoses": 45939,
-      "firstDosesPercentage": 0.8,
-      "firstDosesTo90Percent": 5583,
-      "secondDoses": 38606,
-      "secondDosesPercentage": 0.67,
-      "secondDosesTo90Percent": 12916,
-      "totalPopulation": 57247
-    },
-    {
-      "dhbName": "Capital and Coast",
-      "firstDoses": 249430,
-      "firstDosesPercentage": 0.92,
-      "firstDosesTo90Percent": 0,
-      "secondDoses": 214922,
-      "secondDosesPercentage": 0.79,
-      "secondDosesTo90Percent": 29135,
-      "totalPopulation": 271174
-    },
-    {
-      "dhbName": "Hutt Valley",
-      "firstDoses": 114179,
-      "firstDosesPercentage": 0.88,
-      "firstDosesTo90Percent": 3036,
-      "secondDoses": 95258,
-      "secondDosesPercentage": 0.73,
-      "secondDosesTo90Percent": 21957,
-      "totalPopulation": 130239
-    },
-    {
-      "dhbName": "Wairarapa",
-      "firstDoses": 35304,
-      "firstDosesPercentage": 0.85,
-      "firstDosesTo90Percent": 1980,
-      "secondDoses": 29722,
-      "secondDosesPercentage": 0.72,
-      "secondDosesTo90Percent": 7562,
-      "totalPopulation": 41427
-    },
-    {
-      "dhbName": "Nelson Marlborough",
-      "firstDoses": 117338,
-      "firstDosesPercentage": 0.86,
-      "firstDosesTo90Percent": 4831,
-      "secondDoses": 102101,
-      "secondDosesPercentage": 0.75,
-      "secondDosesTo90Percent": 20068,
-      "totalPopulation": 135743
-    },
-    {
-      "dhbName": "West Coast",
-      "firstDoses": 22584,
-      "firstDosesPercentage": 0.81,
-      "firstDosesTo90Percent": 2531,
-      "secondDoses": 18378,
-      "secondDosesPercentage": 0.66,
-      "secondDosesTo90Percent": 6737,
-      "totalPopulation": 27906
-    },
-    {
-      "dhbName": "Canterbury",
-      "firstDoses": 436822,
-      "firstDosesPercentage": 0.9,
-      "firstDosesTo90Percent": 0,
-      "secondDoses": 346684,
-      "secondDosesPercentage": 0.72,
-      "secondDosesTo90Percent": 87917,
-      "totalPopulation": 482890
-    },
-    {
-      "dhbName": "South Canterbury",
-      "firstDoses": 45162,
-      "firstDosesPercentage": 0.86,
-      "firstDosesTo90Percent": 2164,
-      "secondDoses": 38658,
-      "secondDosesPercentage": 0.74,
-      "secondDosesTo90Percent": 8668,
-      "totalPopulation": 52584
-    },
-    {
-      "dhbName": "Southern",
-      "firstDoses": 257654,
-      "firstDosesPercentage": 0.89,
-      "firstDosesTo90Percent": 1560,
-      "secondDoses": 220955,
-      "secondDosesPercentage": 0.77,
-      "secondDosesTo90Percent": 38258,
-      "totalPopulation": 288015
-    },
-    {
-      "dhbName": "Overseas / Unknown",
-      "firstDoses": 2040,
-      "firstDosesPercentage": 0.12,
-      "firstDosesTo90Percent": 13416,
-      "secondDoses": 1653,
-      "secondDosesPercentage": 0.1,
-      "secondDosesTo90Percent": 13803,
-      "totalPopulation": 17173
-    }
-  ],
-  "dataValidAsAtNzTimeIso": "2021-10-29T23:59:00.000+13:00"
+  "data": {
+    "vaccinationsPerDhb": [
+      {
+        "dhbName": "Northland",
+        "firstDoses": 127447,
+        "firstDosesPercentage": 0.79,
+        "firstDosesTo90Percent": 17741,
+        "secondDoses": 103000,
+        "secondDosesPercentage": 0.64,
+        "secondDosesTo90Percent": 42188,
+        "totalPopulation": 161320
+      },
+      {
+        "dhbName": "Waitemata",
+        "firstDoses": 478860,
+        "firstDosesPercentage": 0.91,
+        "firstDosesTo90Percent": 0,
+        "secondDoses": 417802,
+        "secondDosesPercentage": 0.79,
+        "secondDosesTo90Percent": 55676,
+        "totalPopulation": 526087
+      },
+      {
+        "dhbName": "Auckland",
+        "firstDoses": 397623,
+        "firstDosesPercentage": 0.94,
+        "firstDosesTo90Percent": 0,
+        "secondDoses": 354251,
+        "secondDosesPercentage": 0.84,
+        "secondDosesTo90Percent": 27311,
+        "totalPopulation": 423958
+      },
+      {
+        "dhbName": "Counties Manukau",
+        "firstDoses": 427835,
+        "firstDosesPercentage": 0.89,
+        "firstDosesTo90Percent": 6661,
+        "secondDoses": 366733,
+        "secondDosesPercentage": 0.76,
+        "secondDosesTo90Percent": 67763,
+        "totalPopulation": 482773
+      },
+      {
+        "dhbName": "Waikato",
+        "firstDoses": 308535,
+        "firstDosesPercentage": 0.86,
+        "firstDosesTo90Percent": 12923,
+        "secondDoses": 254507,
+        "secondDosesPercentage": 0.71,
+        "secondDosesTo90Percent": 66951,
+        "totalPopulation": 357176
+      },
+      {
+        "dhbName": "Lakes",
+        "firstDoses": 75641,
+        "firstDosesPercentage": 0.8,
+        "firstDosesTo90Percent": 9336,
+        "secondDoses": 61016,
+        "secondDosesPercentage": 0.65,
+        "secondDosesTo90Percent": 23961,
+        "totalPopulation": 94419
+      },
+      {
+        "dhbName": "Bay of Plenty",
+        "firstDoses": 179551,
+        "firstDosesPercentage": 0.83,
+        "firstDosesTo90Percent": 15696,
+        "secondDoses": 143827,
+        "secondDosesPercentage": 0.66,
+        "secondDosesTo90Percent": 51420,
+        "totalPopulation": 216941
+      },
+      {
+        "dhbName": "Tairawhiti",
+        "firstDoses": 32626,
+        "firstDosesPercentage": 0.78,
+        "firstDosesTo90Percent": 5142,
+        "secondDoses": 26373,
+        "secondDosesPercentage": 0.63,
+        "secondDosesTo90Percent": 11396,
+        "totalPopulation": 41965
+      },
+      {
+        "dhbName": "Taranaki",
+        "firstDoses": 85658,
+        "firstDosesPercentage": 0.84,
+        "firstDosesTo90Percent": 6274,
+        "secondDoses": 66348,
+        "secondDosesPercentage": 0.65,
+        "secondDosesTo90Percent": 25584,
+        "totalPopulation": 102147
+      },
+      {
+        "dhbName": "Hawkes Bay",
+        "firstDoses": 122399,
+        "firstDosesPercentage": 0.84,
+        "firstDosesTo90Percent": 8615,
+        "secondDoses": 102181,
+        "secondDosesPercentage": 0.7,
+        "secondDosesTo90Percent": 28833,
+        "totalPopulation": 145571
+      },
+      {
+        "dhbName": "MidCentral",
+        "firstDoses": 130862,
+        "firstDosesPercentage": 0.86,
+        "firstDosesTo90Percent": 6210,
+        "secondDoses": 108830,
+        "secondDosesPercentage": 0.71,
+        "secondDosesTo90Percent": 28242,
+        "totalPopulation": 152302
+      },
+      {
+        "dhbName": "Whanganui",
+        "firstDoses": 45939,
+        "firstDosesPercentage": 0.8,
+        "firstDosesTo90Percent": 5583,
+        "secondDoses": 38606,
+        "secondDosesPercentage": 0.67,
+        "secondDosesTo90Percent": 12916,
+        "totalPopulation": 57247
+      },
+      {
+        "dhbName": "Capital and Coast",
+        "firstDoses": 249430,
+        "firstDosesPercentage": 0.92,
+        "firstDosesTo90Percent": 0,
+        "secondDoses": 214922,
+        "secondDosesPercentage": 0.79,
+        "secondDosesTo90Percent": 29135,
+        "totalPopulation": 271174
+      },
+      {
+        "dhbName": "Hutt Valley",
+        "firstDoses": 114179,
+        "firstDosesPercentage": 0.88,
+        "firstDosesTo90Percent": 3036,
+        "secondDoses": 95258,
+        "secondDosesPercentage": 0.73,
+        "secondDosesTo90Percent": 21957,
+        "totalPopulation": 130239
+      },
+      {
+        "dhbName": "Wairarapa",
+        "firstDoses": 35304,
+        "firstDosesPercentage": 0.85,
+        "firstDosesTo90Percent": 1980,
+        "secondDoses": 29722,
+        "secondDosesPercentage": 0.72,
+        "secondDosesTo90Percent": 7562,
+        "totalPopulation": 41427
+      },
+      {
+        "dhbName": "Nelson Marlborough",
+        "firstDoses": 117338,
+        "firstDosesPercentage": 0.86,
+        "firstDosesTo90Percent": 4831,
+        "secondDoses": 102101,
+        "secondDosesPercentage": 0.75,
+        "secondDosesTo90Percent": 20068,
+        "totalPopulation": 135743
+      },
+      {
+        "dhbName": "West Coast",
+        "firstDoses": 22584,
+        "firstDosesPercentage": 0.81,
+        "firstDosesTo90Percent": 2531,
+        "secondDoses": 18378,
+        "secondDosesPercentage": 0.66,
+        "secondDosesTo90Percent": 6737,
+        "totalPopulation": 27906
+      },
+      {
+        "dhbName": "Canterbury",
+        "firstDoses": 436822,
+        "firstDosesPercentage": 0.9,
+        "firstDosesTo90Percent": 0,
+        "secondDoses": 346684,
+        "secondDosesPercentage": 0.72,
+        "secondDosesTo90Percent": 87917,
+        "totalPopulation": 482890
+      },
+      {
+        "dhbName": "South Canterbury",
+        "firstDoses": 45162,
+        "firstDosesPercentage": 0.86,
+        "firstDosesTo90Percent": 2164,
+        "secondDoses": 38658,
+        "secondDosesPercentage": 0.74,
+        "secondDosesTo90Percent": 8668,
+        "totalPopulation": 52584
+      },
+      {
+        "dhbName": "Southern",
+        "firstDoses": 257654,
+        "firstDosesPercentage": 0.89,
+        "firstDosesTo90Percent": 1560,
+        "secondDoses": 220955,
+        "secondDosesPercentage": 0.77,
+        "secondDosesTo90Percent": 38258,
+        "totalPopulation": 288015
+      },
+      {
+        "dhbName": "Overseas / Unknown",
+        "firstDoses": 2040,
+        "firstDosesPercentage": 0.12,
+        "firstDosesTo90Percent": 13416,
+        "secondDoses": 1653,
+        "secondDosesPercentage": 0.1,
+        "secondDosesTo90Percent": 13803,
+        "totalPopulation": 17173
+      }
+    ],
+    "dataValidAsAtNzTimeIso": "2021-10-29T23:59:00.000+13:00"
+  }
 }

--- a/data/vaccineData/2021-10-29.json
+++ b/data/vaccineData/2021-10-29.json
@@ -1,5 +1,5 @@
 {
-  "metaData": {
+  "metadata": {
     "createdAtUtcTimeIso": "2021-11-07T05:46:24.787Z",
     "updatedAtUtcTimeIso": "2021-11-07T05:46:24.787Z"
   },

--- a/data/vaccineData/2021-10-29.json
+++ b/data/vaccineData/2021-10-29.json
@@ -1,4 +1,8 @@
 {
+  "metaData": {
+    "createdAtUtcTimeIso": "2021-11-07T05:46:24.787Z",
+    "updatedAtUtcTimeIso": "2021-11-07T05:46:24.787Z"
+  },
   "data": {
     "vaccinationsPerDhb": [
       {

--- a/data/vaccineData/2021-10-30.json
+++ b/data/vaccineData/2021-10-30.json
@@ -1,215 +1,217 @@
 {
-  "vaccinationsPerDhb": [
-    {
-      "dhbName": "Northland",
-      "firstDoses": 127690,
-      "firstDosesPercentage": 0.79,
-      "firstDosesTo90Percent": 17498,
-      "secondDoses": 103567,
-      "secondDosesPercentage": 0.64,
-      "secondDosesTo90Percent": 41621,
-      "totalPopulation": 161320
-    },
-    {
-      "dhbName": "Waitemata",
-      "firstDoses": 479602,
-      "firstDosesPercentage": 0.91,
-      "firstDosesTo90Percent": 0,
-      "secondDoses": 421626,
-      "secondDosesPercentage": 0.8,
-      "secondDosesTo90Percent": 51852,
-      "totalPopulation": 526087
-    },
-    {
-      "dhbName": "Auckland",
-      "firstDoses": 398266,
-      "firstDosesPercentage": 0.94,
-      "firstDosesTo90Percent": 0,
-      "secondDoses": 356967,
-      "secondDosesPercentage": 0.84,
-      "secondDosesTo90Percent": 24595,
-      "totalPopulation": 423958
-    },
-    {
-      "dhbName": "Counties Manukau",
-      "firstDoses": 429142,
-      "firstDosesPercentage": 0.89,
-      "firstDosesTo90Percent": 5354,
-      "secondDoses": 370946,
-      "secondDosesPercentage": 0.77,
-      "secondDosesTo90Percent": 63550,
-      "totalPopulation": 482773
-    },
-    {
-      "dhbName": "Waikato",
-      "firstDoses": 309408,
-      "firstDosesPercentage": 0.87,
-      "firstDosesTo90Percent": 12050,
-      "secondDoses": 257063,
-      "secondDosesPercentage": 0.72,
-      "secondDosesTo90Percent": 64395,
-      "totalPopulation": 357176
-    },
-    {
-      "dhbName": "Lakes",
-      "firstDoses": 75958,
-      "firstDosesPercentage": 0.8,
-      "firstDosesTo90Percent": 9019,
-      "secondDoses": 61754,
-      "secondDosesPercentage": 0.65,
-      "secondDosesTo90Percent": 23223,
-      "totalPopulation": 94419
-    },
-    {
-      "dhbName": "Bay of Plenty",
-      "firstDoses": 180060,
-      "firstDosesPercentage": 0.83,
-      "firstDosesTo90Percent": 15187,
-      "secondDoses": 145435,
-      "secondDosesPercentage": 0.67,
-      "secondDosesTo90Percent": 49812,
-      "totalPopulation": 216941
-    },
-    {
-      "dhbName": "Tairawhiti",
-      "firstDoses": 32730,
-      "firstDosesPercentage": 0.78,
-      "firstDosesTo90Percent": 5038,
-      "secondDoses": 26541,
-      "secondDosesPercentage": 0.63,
-      "secondDosesTo90Percent": 11228,
-      "totalPopulation": 41965
-    },
-    {
-      "dhbName": "Taranaki",
-      "firstDoses": 85912,
-      "firstDosesPercentage": 0.84,
-      "firstDosesTo90Percent": 6020,
-      "secondDoses": 67016,
-      "secondDosesPercentage": 0.66,
-      "secondDosesTo90Percent": 24916,
-      "totalPopulation": 102147
-    },
-    {
-      "dhbName": "Hawkes Bay",
-      "firstDoses": 122948,
-      "firstDosesPercentage": 0.84,
-      "firstDosesTo90Percent": 8066,
-      "secondDoses": 103679,
-      "secondDosesPercentage": 0.71,
-      "secondDosesTo90Percent": 27335,
-      "totalPopulation": 145571
-    },
-    {
-      "dhbName": "MidCentral",
-      "firstDoses": 131287,
-      "firstDosesPercentage": 0.86,
-      "firstDosesTo90Percent": 5785,
-      "secondDoses": 109785,
-      "secondDosesPercentage": 0.72,
-      "secondDosesTo90Percent": 27287,
-      "totalPopulation": 152302
-    },
-    {
-      "dhbName": "Whanganui",
-      "firstDoses": 46084,
-      "firstDosesPercentage": 0.81,
-      "firstDosesTo90Percent": 5438,
-      "secondDoses": 38844,
-      "secondDosesPercentage": 0.68,
-      "secondDosesTo90Percent": 12678,
-      "totalPopulation": 57247
-    },
-    {
-      "dhbName": "Capital and Coast",
-      "firstDoses": 249784,
-      "firstDosesPercentage": 0.92,
-      "firstDosesTo90Percent": 0,
-      "secondDoses": 216579,
-      "secondDosesPercentage": 0.8,
-      "secondDosesTo90Percent": 27478,
-      "totalPopulation": 271174
-    },
-    {
-      "dhbName": "Hutt Valley",
-      "firstDoses": 114495,
-      "firstDosesPercentage": 0.88,
-      "firstDosesTo90Percent": 2720,
-      "secondDoses": 96207,
-      "secondDosesPercentage": 0.74,
-      "secondDosesTo90Percent": 21008,
-      "totalPopulation": 130239
-    },
-    {
-      "dhbName": "Wairarapa",
-      "firstDoses": 35408,
-      "firstDosesPercentage": 0.85,
-      "firstDosesTo90Percent": 1876,
-      "secondDoses": 30012,
-      "secondDosesPercentage": 0.72,
-      "secondDosesTo90Percent": 7272,
-      "totalPopulation": 41427
-    },
-    {
-      "dhbName": "Nelson Marlborough",
-      "firstDoses": 117720,
-      "firstDosesPercentage": 0.87,
-      "firstDosesTo90Percent": 4449,
-      "secondDoses": 102987,
-      "secondDosesPercentage": 0.76,
-      "secondDosesTo90Percent": 19182,
-      "totalPopulation": 135743
-    },
-    {
-      "dhbName": "West Coast",
-      "firstDoses": 22676,
-      "firstDosesPercentage": 0.81,
-      "firstDosesTo90Percent": 2439,
-      "secondDoses": 18529,
-      "secondDosesPercentage": 0.66,
-      "secondDosesTo90Percent": 6586,
-      "totalPopulation": 27906
-    },
-    {
-      "dhbName": "Canterbury",
-      "firstDoses": 439245,
-      "firstDosesPercentage": 0.91,
-      "firstDosesTo90Percent": 0,
-      "secondDoses": 353349,
-      "secondDosesPercentage": 0.73,
-      "secondDosesTo90Percent": 81252,
-      "totalPopulation": 482890
-    },
-    {
-      "dhbName": "South Canterbury",
-      "firstDoses": 45463,
-      "firstDosesPercentage": 0.86,
-      "firstDosesTo90Percent": 1863,
-      "secondDoses": 39061,
-      "secondDosesPercentage": 0.74,
-      "secondDosesTo90Percent": 8265,
-      "totalPopulation": 52584
-    },
-    {
-      "dhbName": "Southern",
-      "firstDoses": 258419,
-      "firstDosesPercentage": 0.9,
-      "firstDosesTo90Percent": 794,
-      "secondDoses": 222297,
-      "secondDosesPercentage": 0.77,
-      "secondDosesTo90Percent": 36916,
-      "totalPopulation": 288015
-    },
-    {
-      "dhbName": "Overseas / Unknown",
-      "firstDoses": 2085,
-      "firstDosesPercentage": 0.12,
-      "firstDosesTo90Percent": 13371,
-      "secondDoses": 1670,
-      "secondDosesPercentage": 0.1,
-      "secondDosesTo90Percent": 13786,
-      "totalPopulation": 17173
-    }
-  ],
-  "dataValidAsAtNzTimeIso": "2021-10-30T23:59:00.000+13:00"
+  "data": {
+    "vaccinationsPerDhb": [
+      {
+        "dhbName": "Northland",
+        "firstDoses": 127690,
+        "firstDosesPercentage": 0.79,
+        "firstDosesTo90Percent": 17498,
+        "secondDoses": 103567,
+        "secondDosesPercentage": 0.64,
+        "secondDosesTo90Percent": 41621,
+        "totalPopulation": 161320
+      },
+      {
+        "dhbName": "Waitemata",
+        "firstDoses": 479602,
+        "firstDosesPercentage": 0.91,
+        "firstDosesTo90Percent": 0,
+        "secondDoses": 421626,
+        "secondDosesPercentage": 0.8,
+        "secondDosesTo90Percent": 51852,
+        "totalPopulation": 526087
+      },
+      {
+        "dhbName": "Auckland",
+        "firstDoses": 398266,
+        "firstDosesPercentage": 0.94,
+        "firstDosesTo90Percent": 0,
+        "secondDoses": 356967,
+        "secondDosesPercentage": 0.84,
+        "secondDosesTo90Percent": 24595,
+        "totalPopulation": 423958
+      },
+      {
+        "dhbName": "Counties Manukau",
+        "firstDoses": 429142,
+        "firstDosesPercentage": 0.89,
+        "firstDosesTo90Percent": 5354,
+        "secondDoses": 370946,
+        "secondDosesPercentage": 0.77,
+        "secondDosesTo90Percent": 63550,
+        "totalPopulation": 482773
+      },
+      {
+        "dhbName": "Waikato",
+        "firstDoses": 309408,
+        "firstDosesPercentage": 0.87,
+        "firstDosesTo90Percent": 12050,
+        "secondDoses": 257063,
+        "secondDosesPercentage": 0.72,
+        "secondDosesTo90Percent": 64395,
+        "totalPopulation": 357176
+      },
+      {
+        "dhbName": "Lakes",
+        "firstDoses": 75958,
+        "firstDosesPercentage": 0.8,
+        "firstDosesTo90Percent": 9019,
+        "secondDoses": 61754,
+        "secondDosesPercentage": 0.65,
+        "secondDosesTo90Percent": 23223,
+        "totalPopulation": 94419
+      },
+      {
+        "dhbName": "Bay of Plenty",
+        "firstDoses": 180060,
+        "firstDosesPercentage": 0.83,
+        "firstDosesTo90Percent": 15187,
+        "secondDoses": 145435,
+        "secondDosesPercentage": 0.67,
+        "secondDosesTo90Percent": 49812,
+        "totalPopulation": 216941
+      },
+      {
+        "dhbName": "Tairawhiti",
+        "firstDoses": 32730,
+        "firstDosesPercentage": 0.78,
+        "firstDosesTo90Percent": 5038,
+        "secondDoses": 26541,
+        "secondDosesPercentage": 0.63,
+        "secondDosesTo90Percent": 11228,
+        "totalPopulation": 41965
+      },
+      {
+        "dhbName": "Taranaki",
+        "firstDoses": 85912,
+        "firstDosesPercentage": 0.84,
+        "firstDosesTo90Percent": 6020,
+        "secondDoses": 67016,
+        "secondDosesPercentage": 0.66,
+        "secondDosesTo90Percent": 24916,
+        "totalPopulation": 102147
+      },
+      {
+        "dhbName": "Hawkes Bay",
+        "firstDoses": 122948,
+        "firstDosesPercentage": 0.84,
+        "firstDosesTo90Percent": 8066,
+        "secondDoses": 103679,
+        "secondDosesPercentage": 0.71,
+        "secondDosesTo90Percent": 27335,
+        "totalPopulation": 145571
+      },
+      {
+        "dhbName": "MidCentral",
+        "firstDoses": 131287,
+        "firstDosesPercentage": 0.86,
+        "firstDosesTo90Percent": 5785,
+        "secondDoses": 109785,
+        "secondDosesPercentage": 0.72,
+        "secondDosesTo90Percent": 27287,
+        "totalPopulation": 152302
+      },
+      {
+        "dhbName": "Whanganui",
+        "firstDoses": 46084,
+        "firstDosesPercentage": 0.81,
+        "firstDosesTo90Percent": 5438,
+        "secondDoses": 38844,
+        "secondDosesPercentage": 0.68,
+        "secondDosesTo90Percent": 12678,
+        "totalPopulation": 57247
+      },
+      {
+        "dhbName": "Capital and Coast",
+        "firstDoses": 249784,
+        "firstDosesPercentage": 0.92,
+        "firstDosesTo90Percent": 0,
+        "secondDoses": 216579,
+        "secondDosesPercentage": 0.8,
+        "secondDosesTo90Percent": 27478,
+        "totalPopulation": 271174
+      },
+      {
+        "dhbName": "Hutt Valley",
+        "firstDoses": 114495,
+        "firstDosesPercentage": 0.88,
+        "firstDosesTo90Percent": 2720,
+        "secondDoses": 96207,
+        "secondDosesPercentage": 0.74,
+        "secondDosesTo90Percent": 21008,
+        "totalPopulation": 130239
+      },
+      {
+        "dhbName": "Wairarapa",
+        "firstDoses": 35408,
+        "firstDosesPercentage": 0.85,
+        "firstDosesTo90Percent": 1876,
+        "secondDoses": 30012,
+        "secondDosesPercentage": 0.72,
+        "secondDosesTo90Percent": 7272,
+        "totalPopulation": 41427
+      },
+      {
+        "dhbName": "Nelson Marlborough",
+        "firstDoses": 117720,
+        "firstDosesPercentage": 0.87,
+        "firstDosesTo90Percent": 4449,
+        "secondDoses": 102987,
+        "secondDosesPercentage": 0.76,
+        "secondDosesTo90Percent": 19182,
+        "totalPopulation": 135743
+      },
+      {
+        "dhbName": "West Coast",
+        "firstDoses": 22676,
+        "firstDosesPercentage": 0.81,
+        "firstDosesTo90Percent": 2439,
+        "secondDoses": 18529,
+        "secondDosesPercentage": 0.66,
+        "secondDosesTo90Percent": 6586,
+        "totalPopulation": 27906
+      },
+      {
+        "dhbName": "Canterbury",
+        "firstDoses": 439245,
+        "firstDosesPercentage": 0.91,
+        "firstDosesTo90Percent": 0,
+        "secondDoses": 353349,
+        "secondDosesPercentage": 0.73,
+        "secondDosesTo90Percent": 81252,
+        "totalPopulation": 482890
+      },
+      {
+        "dhbName": "South Canterbury",
+        "firstDoses": 45463,
+        "firstDosesPercentage": 0.86,
+        "firstDosesTo90Percent": 1863,
+        "secondDoses": 39061,
+        "secondDosesPercentage": 0.74,
+        "secondDosesTo90Percent": 8265,
+        "totalPopulation": 52584
+      },
+      {
+        "dhbName": "Southern",
+        "firstDoses": 258419,
+        "firstDosesPercentage": 0.9,
+        "firstDosesTo90Percent": 794,
+        "secondDoses": 222297,
+        "secondDosesPercentage": 0.77,
+        "secondDosesTo90Percent": 36916,
+        "totalPopulation": 288015
+      },
+      {
+        "dhbName": "Overseas / Unknown",
+        "firstDoses": 2085,
+        "firstDosesPercentage": 0.12,
+        "firstDosesTo90Percent": 13371,
+        "secondDoses": 1670,
+        "secondDosesPercentage": 0.1,
+        "secondDosesTo90Percent": 13786,
+        "totalPopulation": 17173
+      }
+    ],
+    "dataValidAsAtNzTimeIso": "2021-10-30T23:59:00.000+13:00"
+  }
 }

--- a/data/vaccineData/2021-10-30.json
+++ b/data/vaccineData/2021-10-30.json
@@ -1,5 +1,5 @@
 {
-  "metaData": {
+  "metadata": {
     "createdAtUtcTimeIso": "2021-11-07T05:46:24.787Z",
     "updatedAtUtcTimeIso": "2021-11-07T05:46:24.787Z"
   },

--- a/data/vaccineData/2021-10-30.json
+++ b/data/vaccineData/2021-10-30.json
@@ -1,4 +1,8 @@
 {
+  "metaData": {
+    "createdAtUtcTimeIso": "2021-11-07T05:46:24.787Z",
+    "updatedAtUtcTimeIso": "2021-11-07T05:46:24.787Z"
+  },
   "data": {
     "vaccinationsPerDhb": [
       {

--- a/data/vaccineData/2021-10-31.json
+++ b/data/vaccineData/2021-10-31.json
@@ -1,215 +1,217 @@
 {
-  "vaccinationsPerDhb": [
-    {
-      "dhbName": "Northland",
-      "firstDoses": 127753,
-      "firstDosesPercentage": 0.79,
-      "firstDosesTo90Percent": 17435,
-      "secondDoses": 103689,
-      "secondDosesPercentage": 0.64,
-      "secondDosesTo90Percent": 41499,
-      "totalPopulation": 161320
-    },
-    {
-      "dhbName": "Waitemata",
-      "firstDoses": 480049,
-      "firstDosesPercentage": 0.91,
-      "firstDosesTo90Percent": 0,
-      "secondDoses": 423578,
-      "secondDosesPercentage": 0.81,
-      "secondDosesTo90Percent": 49900,
-      "totalPopulation": 526087
-    },
-    {
-      "dhbName": "Auckland",
-      "firstDoses": 398544,
-      "firstDosesPercentage": 0.94,
-      "firstDosesTo90Percent": 0,
-      "secondDoses": 358316,
-      "secondDosesPercentage": 0.85,
-      "secondDosesTo90Percent": 23246,
-      "totalPopulation": 423958
-    },
-    {
-      "dhbName": "Counties Manukau",
-      "firstDoses": 429723,
-      "firstDosesPercentage": 0.89,
-      "firstDosesTo90Percent": 4773,
-      "secondDoses": 372728,
-      "secondDosesPercentage": 0.77,
-      "secondDosesTo90Percent": 61768,
-      "totalPopulation": 482773
-    },
-    {
-      "dhbName": "Waikato",
-      "firstDoses": 309731,
-      "firstDosesPercentage": 0.87,
-      "firstDosesTo90Percent": 11727,
-      "secondDoses": 258044,
-      "secondDosesPercentage": 0.72,
-      "secondDosesTo90Percent": 63414,
-      "totalPopulation": 357176
-    },
-    {
-      "dhbName": "Lakes",
-      "firstDoses": 76233,
-      "firstDosesPercentage": 0.81,
-      "firstDosesTo90Percent": 8744,
-      "secondDoses": 62138,
-      "secondDosesPercentage": 0.66,
-      "secondDosesTo90Percent": 22839,
-      "totalPopulation": 94419
-    },
-    {
-      "dhbName": "Bay of Plenty",
-      "firstDoses": 180360,
-      "firstDosesPercentage": 0.83,
-      "firstDosesTo90Percent": 14887,
-      "secondDoses": 146574,
-      "secondDosesPercentage": 0.68,
-      "secondDosesTo90Percent": 48673,
-      "totalPopulation": 216941
-    },
-    {
-      "dhbName": "Tairawhiti",
-      "firstDoses": 32821,
-      "firstDosesPercentage": 0.78,
-      "firstDosesTo90Percent": 4948,
-      "secondDoses": 26626,
-      "secondDosesPercentage": 0.63,
-      "secondDosesTo90Percent": 11142,
-      "totalPopulation": 41965
-    },
-    {
-      "dhbName": "Taranaki",
-      "firstDoses": 86021,
-      "firstDosesPercentage": 0.84,
-      "firstDosesTo90Percent": 5911,
-      "secondDoses": 67480,
-      "secondDosesPercentage": 0.66,
-      "secondDosesTo90Percent": 24452,
-      "totalPopulation": 102147
-    },
-    {
-      "dhbName": "Hawkes Bay",
-      "firstDoses": 123225,
-      "firstDosesPercentage": 0.85,
-      "firstDosesTo90Percent": 7789,
-      "secondDoses": 104086,
-      "secondDosesPercentage": 0.72,
-      "secondDosesTo90Percent": 26928,
-      "totalPopulation": 145571
-    },
-    {
-      "dhbName": "MidCentral",
-      "firstDoses": 131441,
-      "firstDosesPercentage": 0.86,
-      "firstDosesTo90Percent": 5631,
-      "secondDoses": 110273,
-      "secondDosesPercentage": 0.72,
-      "secondDosesTo90Percent": 26799,
-      "totalPopulation": 152302
-    },
-    {
-      "dhbName": "Whanganui",
-      "firstDoses": 46122,
-      "firstDosesPercentage": 0.81,
-      "firstDosesTo90Percent": 5400,
-      "secondDoses": 38881,
-      "secondDosesPercentage": 0.68,
-      "secondDosesTo90Percent": 12641,
-      "totalPopulation": 57247
-    },
-    {
-      "dhbName": "Capital and Coast",
-      "firstDoses": 249910,
-      "firstDosesPercentage": 0.92,
-      "firstDosesTo90Percent": 0,
-      "secondDoses": 217398,
-      "secondDosesPercentage": 0.8,
-      "secondDosesTo90Percent": 26659,
-      "totalPopulation": 271174
-    },
-    {
-      "dhbName": "Hutt Valley",
-      "firstDoses": 114709,
-      "firstDosesPercentage": 0.88,
-      "firstDosesTo90Percent": 2506,
-      "secondDoses": 97185,
-      "secondDosesPercentage": 0.75,
-      "secondDosesTo90Percent": 20030,
-      "totalPopulation": 130239
-    },
-    {
-      "dhbName": "Wairarapa",
-      "firstDoses": 35433,
-      "firstDosesPercentage": 0.86,
-      "firstDosesTo90Percent": 1851,
-      "secondDoses": 30046,
-      "secondDosesPercentage": 0.73,
-      "secondDosesTo90Percent": 7238,
-      "totalPopulation": 41427
-    },
-    {
-      "dhbName": "Nelson Marlborough",
-      "firstDoses": 117863,
-      "firstDosesPercentage": 0.87,
-      "firstDosesTo90Percent": 4306,
-      "secondDoses": 103259,
-      "secondDosesPercentage": 0.76,
-      "secondDosesTo90Percent": 18910,
-      "totalPopulation": 135743
-    },
-    {
-      "dhbName": "West Coast",
-      "firstDoses": 22811,
-      "firstDosesPercentage": 0.82,
-      "firstDosesTo90Percent": 2304,
-      "secondDoses": 18802,
-      "secondDosesPercentage": 0.67,
-      "secondDosesTo90Percent": 6313,
-      "totalPopulation": 27906
-    },
-    {
-      "dhbName": "Canterbury",
-      "firstDoses": 440277,
-      "firstDosesPercentage": 0.91,
-      "firstDosesTo90Percent": 0,
-      "secondDoses": 356328,
-      "secondDosesPercentage": 0.74,
-      "secondDosesTo90Percent": 78273,
-      "totalPopulation": 482890
-    },
-    {
-      "dhbName": "South Canterbury",
-      "firstDoses": 45539,
-      "firstDosesPercentage": 0.87,
-      "firstDosesTo90Percent": 1787,
-      "secondDoses": 39217,
-      "secondDosesPercentage": 0.75,
-      "secondDosesTo90Percent": 8109,
-      "totalPopulation": 52584
-    },
-    {
-      "dhbName": "Southern",
-      "firstDoses": 258702,
-      "firstDosesPercentage": 0.9,
-      "firstDosesTo90Percent": 512,
-      "secondDoses": 222975,
-      "secondDosesPercentage": 0.77,
-      "secondDosesTo90Percent": 36238,
-      "totalPopulation": 288015
-    },
-    {
-      "dhbName": "Overseas / Unknown",
-      "firstDoses": 2048,
-      "firstDosesPercentage": 0.12,
-      "firstDosesTo90Percent": 13408,
-      "secondDoses": 1678,
-      "secondDosesPercentage": 0.1,
-      "secondDosesTo90Percent": 13778,
-      "totalPopulation": 17173
-    }
-  ],
-  "dataValidAsAtNzTimeIso": "2021-10-31T23:59:00.000+13:00"
+  "data": {
+    "vaccinationsPerDhb": [
+      {
+        "dhbName": "Northland",
+        "firstDoses": 127753,
+        "firstDosesPercentage": 0.79,
+        "firstDosesTo90Percent": 17435,
+        "secondDoses": 103689,
+        "secondDosesPercentage": 0.64,
+        "secondDosesTo90Percent": 41499,
+        "totalPopulation": 161320
+      },
+      {
+        "dhbName": "Waitemata",
+        "firstDoses": 480049,
+        "firstDosesPercentage": 0.91,
+        "firstDosesTo90Percent": 0,
+        "secondDoses": 423578,
+        "secondDosesPercentage": 0.81,
+        "secondDosesTo90Percent": 49900,
+        "totalPopulation": 526087
+      },
+      {
+        "dhbName": "Auckland",
+        "firstDoses": 398544,
+        "firstDosesPercentage": 0.94,
+        "firstDosesTo90Percent": 0,
+        "secondDoses": 358316,
+        "secondDosesPercentage": 0.85,
+        "secondDosesTo90Percent": 23246,
+        "totalPopulation": 423958
+      },
+      {
+        "dhbName": "Counties Manukau",
+        "firstDoses": 429723,
+        "firstDosesPercentage": 0.89,
+        "firstDosesTo90Percent": 4773,
+        "secondDoses": 372728,
+        "secondDosesPercentage": 0.77,
+        "secondDosesTo90Percent": 61768,
+        "totalPopulation": 482773
+      },
+      {
+        "dhbName": "Waikato",
+        "firstDoses": 309731,
+        "firstDosesPercentage": 0.87,
+        "firstDosesTo90Percent": 11727,
+        "secondDoses": 258044,
+        "secondDosesPercentage": 0.72,
+        "secondDosesTo90Percent": 63414,
+        "totalPopulation": 357176
+      },
+      {
+        "dhbName": "Lakes",
+        "firstDoses": 76233,
+        "firstDosesPercentage": 0.81,
+        "firstDosesTo90Percent": 8744,
+        "secondDoses": 62138,
+        "secondDosesPercentage": 0.66,
+        "secondDosesTo90Percent": 22839,
+        "totalPopulation": 94419
+      },
+      {
+        "dhbName": "Bay of Plenty",
+        "firstDoses": 180360,
+        "firstDosesPercentage": 0.83,
+        "firstDosesTo90Percent": 14887,
+        "secondDoses": 146574,
+        "secondDosesPercentage": 0.68,
+        "secondDosesTo90Percent": 48673,
+        "totalPopulation": 216941
+      },
+      {
+        "dhbName": "Tairawhiti",
+        "firstDoses": 32821,
+        "firstDosesPercentage": 0.78,
+        "firstDosesTo90Percent": 4948,
+        "secondDoses": 26626,
+        "secondDosesPercentage": 0.63,
+        "secondDosesTo90Percent": 11142,
+        "totalPopulation": 41965
+      },
+      {
+        "dhbName": "Taranaki",
+        "firstDoses": 86021,
+        "firstDosesPercentage": 0.84,
+        "firstDosesTo90Percent": 5911,
+        "secondDoses": 67480,
+        "secondDosesPercentage": 0.66,
+        "secondDosesTo90Percent": 24452,
+        "totalPopulation": 102147
+      },
+      {
+        "dhbName": "Hawkes Bay",
+        "firstDoses": 123225,
+        "firstDosesPercentage": 0.85,
+        "firstDosesTo90Percent": 7789,
+        "secondDoses": 104086,
+        "secondDosesPercentage": 0.72,
+        "secondDosesTo90Percent": 26928,
+        "totalPopulation": 145571
+      },
+      {
+        "dhbName": "MidCentral",
+        "firstDoses": 131441,
+        "firstDosesPercentage": 0.86,
+        "firstDosesTo90Percent": 5631,
+        "secondDoses": 110273,
+        "secondDosesPercentage": 0.72,
+        "secondDosesTo90Percent": 26799,
+        "totalPopulation": 152302
+      },
+      {
+        "dhbName": "Whanganui",
+        "firstDoses": 46122,
+        "firstDosesPercentage": 0.81,
+        "firstDosesTo90Percent": 5400,
+        "secondDoses": 38881,
+        "secondDosesPercentage": 0.68,
+        "secondDosesTo90Percent": 12641,
+        "totalPopulation": 57247
+      },
+      {
+        "dhbName": "Capital and Coast",
+        "firstDoses": 249910,
+        "firstDosesPercentage": 0.92,
+        "firstDosesTo90Percent": 0,
+        "secondDoses": 217398,
+        "secondDosesPercentage": 0.8,
+        "secondDosesTo90Percent": 26659,
+        "totalPopulation": 271174
+      },
+      {
+        "dhbName": "Hutt Valley",
+        "firstDoses": 114709,
+        "firstDosesPercentage": 0.88,
+        "firstDosesTo90Percent": 2506,
+        "secondDoses": 97185,
+        "secondDosesPercentage": 0.75,
+        "secondDosesTo90Percent": 20030,
+        "totalPopulation": 130239
+      },
+      {
+        "dhbName": "Wairarapa",
+        "firstDoses": 35433,
+        "firstDosesPercentage": 0.86,
+        "firstDosesTo90Percent": 1851,
+        "secondDoses": 30046,
+        "secondDosesPercentage": 0.73,
+        "secondDosesTo90Percent": 7238,
+        "totalPopulation": 41427
+      },
+      {
+        "dhbName": "Nelson Marlborough",
+        "firstDoses": 117863,
+        "firstDosesPercentage": 0.87,
+        "firstDosesTo90Percent": 4306,
+        "secondDoses": 103259,
+        "secondDosesPercentage": 0.76,
+        "secondDosesTo90Percent": 18910,
+        "totalPopulation": 135743
+      },
+      {
+        "dhbName": "West Coast",
+        "firstDoses": 22811,
+        "firstDosesPercentage": 0.82,
+        "firstDosesTo90Percent": 2304,
+        "secondDoses": 18802,
+        "secondDosesPercentage": 0.67,
+        "secondDosesTo90Percent": 6313,
+        "totalPopulation": 27906
+      },
+      {
+        "dhbName": "Canterbury",
+        "firstDoses": 440277,
+        "firstDosesPercentage": 0.91,
+        "firstDosesTo90Percent": 0,
+        "secondDoses": 356328,
+        "secondDosesPercentage": 0.74,
+        "secondDosesTo90Percent": 78273,
+        "totalPopulation": 482890
+      },
+      {
+        "dhbName": "South Canterbury",
+        "firstDoses": 45539,
+        "firstDosesPercentage": 0.87,
+        "firstDosesTo90Percent": 1787,
+        "secondDoses": 39217,
+        "secondDosesPercentage": 0.75,
+        "secondDosesTo90Percent": 8109,
+        "totalPopulation": 52584
+      },
+      {
+        "dhbName": "Southern",
+        "firstDoses": 258702,
+        "firstDosesPercentage": 0.9,
+        "firstDosesTo90Percent": 512,
+        "secondDoses": 222975,
+        "secondDosesPercentage": 0.77,
+        "secondDosesTo90Percent": 36238,
+        "totalPopulation": 288015
+      },
+      {
+        "dhbName": "Overseas / Unknown",
+        "firstDoses": 2048,
+        "firstDosesPercentage": 0.12,
+        "firstDosesTo90Percent": 13408,
+        "secondDoses": 1678,
+        "secondDosesPercentage": 0.1,
+        "secondDosesTo90Percent": 13778,
+        "totalPopulation": 17173
+      }
+    ],
+    "dataValidAsAtNzTimeIso": "2021-10-31T23:59:00.000+13:00"
+  }
 }

--- a/data/vaccineData/2021-10-31.json
+++ b/data/vaccineData/2021-10-31.json
@@ -1,4 +1,8 @@
 {
+  "metaData": {
+    "createdAtUtcTimeIso": "2021-11-07T05:46:24.788Z",
+    "updatedAtUtcTimeIso": "2021-11-07T05:46:24.788Z"
+  },
   "data": {
     "vaccinationsPerDhb": [
       {

--- a/data/vaccineData/2021-10-31.json
+++ b/data/vaccineData/2021-10-31.json
@@ -1,5 +1,5 @@
 {
-  "metaData": {
+  "metadata": {
     "createdAtUtcTimeIso": "2021-11-07T05:46:24.788Z",
     "updatedAtUtcTimeIso": "2021-11-07T05:46:24.788Z"
   },

--- a/data/vaccineData/2021-11-01.json
+++ b/data/vaccineData/2021-11-01.json
@@ -1,4 +1,8 @@
 {
+  "metaData": {
+    "createdAtUtcTimeIso": "2021-11-07T05:46:24.788Z",
+    "updatedAtUtcTimeIso": "2021-11-07T05:46:24.788Z"
+  },
   "data": {
     "vaccinationsPerDhb": [
       {

--- a/data/vaccineData/2021-11-01.json
+++ b/data/vaccineData/2021-11-01.json
@@ -1,5 +1,5 @@
 {
-  "metaData": {
+  "metadata": {
     "createdAtUtcTimeIso": "2021-11-07T05:46:24.788Z",
     "updatedAtUtcTimeIso": "2021-11-07T05:46:24.788Z"
   },

--- a/data/vaccineData/2021-11-01.json
+++ b/data/vaccineData/2021-11-01.json
@@ -1,215 +1,217 @@
 {
-  "vaccinationsPerDhb": [
-    {
-      "dhbName": "Northland",
-      "firstDoses": 128068,
-      "firstDosesPercentage": 0.79,
-      "firstDosesTo90Percent": 17120,
-      "secondDoses": 104560,
-      "secondDosesPercentage": 0.65,
-      "secondDosesTo90Percent": 40628,
-      "totalPopulation": 161320
-    },
-    {
-      "dhbName": "Waitemata",
-      "firstDoses": 480711,
-      "firstDosesPercentage": 0.91,
-      "firstDosesTo90Percent": 0,
-      "secondDoses": 426209,
-      "secondDosesPercentage": 0.81,
-      "secondDosesTo90Percent": 47269,
-      "totalPopulation": 526087
-    },
-    {
-      "dhbName": "Auckland",
-      "firstDoses": 399036,
-      "firstDosesPercentage": 0.94,
-      "firstDosesTo90Percent": 0,
-      "secondDoses": 360143,
-      "secondDosesPercentage": 0.85,
-      "secondDosesTo90Percent": 21419,
-      "totalPopulation": 423958
-    },
-    {
-      "dhbName": "Counties Manukau",
-      "firstDoses": 430545,
-      "firstDosesPercentage": 0.89,
-      "firstDosesTo90Percent": 3951,
-      "secondDoses": 374881,
-      "secondDosesPercentage": 0.78,
-      "secondDosesTo90Percent": 59615,
-      "totalPopulation": 482773
-    },
-    {
-      "dhbName": "Waikato",
-      "firstDoses": 310407,
-      "firstDosesPercentage": 0.87,
-      "firstDosesTo90Percent": 11051,
-      "secondDoses": 259826,
-      "secondDosesPercentage": 0.73,
-      "secondDosesTo90Percent": 61632,
-      "totalPopulation": 357176
-    },
-    {
-      "dhbName": "Lakes",
-      "firstDoses": 76421,
-      "firstDosesPercentage": 0.81,
-      "firstDosesTo90Percent": 8556,
-      "secondDoses": 62426,
-      "secondDosesPercentage": 0.66,
-      "secondDosesTo90Percent": 22551,
-      "totalPopulation": 94419
-    },
-    {
-      "dhbName": "Bay of Plenty",
-      "firstDoses": 180801,
-      "firstDosesPercentage": 0.83,
-      "firstDosesTo90Percent": 14446,
-      "secondDoses": 148017,
-      "secondDosesPercentage": 0.68,
-      "secondDosesTo90Percent": 47230,
-      "totalPopulation": 216941
-    },
-    {
-      "dhbName": "Tairawhiti",
-      "firstDoses": 32971,
-      "firstDosesPercentage": 0.79,
-      "firstDosesTo90Percent": 4798,
-      "secondDoses": 26826,
-      "secondDosesPercentage": 0.64,
-      "secondDosesTo90Percent": 10942,
-      "totalPopulation": 41965
-    },
-    {
-      "dhbName": "Taranaki",
-      "firstDoses": 86191,
-      "firstDosesPercentage": 0.84,
-      "firstDosesTo90Percent": 5741,
-      "secondDoses": 68071,
-      "secondDosesPercentage": 0.67,
-      "secondDosesTo90Percent": 23861,
-      "totalPopulation": 102147
-    },
-    {
-      "dhbName": "Hawkes Bay",
-      "firstDoses": 123446,
-      "firstDosesPercentage": 0.85,
-      "firstDosesTo90Percent": 7568,
-      "secondDoses": 104470,
-      "secondDosesPercentage": 0.72,
-      "secondDosesTo90Percent": 26544,
-      "totalPopulation": 145571
-    },
-    {
-      "dhbName": "MidCentral",
-      "firstDoses": 131740,
-      "firstDosesPercentage": 0.86,
-      "firstDosesTo90Percent": 5332,
-      "secondDoses": 110879,
-      "secondDosesPercentage": 0.73,
-      "secondDosesTo90Percent": 26193,
-      "totalPopulation": 152302
-    },
-    {
-      "dhbName": "Whanganui",
-      "firstDoses": 46207,
-      "firstDosesPercentage": 0.81,
-      "firstDosesTo90Percent": 5315,
-      "secondDoses": 39038,
-      "secondDosesPercentage": 0.68,
-      "secondDosesTo90Percent": 12484,
-      "totalPopulation": 57247
-    },
-    {
-      "dhbName": "Capital and Coast",
-      "firstDoses": 250231,
-      "firstDosesPercentage": 0.92,
-      "firstDosesTo90Percent": 0,
-      "secondDoses": 219122,
-      "secondDosesPercentage": 0.81,
-      "secondDosesTo90Percent": 24935,
-      "totalPopulation": 271174
-    },
-    {
-      "dhbName": "Hutt Valley",
-      "firstDoses": 114892,
-      "firstDosesPercentage": 0.88,
-      "firstDosesTo90Percent": 2323,
-      "secondDoses": 97676,
-      "secondDosesPercentage": 0.75,
-      "secondDosesTo90Percent": 19539,
-      "totalPopulation": 130239
-    },
-    {
-      "dhbName": "Wairarapa",
-      "firstDoses": 35511,
-      "firstDosesPercentage": 0.86,
-      "firstDosesTo90Percent": 1773,
-      "secondDoses": 30174,
-      "secondDosesPercentage": 0.73,
-      "secondDosesTo90Percent": 7110,
-      "totalPopulation": 41427
-    },
-    {
-      "dhbName": "Nelson Marlborough",
-      "firstDoses": 118070,
-      "firstDosesPercentage": 0.87,
-      "firstDosesTo90Percent": 4099,
-      "secondDoses": 103539,
-      "secondDosesPercentage": 0.76,
-      "secondDosesTo90Percent": 18630,
-      "totalPopulation": 135743
-    },
-    {
-      "dhbName": "West Coast",
-      "firstDoses": 22822,
-      "firstDosesPercentage": 0.82,
-      "firstDosesTo90Percent": 2293,
-      "secondDoses": 18817,
-      "secondDosesPercentage": 0.67,
-      "secondDosesTo90Percent": 6298,
-      "totalPopulation": 27906
-    },
-    {
-      "dhbName": "Canterbury",
-      "firstDoses": 441511,
-      "firstDosesPercentage": 0.91,
-      "firstDosesTo90Percent": 0,
-      "secondDoses": 359535,
-      "secondDosesPercentage": 0.74,
-      "secondDosesTo90Percent": 75066,
-      "totalPopulation": 482890
-    },
-    {
-      "dhbName": "South Canterbury",
-      "firstDoses": 45654,
-      "firstDosesPercentage": 0.87,
-      "firstDosesTo90Percent": 1672,
-      "secondDoses": 39525,
-      "secondDosesPercentage": 0.75,
-      "secondDosesTo90Percent": 7801,
-      "totalPopulation": 52584
-    },
-    {
-      "dhbName": "Southern",
-      "firstDoses": 259459,
-      "firstDosesPercentage": 0.9,
-      "firstDosesTo90Percent": 0,
-      "secondDoses": 224409,
-      "secondDosesPercentage": 0.78,
-      "secondDosesTo90Percent": 34804,
-      "totalPopulation": 288015
-    },
-    {
-      "dhbName": "Overseas / Unknown",
-      "firstDoses": 2046,
-      "firstDosesPercentage": 0.12,
-      "firstDosesTo90Percent": 13410,
-      "secondDoses": 1674,
-      "secondDosesPercentage": 0.1,
-      "secondDosesTo90Percent": 13782,
-      "totalPopulation": 17173
-    }
-  ],
-  "dataValidAsAtNzTimeIso": "2021-11-01T23:59:00.000+13:00"
+  "data": {
+    "vaccinationsPerDhb": [
+      {
+        "dhbName": "Northland",
+        "firstDoses": 128068,
+        "firstDosesPercentage": 0.79,
+        "firstDosesTo90Percent": 17120,
+        "secondDoses": 104560,
+        "secondDosesPercentage": 0.65,
+        "secondDosesTo90Percent": 40628,
+        "totalPopulation": 161320
+      },
+      {
+        "dhbName": "Waitemata",
+        "firstDoses": 480711,
+        "firstDosesPercentage": 0.91,
+        "firstDosesTo90Percent": 0,
+        "secondDoses": 426209,
+        "secondDosesPercentage": 0.81,
+        "secondDosesTo90Percent": 47269,
+        "totalPopulation": 526087
+      },
+      {
+        "dhbName": "Auckland",
+        "firstDoses": 399036,
+        "firstDosesPercentage": 0.94,
+        "firstDosesTo90Percent": 0,
+        "secondDoses": 360143,
+        "secondDosesPercentage": 0.85,
+        "secondDosesTo90Percent": 21419,
+        "totalPopulation": 423958
+      },
+      {
+        "dhbName": "Counties Manukau",
+        "firstDoses": 430545,
+        "firstDosesPercentage": 0.89,
+        "firstDosesTo90Percent": 3951,
+        "secondDoses": 374881,
+        "secondDosesPercentage": 0.78,
+        "secondDosesTo90Percent": 59615,
+        "totalPopulation": 482773
+      },
+      {
+        "dhbName": "Waikato",
+        "firstDoses": 310407,
+        "firstDosesPercentage": 0.87,
+        "firstDosesTo90Percent": 11051,
+        "secondDoses": 259826,
+        "secondDosesPercentage": 0.73,
+        "secondDosesTo90Percent": 61632,
+        "totalPopulation": 357176
+      },
+      {
+        "dhbName": "Lakes",
+        "firstDoses": 76421,
+        "firstDosesPercentage": 0.81,
+        "firstDosesTo90Percent": 8556,
+        "secondDoses": 62426,
+        "secondDosesPercentage": 0.66,
+        "secondDosesTo90Percent": 22551,
+        "totalPopulation": 94419
+      },
+      {
+        "dhbName": "Bay of Plenty",
+        "firstDoses": 180801,
+        "firstDosesPercentage": 0.83,
+        "firstDosesTo90Percent": 14446,
+        "secondDoses": 148017,
+        "secondDosesPercentage": 0.68,
+        "secondDosesTo90Percent": 47230,
+        "totalPopulation": 216941
+      },
+      {
+        "dhbName": "Tairawhiti",
+        "firstDoses": 32971,
+        "firstDosesPercentage": 0.79,
+        "firstDosesTo90Percent": 4798,
+        "secondDoses": 26826,
+        "secondDosesPercentage": 0.64,
+        "secondDosesTo90Percent": 10942,
+        "totalPopulation": 41965
+      },
+      {
+        "dhbName": "Taranaki",
+        "firstDoses": 86191,
+        "firstDosesPercentage": 0.84,
+        "firstDosesTo90Percent": 5741,
+        "secondDoses": 68071,
+        "secondDosesPercentage": 0.67,
+        "secondDosesTo90Percent": 23861,
+        "totalPopulation": 102147
+      },
+      {
+        "dhbName": "Hawkes Bay",
+        "firstDoses": 123446,
+        "firstDosesPercentage": 0.85,
+        "firstDosesTo90Percent": 7568,
+        "secondDoses": 104470,
+        "secondDosesPercentage": 0.72,
+        "secondDosesTo90Percent": 26544,
+        "totalPopulation": 145571
+      },
+      {
+        "dhbName": "MidCentral",
+        "firstDoses": 131740,
+        "firstDosesPercentage": 0.86,
+        "firstDosesTo90Percent": 5332,
+        "secondDoses": 110879,
+        "secondDosesPercentage": 0.73,
+        "secondDosesTo90Percent": 26193,
+        "totalPopulation": 152302
+      },
+      {
+        "dhbName": "Whanganui",
+        "firstDoses": 46207,
+        "firstDosesPercentage": 0.81,
+        "firstDosesTo90Percent": 5315,
+        "secondDoses": 39038,
+        "secondDosesPercentage": 0.68,
+        "secondDosesTo90Percent": 12484,
+        "totalPopulation": 57247
+      },
+      {
+        "dhbName": "Capital and Coast",
+        "firstDoses": 250231,
+        "firstDosesPercentage": 0.92,
+        "firstDosesTo90Percent": 0,
+        "secondDoses": 219122,
+        "secondDosesPercentage": 0.81,
+        "secondDosesTo90Percent": 24935,
+        "totalPopulation": 271174
+      },
+      {
+        "dhbName": "Hutt Valley",
+        "firstDoses": 114892,
+        "firstDosesPercentage": 0.88,
+        "firstDosesTo90Percent": 2323,
+        "secondDoses": 97676,
+        "secondDosesPercentage": 0.75,
+        "secondDosesTo90Percent": 19539,
+        "totalPopulation": 130239
+      },
+      {
+        "dhbName": "Wairarapa",
+        "firstDoses": 35511,
+        "firstDosesPercentage": 0.86,
+        "firstDosesTo90Percent": 1773,
+        "secondDoses": 30174,
+        "secondDosesPercentage": 0.73,
+        "secondDosesTo90Percent": 7110,
+        "totalPopulation": 41427
+      },
+      {
+        "dhbName": "Nelson Marlborough",
+        "firstDoses": 118070,
+        "firstDosesPercentage": 0.87,
+        "firstDosesTo90Percent": 4099,
+        "secondDoses": 103539,
+        "secondDosesPercentage": 0.76,
+        "secondDosesTo90Percent": 18630,
+        "totalPopulation": 135743
+      },
+      {
+        "dhbName": "West Coast",
+        "firstDoses": 22822,
+        "firstDosesPercentage": 0.82,
+        "firstDosesTo90Percent": 2293,
+        "secondDoses": 18817,
+        "secondDosesPercentage": 0.67,
+        "secondDosesTo90Percent": 6298,
+        "totalPopulation": 27906
+      },
+      {
+        "dhbName": "Canterbury",
+        "firstDoses": 441511,
+        "firstDosesPercentage": 0.91,
+        "firstDosesTo90Percent": 0,
+        "secondDoses": 359535,
+        "secondDosesPercentage": 0.74,
+        "secondDosesTo90Percent": 75066,
+        "totalPopulation": 482890
+      },
+      {
+        "dhbName": "South Canterbury",
+        "firstDoses": 45654,
+        "firstDosesPercentage": 0.87,
+        "firstDosesTo90Percent": 1672,
+        "secondDoses": 39525,
+        "secondDosesPercentage": 0.75,
+        "secondDosesTo90Percent": 7801,
+        "totalPopulation": 52584
+      },
+      {
+        "dhbName": "Southern",
+        "firstDoses": 259459,
+        "firstDosesPercentage": 0.9,
+        "firstDosesTo90Percent": 0,
+        "secondDoses": 224409,
+        "secondDosesPercentage": 0.78,
+        "secondDosesTo90Percent": 34804,
+        "totalPopulation": 288015
+      },
+      {
+        "dhbName": "Overseas / Unknown",
+        "firstDoses": 2046,
+        "firstDosesPercentage": 0.12,
+        "firstDosesTo90Percent": 13410,
+        "secondDoses": 1674,
+        "secondDosesPercentage": 0.1,
+        "secondDosesTo90Percent": 13782,
+        "totalPopulation": 17173
+      }
+    ],
+    "dataValidAsAtNzTimeIso": "2021-11-01T23:59:00.000+13:00"
+  }
 }

--- a/data/vaccineData/2021-11-02.json
+++ b/data/vaccineData/2021-11-02.json
@@ -1,5 +1,5 @@
 {
-  "metaData": {
+  "metadata": {
     "createdAtUtcTimeIso": "2021-11-07T05:46:24.787Z",
     "updatedAtUtcTimeIso": "2021-11-07T05:46:24.787Z"
   },

--- a/data/vaccineData/2021-11-02.json
+++ b/data/vaccineData/2021-11-02.json
@@ -1,215 +1,217 @@
 {
-  "vaccinationsPerDhb": [
-    {
-      "dhbName": "Northland",
-      "firstDoses": 128556,
-      "firstDosesPercentage": 0.8,
-      "firstDosesTo90Percent": 16632,
-      "secondDoses": 105631,
-      "secondDosesPercentage": 0.65,
-      "secondDosesTo90Percent": 39557,
-      "totalPopulation": 161320
-    },
-    {
-      "dhbName": "Waitemata",
-      "firstDoses": 481264,
-      "firstDosesPercentage": 0.91,
-      "firstDosesTo90Percent": 0,
-      "secondDoses": 428451,
-      "secondDosesPercentage": 0.81,
-      "secondDosesTo90Percent": 45027,
-      "totalPopulation": 526087
-    },
-    {
-      "dhbName": "Auckland",
-      "firstDoses": 399426,
-      "firstDosesPercentage": 0.94,
-      "firstDosesTo90Percent": 0,
-      "secondDoses": 361728,
-      "secondDosesPercentage": 0.85,
-      "secondDosesTo90Percent": 19834,
-      "totalPopulation": 423958
-    },
-    {
-      "dhbName": "Counties Manukau",
-      "firstDoses": 431303,
-      "firstDosesPercentage": 0.89,
-      "firstDosesTo90Percent": 3193,
-      "secondDoses": 376790,
-      "secondDosesPercentage": 0.78,
-      "secondDosesTo90Percent": 57706,
-      "totalPopulation": 482773
-    },
-    {
-      "dhbName": "Waikato",
-      "firstDoses": 311221,
-      "firstDosesPercentage": 0.87,
-      "firstDosesTo90Percent": 10237,
-      "secondDoses": 261839,
-      "secondDosesPercentage": 0.73,
-      "secondDosesTo90Percent": 59619,
-      "totalPopulation": 357176
-    },
-    {
-      "dhbName": "Lakes",
-      "firstDoses": 76643,
-      "firstDosesPercentage": 0.81,
-      "firstDosesTo90Percent": 8334,
-      "secondDoses": 63033,
-      "secondDosesPercentage": 0.67,
-      "secondDosesTo90Percent": 21944,
-      "totalPopulation": 94419
-    },
-    {
-      "dhbName": "Bay of Plenty",
-      "firstDoses": 181214,
-      "firstDosesPercentage": 0.84,
-      "firstDosesTo90Percent": 14033,
-      "secondDoses": 149431,
-      "secondDosesPercentage": 0.69,
-      "secondDosesTo90Percent": 45816,
-      "totalPopulation": 216941
-    },
-    {
-      "dhbName": "Tairawhiti",
-      "firstDoses": 33125,
-      "firstDosesPercentage": 0.79,
-      "firstDosesTo90Percent": 4644,
-      "secondDoses": 27017,
-      "secondDosesPercentage": 0.64,
-      "secondDosesTo90Percent": 10752,
-      "totalPopulation": 41965
-    },
-    {
-      "dhbName": "Taranaki",
-      "firstDoses": 86381,
-      "firstDosesPercentage": 0.85,
-      "firstDosesTo90Percent": 5551,
-      "secondDoses": 68720,
-      "secondDosesPercentage": 0.67,
-      "secondDosesTo90Percent": 23212,
-      "totalPopulation": 102147
-    },
-    {
-      "dhbName": "Hawkes Bay",
-      "firstDoses": 123666,
-      "firstDosesPercentage": 0.85,
-      "firstDosesTo90Percent": 7348,
-      "secondDoses": 104851,
-      "secondDosesPercentage": 0.72,
-      "secondDosesTo90Percent": 26163,
-      "totalPopulation": 145571
-    },
-    {
-      "dhbName": "MidCentral",
-      "firstDoses": 132067,
-      "firstDosesPercentage": 0.87,
-      "firstDosesTo90Percent": 5005,
-      "secondDoses": 111587,
-      "secondDosesPercentage": 0.73,
-      "secondDosesTo90Percent": 25485,
-      "totalPopulation": 152302
-    },
-    {
-      "dhbName": "Whanganui",
-      "firstDoses": 46340,
-      "firstDosesPercentage": 0.81,
-      "firstDosesTo90Percent": 5182,
-      "secondDoses": 39339,
-      "secondDosesPercentage": 0.69,
-      "secondDosesTo90Percent": 12183,
-      "totalPopulation": 57247
-    },
-    {
-      "dhbName": "Capital and Coast",
-      "firstDoses": 250511,
-      "firstDosesPercentage": 0.92,
-      "firstDosesTo90Percent": 0,
-      "secondDoses": 220597,
-      "secondDosesPercentage": 0.81,
-      "secondDosesTo90Percent": 23460,
-      "totalPopulation": 271174
-    },
-    {
-      "dhbName": "Hutt Valley",
-      "firstDoses": 115093,
-      "firstDosesPercentage": 0.88,
-      "firstDosesTo90Percent": 2122,
-      "secondDoses": 98405,
-      "secondDosesPercentage": 0.76,
-      "secondDosesTo90Percent": 18810,
-      "totalPopulation": 130239
-    },
-    {
-      "dhbName": "Wairarapa",
-      "firstDoses": 35594,
-      "firstDosesPercentage": 0.86,
-      "firstDosesTo90Percent": 1690,
-      "secondDoses": 30372,
-      "secondDosesPercentage": 0.73,
-      "secondDosesTo90Percent": 6912,
-      "totalPopulation": 41427
-    },
-    {
-      "dhbName": "Nelson Marlborough",
-      "firstDoses": 118314,
-      "firstDosesPercentage": 0.87,
-      "firstDosesTo90Percent": 3855,
-      "secondDoses": 103969,
-      "secondDosesPercentage": 0.77,
-      "secondDosesTo90Percent": 18200,
-      "totalPopulation": 135743
-    },
-    {
-      "dhbName": "West Coast",
-      "firstDoses": 22945,
-      "firstDosesPercentage": 0.82,
-      "firstDosesTo90Percent": 2170,
-      "secondDoses": 18966,
-      "secondDosesPercentage": 0.68,
-      "secondDosesTo90Percent": 6149,
-      "totalPopulation": 27906
-    },
-    {
-      "dhbName": "Canterbury",
-      "firstDoses": 442737,
-      "firstDosesPercentage": 0.92,
-      "firstDosesTo90Percent": 0,
-      "secondDoses": 363253,
-      "secondDosesPercentage": 0.75,
-      "secondDosesTo90Percent": 71348,
-      "totalPopulation": 482890
-    },
-    {
-      "dhbName": "South Canterbury",
-      "firstDoses": 45784,
-      "firstDosesPercentage": 0.87,
-      "firstDosesTo90Percent": 1542,
-      "secondDoses": 39780,
-      "secondDosesPercentage": 0.76,
-      "secondDosesTo90Percent": 7546,
-      "totalPopulation": 52584
-    },
-    {
-      "dhbName": "Southern",
-      "firstDoses": 260128,
-      "firstDosesPercentage": 0.9,
-      "firstDosesTo90Percent": 0,
-      "secondDoses": 225777,
-      "secondDosesPercentage": 0.78,
-      "secondDosesTo90Percent": 33436,
-      "totalPopulation": 288015
-    },
-    {
-      "dhbName": "Overseas / Unknown",
-      "firstDoses": 2047,
-      "firstDosesPercentage": 0.12,
-      "firstDosesTo90Percent": 13409,
-      "secondDoses": 1690,
-      "secondDosesPercentage": 0.1,
-      "secondDosesTo90Percent": 13766,
-      "totalPopulation": 17173
-    }
-  ],
-  "dataValidAsAtNzTimeIso": "2021-11-02T23:59:00.000+13:00"
+  "data": {
+    "vaccinationsPerDhb": [
+      {
+        "dhbName": "Northland",
+        "firstDoses": 128556,
+        "firstDosesPercentage": 0.8,
+        "firstDosesTo90Percent": 16632,
+        "secondDoses": 105631,
+        "secondDosesPercentage": 0.65,
+        "secondDosesTo90Percent": 39557,
+        "totalPopulation": 161320
+      },
+      {
+        "dhbName": "Waitemata",
+        "firstDoses": 481264,
+        "firstDosesPercentage": 0.91,
+        "firstDosesTo90Percent": 0,
+        "secondDoses": 428451,
+        "secondDosesPercentage": 0.81,
+        "secondDosesTo90Percent": 45027,
+        "totalPopulation": 526087
+      },
+      {
+        "dhbName": "Auckland",
+        "firstDoses": 399426,
+        "firstDosesPercentage": 0.94,
+        "firstDosesTo90Percent": 0,
+        "secondDoses": 361728,
+        "secondDosesPercentage": 0.85,
+        "secondDosesTo90Percent": 19834,
+        "totalPopulation": 423958
+      },
+      {
+        "dhbName": "Counties Manukau",
+        "firstDoses": 431303,
+        "firstDosesPercentage": 0.89,
+        "firstDosesTo90Percent": 3193,
+        "secondDoses": 376790,
+        "secondDosesPercentage": 0.78,
+        "secondDosesTo90Percent": 57706,
+        "totalPopulation": 482773
+      },
+      {
+        "dhbName": "Waikato",
+        "firstDoses": 311221,
+        "firstDosesPercentage": 0.87,
+        "firstDosesTo90Percent": 10237,
+        "secondDoses": 261839,
+        "secondDosesPercentage": 0.73,
+        "secondDosesTo90Percent": 59619,
+        "totalPopulation": 357176
+      },
+      {
+        "dhbName": "Lakes",
+        "firstDoses": 76643,
+        "firstDosesPercentage": 0.81,
+        "firstDosesTo90Percent": 8334,
+        "secondDoses": 63033,
+        "secondDosesPercentage": 0.67,
+        "secondDosesTo90Percent": 21944,
+        "totalPopulation": 94419
+      },
+      {
+        "dhbName": "Bay of Plenty",
+        "firstDoses": 181214,
+        "firstDosesPercentage": 0.84,
+        "firstDosesTo90Percent": 14033,
+        "secondDoses": 149431,
+        "secondDosesPercentage": 0.69,
+        "secondDosesTo90Percent": 45816,
+        "totalPopulation": 216941
+      },
+      {
+        "dhbName": "Tairawhiti",
+        "firstDoses": 33125,
+        "firstDosesPercentage": 0.79,
+        "firstDosesTo90Percent": 4644,
+        "secondDoses": 27017,
+        "secondDosesPercentage": 0.64,
+        "secondDosesTo90Percent": 10752,
+        "totalPopulation": 41965
+      },
+      {
+        "dhbName": "Taranaki",
+        "firstDoses": 86381,
+        "firstDosesPercentage": 0.85,
+        "firstDosesTo90Percent": 5551,
+        "secondDoses": 68720,
+        "secondDosesPercentage": 0.67,
+        "secondDosesTo90Percent": 23212,
+        "totalPopulation": 102147
+      },
+      {
+        "dhbName": "Hawkes Bay",
+        "firstDoses": 123666,
+        "firstDosesPercentage": 0.85,
+        "firstDosesTo90Percent": 7348,
+        "secondDoses": 104851,
+        "secondDosesPercentage": 0.72,
+        "secondDosesTo90Percent": 26163,
+        "totalPopulation": 145571
+      },
+      {
+        "dhbName": "MidCentral",
+        "firstDoses": 132067,
+        "firstDosesPercentage": 0.87,
+        "firstDosesTo90Percent": 5005,
+        "secondDoses": 111587,
+        "secondDosesPercentage": 0.73,
+        "secondDosesTo90Percent": 25485,
+        "totalPopulation": 152302
+      },
+      {
+        "dhbName": "Whanganui",
+        "firstDoses": 46340,
+        "firstDosesPercentage": 0.81,
+        "firstDosesTo90Percent": 5182,
+        "secondDoses": 39339,
+        "secondDosesPercentage": 0.69,
+        "secondDosesTo90Percent": 12183,
+        "totalPopulation": 57247
+      },
+      {
+        "dhbName": "Capital and Coast",
+        "firstDoses": 250511,
+        "firstDosesPercentage": 0.92,
+        "firstDosesTo90Percent": 0,
+        "secondDoses": 220597,
+        "secondDosesPercentage": 0.81,
+        "secondDosesTo90Percent": 23460,
+        "totalPopulation": 271174
+      },
+      {
+        "dhbName": "Hutt Valley",
+        "firstDoses": 115093,
+        "firstDosesPercentage": 0.88,
+        "firstDosesTo90Percent": 2122,
+        "secondDoses": 98405,
+        "secondDosesPercentage": 0.76,
+        "secondDosesTo90Percent": 18810,
+        "totalPopulation": 130239
+      },
+      {
+        "dhbName": "Wairarapa",
+        "firstDoses": 35594,
+        "firstDosesPercentage": 0.86,
+        "firstDosesTo90Percent": 1690,
+        "secondDoses": 30372,
+        "secondDosesPercentage": 0.73,
+        "secondDosesTo90Percent": 6912,
+        "totalPopulation": 41427
+      },
+      {
+        "dhbName": "Nelson Marlborough",
+        "firstDoses": 118314,
+        "firstDosesPercentage": 0.87,
+        "firstDosesTo90Percent": 3855,
+        "secondDoses": 103969,
+        "secondDosesPercentage": 0.77,
+        "secondDosesTo90Percent": 18200,
+        "totalPopulation": 135743
+      },
+      {
+        "dhbName": "West Coast",
+        "firstDoses": 22945,
+        "firstDosesPercentage": 0.82,
+        "firstDosesTo90Percent": 2170,
+        "secondDoses": 18966,
+        "secondDosesPercentage": 0.68,
+        "secondDosesTo90Percent": 6149,
+        "totalPopulation": 27906
+      },
+      {
+        "dhbName": "Canterbury",
+        "firstDoses": 442737,
+        "firstDosesPercentage": 0.92,
+        "firstDosesTo90Percent": 0,
+        "secondDoses": 363253,
+        "secondDosesPercentage": 0.75,
+        "secondDosesTo90Percent": 71348,
+        "totalPopulation": 482890
+      },
+      {
+        "dhbName": "South Canterbury",
+        "firstDoses": 45784,
+        "firstDosesPercentage": 0.87,
+        "firstDosesTo90Percent": 1542,
+        "secondDoses": 39780,
+        "secondDosesPercentage": 0.76,
+        "secondDosesTo90Percent": 7546,
+        "totalPopulation": 52584
+      },
+      {
+        "dhbName": "Southern",
+        "firstDoses": 260128,
+        "firstDosesPercentage": 0.9,
+        "firstDosesTo90Percent": 0,
+        "secondDoses": 225777,
+        "secondDosesPercentage": 0.78,
+        "secondDosesTo90Percent": 33436,
+        "totalPopulation": 288015
+      },
+      {
+        "dhbName": "Overseas / Unknown",
+        "firstDoses": 2047,
+        "firstDosesPercentage": 0.12,
+        "firstDosesTo90Percent": 13409,
+        "secondDoses": 1690,
+        "secondDosesPercentage": 0.1,
+        "secondDosesTo90Percent": 13766,
+        "totalPopulation": 17173
+      }
+    ],
+    "dataValidAsAtNzTimeIso": "2021-11-02T23:59:00.000+13:00"
+  }
 }

--- a/data/vaccineData/2021-11-02.json
+++ b/data/vaccineData/2021-11-02.json
@@ -1,4 +1,8 @@
 {
+  "metaData": {
+    "createdAtUtcTimeIso": "2021-11-07T05:46:24.787Z",
+    "updatedAtUtcTimeIso": "2021-11-07T05:46:24.787Z"
+  },
   "data": {
     "vaccinationsPerDhb": [
       {

--- a/data/vaccineData/2021-11-03.json
+++ b/data/vaccineData/2021-11-03.json
@@ -1,4 +1,8 @@
 {
+  "metaData": {
+    "createdAtUtcTimeIso": "2021-11-07T05:46:24.789Z",
+    "updatedAtUtcTimeIso": "2021-11-07T05:46:24.789Z"
+  },
   "data": {
     "vaccinationsPerDhb": [
       {

--- a/data/vaccineData/2021-11-03.json
+++ b/data/vaccineData/2021-11-03.json
@@ -1,5 +1,5 @@
 {
-  "metaData": {
+  "metadata": {
     "createdAtUtcTimeIso": "2021-11-07T05:46:24.789Z",
     "updatedAtUtcTimeIso": "2021-11-07T05:46:24.789Z"
   },

--- a/data/vaccineData/2021-11-03.json
+++ b/data/vaccineData/2021-11-03.json
@@ -1,215 +1,217 @@
 {
-  "vaccinationsPerDhb": [
-    {
-      "dhbName": "Northland",
-      "firstDoses": 129027,
-      "firstDosesPercentage": 0.8,
-      "firstDosesTo90Percent": 16161,
-      "secondDoses": 106740,
-      "secondDosesPercentage": 0.66,
-      "secondDosesTo90Percent": 38448,
-      "totalPopulation": 161320
-    },
-    {
-      "dhbName": "Waitemata",
-      "firstDoses": 481759,
-      "firstDosesPercentage": 0.92,
-      "firstDosesTo90Percent": 0,
-      "secondDoses": 430497,
-      "secondDosesPercentage": 0.82,
-      "secondDosesTo90Percent": 42981,
-      "totalPopulation": 526087
-    },
-    {
-      "dhbName": "Auckland",
-      "firstDoses": 399755,
-      "firstDosesPercentage": 0.94,
-      "firstDosesTo90Percent": 0,
-      "secondDoses": 363131,
-      "secondDosesPercentage": 0.86,
-      "secondDosesTo90Percent": 18431,
-      "totalPopulation": 423958
-    },
-    {
-      "dhbName": "Counties Manukau",
-      "firstDoses": 431883,
-      "firstDosesPercentage": 0.89,
-      "firstDosesTo90Percent": 2613,
-      "secondDoses": 378471,
-      "secondDosesPercentage": 0.78,
-      "secondDosesTo90Percent": 56025,
-      "totalPopulation": 482773
-    },
-    {
-      "dhbName": "Waikato",
-      "firstDoses": 311897,
-      "firstDosesPercentage": 0.87,
-      "firstDosesTo90Percent": 9561,
-      "secondDoses": 263750,
-      "secondDosesPercentage": 0.74,
-      "secondDosesTo90Percent": 57708,
-      "totalPopulation": 357176
-    },
-    {
-      "dhbName": "Lakes",
-      "firstDoses": 76834,
-      "firstDosesPercentage": 0.81,
-      "firstDosesTo90Percent": 8143,
-      "secondDoses": 63513,
-      "secondDosesPercentage": 0.67,
-      "secondDosesTo90Percent": 21464,
-      "totalPopulation": 94419
-    },
-    {
-      "dhbName": "Bay of Plenty",
-      "firstDoses": 181618,
-      "firstDosesPercentage": 0.84,
-      "firstDosesTo90Percent": 13629,
-      "secondDoses": 150784,
-      "secondDosesPercentage": 0.7,
-      "secondDosesTo90Percent": 44463,
-      "totalPopulation": 216941
-    },
-    {
-      "dhbName": "Tairawhiti",
-      "firstDoses": 33228,
-      "firstDosesPercentage": 0.79,
-      "firstDosesTo90Percent": 4540,
-      "secondDoses": 27229,
-      "secondDosesPercentage": 0.65,
-      "secondDosesTo90Percent": 10540,
-      "totalPopulation": 41965
-    },
-    {
-      "dhbName": "Taranaki",
-      "firstDoses": 86549,
-      "firstDosesPercentage": 0.85,
-      "firstDosesTo90Percent": 5383,
-      "secondDoses": 69391,
-      "secondDosesPercentage": 0.68,
-      "secondDosesTo90Percent": 22541,
-      "totalPopulation": 102147
-    },
-    {
-      "dhbName": "Hawkes Bay",
-      "firstDoses": 123888,
-      "firstDosesPercentage": 0.85,
-      "firstDosesTo90Percent": 7126,
-      "secondDoses": 105279,
-      "secondDosesPercentage": 0.72,
-      "secondDosesTo90Percent": 25735,
-      "totalPopulation": 145571
-    },
-    {
-      "dhbName": "MidCentral",
-      "firstDoses": 132338,
-      "firstDosesPercentage": 0.87,
-      "firstDosesTo90Percent": 4734,
-      "secondDoses": 112336,
-      "secondDosesPercentage": 0.74,
-      "secondDosesTo90Percent": 24736,
-      "totalPopulation": 152302
-    },
-    {
-      "dhbName": "Whanganui",
-      "firstDoses": 46498,
-      "firstDosesPercentage": 0.81,
-      "firstDosesTo90Percent": 5024,
-      "secondDoses": 39670,
-      "secondDosesPercentage": 0.69,
-      "secondDosesTo90Percent": 11852,
-      "totalPopulation": 57247
-    },
-    {
-      "dhbName": "Capital and Coast",
-      "firstDoses": 250856,
-      "firstDosesPercentage": 0.93,
-      "firstDosesTo90Percent": 0,
-      "secondDoses": 221996,
-      "secondDosesPercentage": 0.82,
-      "secondDosesTo90Percent": 22061,
-      "totalPopulation": 271174
-    },
-    {
-      "dhbName": "Hutt Valley",
-      "firstDoses": 115248,
-      "firstDosesPercentage": 0.88,
-      "firstDosesTo90Percent": 1967,
-      "secondDoses": 99048,
-      "secondDosesPercentage": 0.76,
-      "secondDosesTo90Percent": 18167,
-      "totalPopulation": 130239
-    },
-    {
-      "dhbName": "Wairarapa",
-      "firstDoses": 35683,
-      "firstDosesPercentage": 0.86,
-      "firstDosesTo90Percent": 1601,
-      "secondDoses": 30538,
-      "secondDosesPercentage": 0.74,
-      "secondDosesTo90Percent": 6746,
-      "totalPopulation": 41427
-    },
-    {
-      "dhbName": "Nelson Marlborough",
-      "firstDoses": 118577,
-      "firstDosesPercentage": 0.87,
-      "firstDosesTo90Percent": 3592,
-      "secondDoses": 104399,
-      "secondDosesPercentage": 0.77,
-      "secondDosesTo90Percent": 17770,
-      "totalPopulation": 135743
-    },
-    {
-      "dhbName": "West Coast",
-      "firstDoses": 23017,
-      "firstDosesPercentage": 0.82,
-      "firstDosesTo90Percent": 2098,
-      "secondDoses": 19163,
-      "secondDosesPercentage": 0.69,
-      "secondDosesTo90Percent": 5952,
-      "totalPopulation": 27906
-    },
-    {
-      "dhbName": "Canterbury",
-      "firstDoses": 443844,
-      "firstDosesPercentage": 0.92,
-      "firstDosesTo90Percent": 0,
-      "secondDoses": 367016,
-      "secondDosesPercentage": 0.76,
-      "secondDosesTo90Percent": 67585,
-      "totalPopulation": 482890
-    },
-    {
-      "dhbName": "South Canterbury",
-      "firstDoses": 45898,
-      "firstDosesPercentage": 0.87,
-      "firstDosesTo90Percent": 1428,
-      "secondDoses": 40025,
-      "secondDosesPercentage": 0.76,
-      "secondDosesTo90Percent": 7301,
-      "totalPopulation": 52584
-    },
-    {
-      "dhbName": "Southern",
-      "firstDoses": 260752,
-      "firstDosesPercentage": 0.91,
-      "firstDosesTo90Percent": 0,
-      "secondDoses": 227111,
-      "secondDosesPercentage": 0.79,
-      "secondDosesTo90Percent": 32102,
-      "totalPopulation": 288015
-    },
-    {
-      "dhbName": "Overseas / Unknown",
-      "firstDoses": 2056,
-      "firstDosesPercentage": 0.12,
-      "firstDosesTo90Percent": 13400,
-      "secondDoses": 1700,
-      "secondDosesPercentage": 0.1,
-      "secondDosesTo90Percent": 13756,
-      "totalPopulation": 17173
-    }
-  ],
-  "dataValidAsAtNzTimeIso": "2021-11-03T23:59:00.000+13:00"
+  "data": {
+    "vaccinationsPerDhb": [
+      {
+        "dhbName": "Northland",
+        "firstDoses": 129027,
+        "firstDosesPercentage": 0.8,
+        "firstDosesTo90Percent": 16161,
+        "secondDoses": 106740,
+        "secondDosesPercentage": 0.66,
+        "secondDosesTo90Percent": 38448,
+        "totalPopulation": 161320
+      },
+      {
+        "dhbName": "Waitemata",
+        "firstDoses": 481759,
+        "firstDosesPercentage": 0.92,
+        "firstDosesTo90Percent": 0,
+        "secondDoses": 430497,
+        "secondDosesPercentage": 0.82,
+        "secondDosesTo90Percent": 42981,
+        "totalPopulation": 526087
+      },
+      {
+        "dhbName": "Auckland",
+        "firstDoses": 399755,
+        "firstDosesPercentage": 0.94,
+        "firstDosesTo90Percent": 0,
+        "secondDoses": 363131,
+        "secondDosesPercentage": 0.86,
+        "secondDosesTo90Percent": 18431,
+        "totalPopulation": 423958
+      },
+      {
+        "dhbName": "Counties Manukau",
+        "firstDoses": 431883,
+        "firstDosesPercentage": 0.89,
+        "firstDosesTo90Percent": 2613,
+        "secondDoses": 378471,
+        "secondDosesPercentage": 0.78,
+        "secondDosesTo90Percent": 56025,
+        "totalPopulation": 482773
+      },
+      {
+        "dhbName": "Waikato",
+        "firstDoses": 311897,
+        "firstDosesPercentage": 0.87,
+        "firstDosesTo90Percent": 9561,
+        "secondDoses": 263750,
+        "secondDosesPercentage": 0.74,
+        "secondDosesTo90Percent": 57708,
+        "totalPopulation": 357176
+      },
+      {
+        "dhbName": "Lakes",
+        "firstDoses": 76834,
+        "firstDosesPercentage": 0.81,
+        "firstDosesTo90Percent": 8143,
+        "secondDoses": 63513,
+        "secondDosesPercentage": 0.67,
+        "secondDosesTo90Percent": 21464,
+        "totalPopulation": 94419
+      },
+      {
+        "dhbName": "Bay of Plenty",
+        "firstDoses": 181618,
+        "firstDosesPercentage": 0.84,
+        "firstDosesTo90Percent": 13629,
+        "secondDoses": 150784,
+        "secondDosesPercentage": 0.7,
+        "secondDosesTo90Percent": 44463,
+        "totalPopulation": 216941
+      },
+      {
+        "dhbName": "Tairawhiti",
+        "firstDoses": 33228,
+        "firstDosesPercentage": 0.79,
+        "firstDosesTo90Percent": 4540,
+        "secondDoses": 27229,
+        "secondDosesPercentage": 0.65,
+        "secondDosesTo90Percent": 10540,
+        "totalPopulation": 41965
+      },
+      {
+        "dhbName": "Taranaki",
+        "firstDoses": 86549,
+        "firstDosesPercentage": 0.85,
+        "firstDosesTo90Percent": 5383,
+        "secondDoses": 69391,
+        "secondDosesPercentage": 0.68,
+        "secondDosesTo90Percent": 22541,
+        "totalPopulation": 102147
+      },
+      {
+        "dhbName": "Hawkes Bay",
+        "firstDoses": 123888,
+        "firstDosesPercentage": 0.85,
+        "firstDosesTo90Percent": 7126,
+        "secondDoses": 105279,
+        "secondDosesPercentage": 0.72,
+        "secondDosesTo90Percent": 25735,
+        "totalPopulation": 145571
+      },
+      {
+        "dhbName": "MidCentral",
+        "firstDoses": 132338,
+        "firstDosesPercentage": 0.87,
+        "firstDosesTo90Percent": 4734,
+        "secondDoses": 112336,
+        "secondDosesPercentage": 0.74,
+        "secondDosesTo90Percent": 24736,
+        "totalPopulation": 152302
+      },
+      {
+        "dhbName": "Whanganui",
+        "firstDoses": 46498,
+        "firstDosesPercentage": 0.81,
+        "firstDosesTo90Percent": 5024,
+        "secondDoses": 39670,
+        "secondDosesPercentage": 0.69,
+        "secondDosesTo90Percent": 11852,
+        "totalPopulation": 57247
+      },
+      {
+        "dhbName": "Capital and Coast",
+        "firstDoses": 250856,
+        "firstDosesPercentage": 0.93,
+        "firstDosesTo90Percent": 0,
+        "secondDoses": 221996,
+        "secondDosesPercentage": 0.82,
+        "secondDosesTo90Percent": 22061,
+        "totalPopulation": 271174
+      },
+      {
+        "dhbName": "Hutt Valley",
+        "firstDoses": 115248,
+        "firstDosesPercentage": 0.88,
+        "firstDosesTo90Percent": 1967,
+        "secondDoses": 99048,
+        "secondDosesPercentage": 0.76,
+        "secondDosesTo90Percent": 18167,
+        "totalPopulation": 130239
+      },
+      {
+        "dhbName": "Wairarapa",
+        "firstDoses": 35683,
+        "firstDosesPercentage": 0.86,
+        "firstDosesTo90Percent": 1601,
+        "secondDoses": 30538,
+        "secondDosesPercentage": 0.74,
+        "secondDosesTo90Percent": 6746,
+        "totalPopulation": 41427
+      },
+      {
+        "dhbName": "Nelson Marlborough",
+        "firstDoses": 118577,
+        "firstDosesPercentage": 0.87,
+        "firstDosesTo90Percent": 3592,
+        "secondDoses": 104399,
+        "secondDosesPercentage": 0.77,
+        "secondDosesTo90Percent": 17770,
+        "totalPopulation": 135743
+      },
+      {
+        "dhbName": "West Coast",
+        "firstDoses": 23017,
+        "firstDosesPercentage": 0.82,
+        "firstDosesTo90Percent": 2098,
+        "secondDoses": 19163,
+        "secondDosesPercentage": 0.69,
+        "secondDosesTo90Percent": 5952,
+        "totalPopulation": 27906
+      },
+      {
+        "dhbName": "Canterbury",
+        "firstDoses": 443844,
+        "firstDosesPercentage": 0.92,
+        "firstDosesTo90Percent": 0,
+        "secondDoses": 367016,
+        "secondDosesPercentage": 0.76,
+        "secondDosesTo90Percent": 67585,
+        "totalPopulation": 482890
+      },
+      {
+        "dhbName": "South Canterbury",
+        "firstDoses": 45898,
+        "firstDosesPercentage": 0.87,
+        "firstDosesTo90Percent": 1428,
+        "secondDoses": 40025,
+        "secondDosesPercentage": 0.76,
+        "secondDosesTo90Percent": 7301,
+        "totalPopulation": 52584
+      },
+      {
+        "dhbName": "Southern",
+        "firstDoses": 260752,
+        "firstDosesPercentage": 0.91,
+        "firstDosesTo90Percent": 0,
+        "secondDoses": 227111,
+        "secondDosesPercentage": 0.79,
+        "secondDosesTo90Percent": 32102,
+        "totalPopulation": 288015
+      },
+      {
+        "dhbName": "Overseas / Unknown",
+        "firstDoses": 2056,
+        "firstDosesPercentage": 0.12,
+        "firstDosesTo90Percent": 13400,
+        "secondDoses": 1700,
+        "secondDosesPercentage": 0.1,
+        "secondDosesTo90Percent": 13756,
+        "totalPopulation": 17173
+      }
+    ],
+    "dataValidAsAtNzTimeIso": "2021-11-03T23:59:00.000+13:00"
+  }
 }

--- a/data/vaccineData/2021-11-04.json
+++ b/data/vaccineData/2021-11-04.json
@@ -1,4 +1,8 @@
 {
+  "metaData": {
+    "createdAtUtcTimeIso": "2021-11-07T05:46:24.789Z",
+    "updatedAtUtcTimeIso": "2021-11-07T05:46:24.789Z"
+  },
   "data": {
     "vaccinationsPerDhb": [
       {

--- a/data/vaccineData/2021-11-04.json
+++ b/data/vaccineData/2021-11-04.json
@@ -1,5 +1,5 @@
 {
-  "metaData": {
+  "metadata": {
     "createdAtUtcTimeIso": "2021-11-07T05:46:24.789Z",
     "updatedAtUtcTimeIso": "2021-11-07T05:46:24.789Z"
   },

--- a/data/vaccineData/2021-11-04.json
+++ b/data/vaccineData/2021-11-04.json
@@ -1,215 +1,217 @@
 {
-  "vaccinationsPerDhb": [
-    {
-      "dhbName": "Northland",
-      "firstDoses": 129508,
-      "firstDosesPercentage": 0.8,
-      "firstDosesTo90Percent": 15680,
-      "secondDoses": 107760,
-      "secondDosesPercentage": 0.67,
-      "secondDosesTo90Percent": 37428,
-      "totalPopulation": 161320
-    },
-    {
-      "dhbName": "Waitemata",
-      "firstDoses": 482323,
-      "firstDosesPercentage": 0.92,
-      "firstDosesTo90Percent": 0,
-      "secondDoses": 432382,
-      "secondDosesPercentage": 0.82,
-      "secondDosesTo90Percent": 41096,
-      "totalPopulation": 526087
-    },
-    {
-      "dhbName": "Auckland",
-      "firstDoses": 400119,
-      "firstDosesPercentage": 0.94,
-      "firstDosesTo90Percent": 0,
-      "secondDoses": 364481,
-      "secondDosesPercentage": 0.86,
-      "secondDosesTo90Percent": 17081,
-      "totalPopulation": 423958
-    },
-    {
-      "dhbName": "Counties Manukau",
-      "firstDoses": 432521,
-      "firstDosesPercentage": 0.9,
-      "firstDosesTo90Percent": 1975,
-      "secondDoses": 380135,
-      "secondDosesPercentage": 0.79,
-      "secondDosesTo90Percent": 54361,
-      "totalPopulation": 482773
-    },
-    {
-      "dhbName": "Waikato",
-      "firstDoses": 312617,
-      "firstDosesPercentage": 0.88,
-      "firstDosesTo90Percent": 8841,
-      "secondDoses": 266000,
-      "secondDosesPercentage": 0.74,
-      "secondDosesTo90Percent": 55458,
-      "totalPopulation": 357176
-    },
-    {
-      "dhbName": "Lakes",
-      "firstDoses": 77008,
-      "firstDosesPercentage": 0.82,
-      "firstDosesTo90Percent": 7969,
-      "secondDoses": 63973,
-      "secondDosesPercentage": 0.68,
-      "secondDosesTo90Percent": 21004,
-      "totalPopulation": 94419
-    },
-    {
-      "dhbName": "Bay of Plenty",
-      "firstDoses": 181957,
-      "firstDosesPercentage": 0.84,
-      "firstDosesTo90Percent": 13290,
-      "secondDoses": 151770,
-      "secondDosesPercentage": 0.7,
-      "secondDosesTo90Percent": 43477,
-      "totalPopulation": 216941
-    },
-    {
-      "dhbName": "Tairawhiti",
-      "firstDoses": 33377,
-      "firstDosesPercentage": 0.8,
-      "firstDosesTo90Percent": 4392,
-      "secondDoses": 27407,
-      "secondDosesPercentage": 0.65,
-      "secondDosesTo90Percent": 10362,
-      "totalPopulation": 41965
-    },
-    {
-      "dhbName": "Taranaki",
-      "firstDoses": 86738,
-      "firstDosesPercentage": 0.85,
-      "firstDosesTo90Percent": 5194,
-      "secondDoses": 70091,
-      "secondDosesPercentage": 0.69,
-      "secondDosesTo90Percent": 21841,
-      "totalPopulation": 102147
-    },
-    {
-      "dhbName": "Hawkes Bay",
-      "firstDoses": 124237,
-      "firstDosesPercentage": 0.85,
-      "firstDosesTo90Percent": 6777,
-      "secondDoses": 105893,
-      "secondDosesPercentage": 0.73,
-      "secondDosesTo90Percent": 25121,
-      "totalPopulation": 145571
-    },
-    {
-      "dhbName": "MidCentral",
-      "firstDoses": 132630,
-      "firstDosesPercentage": 0.87,
-      "firstDosesTo90Percent": 4442,
-      "secondDoses": 112968,
-      "secondDosesPercentage": 0.74,
-      "secondDosesTo90Percent": 24104,
-      "totalPopulation": 152302
-    },
-    {
-      "dhbName": "Whanganui",
-      "firstDoses": 46655,
-      "firstDosesPercentage": 0.81,
-      "firstDosesTo90Percent": 4867,
-      "secondDoses": 40012,
-      "secondDosesPercentage": 0.7,
-      "secondDosesTo90Percent": 11510,
-      "totalPopulation": 57247
-    },
-    {
-      "dhbName": "Capital and Coast",
-      "firstDoses": 251135,
-      "firstDosesPercentage": 0.93,
-      "firstDosesTo90Percent": 0,
-      "secondDoses": 223367,
-      "secondDosesPercentage": 0.82,
-      "secondDosesTo90Percent": 20690,
-      "totalPopulation": 271174
-    },
-    {
-      "dhbName": "Hutt Valley",
-      "firstDoses": 115453,
-      "firstDosesPercentage": 0.89,
-      "firstDosesTo90Percent": 1762,
-      "secondDoses": 99897,
-      "secondDosesPercentage": 0.77,
-      "secondDosesTo90Percent": 17318,
-      "totalPopulation": 130239
-    },
-    {
-      "dhbName": "Wairarapa",
-      "firstDoses": 35736,
-      "firstDosesPercentage": 0.86,
-      "firstDosesTo90Percent": 1548,
-      "secondDoses": 30671,
-      "secondDosesPercentage": 0.74,
-      "secondDosesTo90Percent": 6613,
-      "totalPopulation": 41427
-    },
-    {
-      "dhbName": "Nelson Marlborough",
-      "firstDoses": 118751,
-      "firstDosesPercentage": 0.87,
-      "firstDosesTo90Percent": 3418,
-      "secondDoses": 104740,
-      "secondDosesPercentage": 0.77,
-      "secondDosesTo90Percent": 17429,
-      "totalPopulation": 135743
-    },
-    {
-      "dhbName": "West Coast",
-      "firstDoses": 23060,
-      "firstDosesPercentage": 0.83,
-      "firstDosesTo90Percent": 2055,
-      "secondDoses": 19274,
-      "secondDosesPercentage": 0.69,
-      "secondDosesTo90Percent": 5841,
-      "totalPopulation": 27906
-    },
-    {
-      "dhbName": "Canterbury",
-      "firstDoses": 444833,
-      "firstDosesPercentage": 0.92,
-      "firstDosesTo90Percent": 0,
-      "secondDoses": 370400,
-      "secondDosesPercentage": 0.77,
-      "secondDosesTo90Percent": 64201,
-      "totalPopulation": 482890
-    },
-    {
-      "dhbName": "South Canterbury",
-      "firstDoses": 45975,
-      "firstDosesPercentage": 0.87,
-      "firstDosesTo90Percent": 1351,
-      "secondDoses": 40170,
-      "secondDosesPercentage": 0.76,
-      "secondDosesTo90Percent": 7156,
-      "totalPopulation": 52584
-    },
-    {
-      "dhbName": "Southern",
-      "firstDoses": 261441,
-      "firstDosesPercentage": 0.91,
-      "firstDosesTo90Percent": 0,
-      "secondDoses": 228407,
-      "secondDosesPercentage": 0.79,
-      "secondDosesTo90Percent": 30806,
-      "totalPopulation": 288015
-    },
-    {
-      "dhbName": "Overseas / Unknown",
-      "firstDoses": 2042,
-      "firstDosesPercentage": 0.12,
-      "firstDosesTo90Percent": 13414,
-      "secondDoses": 1711,
-      "secondDosesPercentage": 0.1,
-      "secondDosesTo90Percent": 13745,
-      "totalPopulation": 17173
-    }
-  ],
-  "dataValidAsAtNzTimeIso": "2021-11-04T23:59:00.000+13:00"
+  "data": {
+    "vaccinationsPerDhb": [
+      {
+        "dhbName": "Northland",
+        "firstDoses": 129508,
+        "firstDosesPercentage": 0.8,
+        "firstDosesTo90Percent": 15680,
+        "secondDoses": 107760,
+        "secondDosesPercentage": 0.67,
+        "secondDosesTo90Percent": 37428,
+        "totalPopulation": 161320
+      },
+      {
+        "dhbName": "Waitemata",
+        "firstDoses": 482323,
+        "firstDosesPercentage": 0.92,
+        "firstDosesTo90Percent": 0,
+        "secondDoses": 432382,
+        "secondDosesPercentage": 0.82,
+        "secondDosesTo90Percent": 41096,
+        "totalPopulation": 526087
+      },
+      {
+        "dhbName": "Auckland",
+        "firstDoses": 400119,
+        "firstDosesPercentage": 0.94,
+        "firstDosesTo90Percent": 0,
+        "secondDoses": 364481,
+        "secondDosesPercentage": 0.86,
+        "secondDosesTo90Percent": 17081,
+        "totalPopulation": 423958
+      },
+      {
+        "dhbName": "Counties Manukau",
+        "firstDoses": 432521,
+        "firstDosesPercentage": 0.9,
+        "firstDosesTo90Percent": 1975,
+        "secondDoses": 380135,
+        "secondDosesPercentage": 0.79,
+        "secondDosesTo90Percent": 54361,
+        "totalPopulation": 482773
+      },
+      {
+        "dhbName": "Waikato",
+        "firstDoses": 312617,
+        "firstDosesPercentage": 0.88,
+        "firstDosesTo90Percent": 8841,
+        "secondDoses": 266000,
+        "secondDosesPercentage": 0.74,
+        "secondDosesTo90Percent": 55458,
+        "totalPopulation": 357176
+      },
+      {
+        "dhbName": "Lakes",
+        "firstDoses": 77008,
+        "firstDosesPercentage": 0.82,
+        "firstDosesTo90Percent": 7969,
+        "secondDoses": 63973,
+        "secondDosesPercentage": 0.68,
+        "secondDosesTo90Percent": 21004,
+        "totalPopulation": 94419
+      },
+      {
+        "dhbName": "Bay of Plenty",
+        "firstDoses": 181957,
+        "firstDosesPercentage": 0.84,
+        "firstDosesTo90Percent": 13290,
+        "secondDoses": 151770,
+        "secondDosesPercentage": 0.7,
+        "secondDosesTo90Percent": 43477,
+        "totalPopulation": 216941
+      },
+      {
+        "dhbName": "Tairawhiti",
+        "firstDoses": 33377,
+        "firstDosesPercentage": 0.8,
+        "firstDosesTo90Percent": 4392,
+        "secondDoses": 27407,
+        "secondDosesPercentage": 0.65,
+        "secondDosesTo90Percent": 10362,
+        "totalPopulation": 41965
+      },
+      {
+        "dhbName": "Taranaki",
+        "firstDoses": 86738,
+        "firstDosesPercentage": 0.85,
+        "firstDosesTo90Percent": 5194,
+        "secondDoses": 70091,
+        "secondDosesPercentage": 0.69,
+        "secondDosesTo90Percent": 21841,
+        "totalPopulation": 102147
+      },
+      {
+        "dhbName": "Hawkes Bay",
+        "firstDoses": 124237,
+        "firstDosesPercentage": 0.85,
+        "firstDosesTo90Percent": 6777,
+        "secondDoses": 105893,
+        "secondDosesPercentage": 0.73,
+        "secondDosesTo90Percent": 25121,
+        "totalPopulation": 145571
+      },
+      {
+        "dhbName": "MidCentral",
+        "firstDoses": 132630,
+        "firstDosesPercentage": 0.87,
+        "firstDosesTo90Percent": 4442,
+        "secondDoses": 112968,
+        "secondDosesPercentage": 0.74,
+        "secondDosesTo90Percent": 24104,
+        "totalPopulation": 152302
+      },
+      {
+        "dhbName": "Whanganui",
+        "firstDoses": 46655,
+        "firstDosesPercentage": 0.81,
+        "firstDosesTo90Percent": 4867,
+        "secondDoses": 40012,
+        "secondDosesPercentage": 0.7,
+        "secondDosesTo90Percent": 11510,
+        "totalPopulation": 57247
+      },
+      {
+        "dhbName": "Capital and Coast",
+        "firstDoses": 251135,
+        "firstDosesPercentage": 0.93,
+        "firstDosesTo90Percent": 0,
+        "secondDoses": 223367,
+        "secondDosesPercentage": 0.82,
+        "secondDosesTo90Percent": 20690,
+        "totalPopulation": 271174
+      },
+      {
+        "dhbName": "Hutt Valley",
+        "firstDoses": 115453,
+        "firstDosesPercentage": 0.89,
+        "firstDosesTo90Percent": 1762,
+        "secondDoses": 99897,
+        "secondDosesPercentage": 0.77,
+        "secondDosesTo90Percent": 17318,
+        "totalPopulation": 130239
+      },
+      {
+        "dhbName": "Wairarapa",
+        "firstDoses": 35736,
+        "firstDosesPercentage": 0.86,
+        "firstDosesTo90Percent": 1548,
+        "secondDoses": 30671,
+        "secondDosesPercentage": 0.74,
+        "secondDosesTo90Percent": 6613,
+        "totalPopulation": 41427
+      },
+      {
+        "dhbName": "Nelson Marlborough",
+        "firstDoses": 118751,
+        "firstDosesPercentage": 0.87,
+        "firstDosesTo90Percent": 3418,
+        "secondDoses": 104740,
+        "secondDosesPercentage": 0.77,
+        "secondDosesTo90Percent": 17429,
+        "totalPopulation": 135743
+      },
+      {
+        "dhbName": "West Coast",
+        "firstDoses": 23060,
+        "firstDosesPercentage": 0.83,
+        "firstDosesTo90Percent": 2055,
+        "secondDoses": 19274,
+        "secondDosesPercentage": 0.69,
+        "secondDosesTo90Percent": 5841,
+        "totalPopulation": 27906
+      },
+      {
+        "dhbName": "Canterbury",
+        "firstDoses": 444833,
+        "firstDosesPercentage": 0.92,
+        "firstDosesTo90Percent": 0,
+        "secondDoses": 370400,
+        "secondDosesPercentage": 0.77,
+        "secondDosesTo90Percent": 64201,
+        "totalPopulation": 482890
+      },
+      {
+        "dhbName": "South Canterbury",
+        "firstDoses": 45975,
+        "firstDosesPercentage": 0.87,
+        "firstDosesTo90Percent": 1351,
+        "secondDoses": 40170,
+        "secondDosesPercentage": 0.76,
+        "secondDosesTo90Percent": 7156,
+        "totalPopulation": 52584
+      },
+      {
+        "dhbName": "Southern",
+        "firstDoses": 261441,
+        "firstDosesPercentage": 0.91,
+        "firstDosesTo90Percent": 0,
+        "secondDoses": 228407,
+        "secondDosesPercentage": 0.79,
+        "secondDosesTo90Percent": 30806,
+        "totalPopulation": 288015
+      },
+      {
+        "dhbName": "Overseas / Unknown",
+        "firstDoses": 2042,
+        "firstDosesPercentage": 0.12,
+        "firstDosesTo90Percent": 13414,
+        "secondDoses": 1711,
+        "secondDosesPercentage": 0.1,
+        "secondDosesTo90Percent": 13745,
+        "totalPopulation": 17173
+      }
+    ],
+    "dataValidAsAtNzTimeIso": "2021-11-04T23:59:00.000+13:00"
+  }
 }

--- a/data/vaccineData/2021-11-05.json
+++ b/data/vaccineData/2021-11-05.json
@@ -1,215 +1,221 @@
 {
-  "vaccinationsPerDhb": [
-    {
-      "dhbName": "Northland",
-      "firstDoses": 129907,
-      "firstDosesPercentage": 0.81,
-      "firstDosesTo90Percent": 15281,
-      "secondDoses": 108668,
-      "secondDosesPercentage": 0.67,
-      "secondDosesTo90Percent": 36520,
-      "totalPopulation": 161320
-    },
-    {
-      "dhbName": "Waitemata",
-      "firstDoses": 482909,
-      "firstDosesPercentage": 0.92,
-      "firstDosesTo90Percent": 0,
-      "secondDoses": 435139,
-      "secondDosesPercentage": 0.83,
-      "secondDosesTo90Percent": 38339,
-      "totalPopulation": 526087
-    },
-    {
-      "dhbName": "Auckland",
-      "firstDoses": 400479,
-      "firstDosesPercentage": 0.94,
-      "firstDosesTo90Percent": 0,
-      "secondDoses": 366278,
-      "secondDosesPercentage": 0.86,
-      "secondDosesTo90Percent": 15284,
-      "totalPopulation": 423958
-    },
-    {
-      "dhbName": "Counties Manukau",
-      "firstDoses": 433242,
-      "firstDosesPercentage": 0.9,
-      "firstDosesTo90Percent": 1254,
-      "secondDoses": 382391,
-      "secondDosesPercentage": 0.79,
-      "secondDosesTo90Percent": 52105,
-      "totalPopulation": 482773
-    },
-    {
-      "dhbName": "Waikato",
-      "firstDoses": 313302,
-      "firstDosesPercentage": 0.88,
-      "firstDosesTo90Percent": 8156,
-      "secondDoses": 268235,
-      "secondDosesPercentage": 0.75,
-      "secondDosesTo90Percent": 53223,
-      "totalPopulation": 357176
-    },
-    {
-      "dhbName": "Lakes",
-      "firstDoses": 77180,
-      "firstDosesPercentage": 0.82,
-      "firstDosesTo90Percent": 7797,
-      "secondDoses": 64515,
-      "secondDosesPercentage": 0.68,
-      "secondDosesTo90Percent": 20462,
-      "totalPopulation": 94419
-    },
-    {
-      "dhbName": "Bay of Plenty",
-      "firstDoses": 182323,
-      "firstDosesPercentage": 0.84,
-      "firstDosesTo90Percent": 12924,
-      "secondDoses": 153099,
-      "secondDosesPercentage": 0.71,
-      "secondDosesTo90Percent": 42148,
-      "totalPopulation": 216941
-    },
-    {
-      "dhbName": "Tairawhiti",
-      "firstDoses": 33438,
-      "firstDosesPercentage": 0.8,
-      "firstDosesTo90Percent": 4330,
-      "secondDoses": 27529,
-      "secondDosesPercentage": 0.66,
-      "secondDosesTo90Percent": 10240,
-      "totalPopulation": 41965
-    },
-    {
-      "dhbName": "Taranaki",
-      "firstDoses": 87049,
-      "firstDosesPercentage": 0.85,
-      "firstDosesTo90Percent": 4883,
-      "secondDoses": 70974,
-      "secondDosesPercentage": 0.69,
-      "secondDosesTo90Percent": 20958,
-      "totalPopulation": 102147
-    },
-    {
-      "dhbName": "Hawkes Bay",
-      "firstDoses": 124478,
-      "firstDosesPercentage": 0.86,
-      "firstDosesTo90Percent": 6536,
-      "secondDoses": 106471,
-      "secondDosesPercentage": 0.73,
-      "secondDosesTo90Percent": 24543,
-      "totalPopulation": 145571
-    },
-    {
-      "dhbName": "MidCentral",
-      "firstDoses": 132922,
-      "firstDosesPercentage": 0.87,
-      "firstDosesTo90Percent": 4150,
-      "secondDoses": 113665,
-      "secondDosesPercentage": 0.75,
-      "secondDosesTo90Percent": 23407,
-      "totalPopulation": 152302
-    },
-    {
-      "dhbName": "Whanganui",
-      "firstDoses": 46784,
-      "firstDosesPercentage": 0.82,
-      "firstDosesTo90Percent": 4738,
-      "secondDoses": 40256,
-      "secondDosesPercentage": 0.7,
-      "secondDosesTo90Percent": 11266,
-      "totalPopulation": 57247
-    },
-    {
-      "dhbName": "Capital and Coast",
-      "firstDoses": 251431,
-      "firstDosesPercentage": 0.93,
-      "firstDosesTo90Percent": 0,
-      "secondDoses": 224666,
-      "secondDosesPercentage": 0.83,
-      "secondDosesTo90Percent": 19391,
-      "totalPopulation": 271174
-    },
-    {
-      "dhbName": "Hutt Valley",
-      "firstDoses": 115606,
-      "firstDosesPercentage": 0.89,
-      "firstDosesTo90Percent": 1609,
-      "secondDoses": 100608,
-      "secondDosesPercentage": 0.77,
-      "secondDosesTo90Percent": 16607,
-      "totalPopulation": 130239
-    },
-    {
-      "dhbName": "Wairarapa",
-      "firstDoses": 35836,
-      "firstDosesPercentage": 0.87,
-      "firstDosesTo90Percent": 1448,
-      "secondDoses": 30908,
-      "secondDosesPercentage": 0.75,
-      "secondDosesTo90Percent": 6376,
-      "totalPopulation": 41427
-    },
-    {
-      "dhbName": "Nelson Marlborough",
-      "firstDoses": 118950,
-      "firstDosesPercentage": 0.88,
-      "firstDosesTo90Percent": 3219,
-      "secondDoses": 105163,
-      "secondDosesPercentage": 0.77,
-      "secondDosesTo90Percent": 17006,
-      "totalPopulation": 135743
-    },
-    {
-      "dhbName": "West Coast",
-      "firstDoses": 23119,
-      "firstDosesPercentage": 0.83,
-      "firstDosesTo90Percent": 1996,
-      "secondDoses": 19403,
-      "secondDosesPercentage": 0.7,
-      "secondDosesTo90Percent": 5712,
-      "totalPopulation": 27906
-    },
-    {
-      "dhbName": "Canterbury",
-      "firstDoses": 445643,
-      "firstDosesPercentage": 0.92,
-      "firstDosesTo90Percent": 0,
-      "secondDoses": 373503,
-      "secondDosesPercentage": 0.77,
-      "secondDosesTo90Percent": 61098,
-      "totalPopulation": 482890
-    },
-    {
-      "dhbName": "South Canterbury",
-      "firstDoses": 46084,
-      "firstDosesPercentage": 0.88,
-      "firstDosesTo90Percent": 1242,
-      "secondDoses": 40424,
-      "secondDosesPercentage": 0.77,
-      "secondDosesTo90Percent": 6902,
-      "totalPopulation": 52584
-    },
-    {
-      "dhbName": "Southern",
-      "firstDoses": 261973,
-      "firstDosesPercentage": 0.91,
-      "firstDosesTo90Percent": 0,
-      "secondDoses": 229645,
-      "secondDosesPercentage": 0.8,
-      "secondDosesTo90Percent": 29568,
-      "totalPopulation": 288015
-    },
-    {
-      "dhbName": "Overseas / Unknown",
-      "firstDoses": 2047,
-      "firstDosesPercentage": 0.12,
-      "firstDosesTo90Percent": 13409,
-      "secondDoses": 1720,
-      "secondDosesPercentage": 0.1,
-      "secondDosesTo90Percent": 13736,
-      "totalPopulation": 17173
-    }
-  ],
-  "dataValidAsAtNzTimeIso": "2021-11-05T23:59:00.000+13:00"
+  "metaData": {
+    "createdAtUtcTimeIso": "2021-11-07T05:46:24.789Z",
+    "updatedAtUtcTimeIso": "2021-11-07T05:46:24.789Z"
+  },
+  "data": {
+    "vaccinationsPerDhb": [
+      {
+        "dhbName": "Northland",
+        "firstDoses": 129907,
+        "firstDosesPercentage": 0.81,
+        "firstDosesTo90Percent": 15281,
+        "secondDoses": 108668,
+        "secondDosesPercentage": 0.67,
+        "secondDosesTo90Percent": 36520,
+        "totalPopulation": 161320
+      },
+      {
+        "dhbName": "Waitemata",
+        "firstDoses": 482909,
+        "firstDosesPercentage": 0.92,
+        "firstDosesTo90Percent": 0,
+        "secondDoses": 435139,
+        "secondDosesPercentage": 0.83,
+        "secondDosesTo90Percent": 38339,
+        "totalPopulation": 526087
+      },
+      {
+        "dhbName": "Auckland",
+        "firstDoses": 400479,
+        "firstDosesPercentage": 0.94,
+        "firstDosesTo90Percent": 0,
+        "secondDoses": 366278,
+        "secondDosesPercentage": 0.86,
+        "secondDosesTo90Percent": 15284,
+        "totalPopulation": 423958
+      },
+      {
+        "dhbName": "Counties Manukau",
+        "firstDoses": 433242,
+        "firstDosesPercentage": 0.9,
+        "firstDosesTo90Percent": 1254,
+        "secondDoses": 382391,
+        "secondDosesPercentage": 0.79,
+        "secondDosesTo90Percent": 52105,
+        "totalPopulation": 482773
+      },
+      {
+        "dhbName": "Waikato",
+        "firstDoses": 313302,
+        "firstDosesPercentage": 0.88,
+        "firstDosesTo90Percent": 8156,
+        "secondDoses": 268235,
+        "secondDosesPercentage": 0.75,
+        "secondDosesTo90Percent": 53223,
+        "totalPopulation": 357176
+      },
+      {
+        "dhbName": "Lakes",
+        "firstDoses": 77180,
+        "firstDosesPercentage": 0.82,
+        "firstDosesTo90Percent": 7797,
+        "secondDoses": 64515,
+        "secondDosesPercentage": 0.68,
+        "secondDosesTo90Percent": 20462,
+        "totalPopulation": 94419
+      },
+      {
+        "dhbName": "Bay of Plenty",
+        "firstDoses": 182323,
+        "firstDosesPercentage": 0.84,
+        "firstDosesTo90Percent": 12924,
+        "secondDoses": 153099,
+        "secondDosesPercentage": 0.71,
+        "secondDosesTo90Percent": 42148,
+        "totalPopulation": 216941
+      },
+      {
+        "dhbName": "Tairawhiti",
+        "firstDoses": 33438,
+        "firstDosesPercentage": 0.8,
+        "firstDosesTo90Percent": 4330,
+        "secondDoses": 27529,
+        "secondDosesPercentage": 0.66,
+        "secondDosesTo90Percent": 10240,
+        "totalPopulation": 41965
+      },
+      {
+        "dhbName": "Taranaki",
+        "firstDoses": 87049,
+        "firstDosesPercentage": 0.85,
+        "firstDosesTo90Percent": 4883,
+        "secondDoses": 70974,
+        "secondDosesPercentage": 0.69,
+        "secondDosesTo90Percent": 20958,
+        "totalPopulation": 102147
+      },
+      {
+        "dhbName": "Hawkes Bay",
+        "firstDoses": 124478,
+        "firstDosesPercentage": 0.86,
+        "firstDosesTo90Percent": 6536,
+        "secondDoses": 106471,
+        "secondDosesPercentage": 0.73,
+        "secondDosesTo90Percent": 24543,
+        "totalPopulation": 145571
+      },
+      {
+        "dhbName": "MidCentral",
+        "firstDoses": 132922,
+        "firstDosesPercentage": 0.87,
+        "firstDosesTo90Percent": 4150,
+        "secondDoses": 113665,
+        "secondDosesPercentage": 0.75,
+        "secondDosesTo90Percent": 23407,
+        "totalPopulation": 152302
+      },
+      {
+        "dhbName": "Whanganui",
+        "firstDoses": 46784,
+        "firstDosesPercentage": 0.82,
+        "firstDosesTo90Percent": 4738,
+        "secondDoses": 40256,
+        "secondDosesPercentage": 0.7,
+        "secondDosesTo90Percent": 11266,
+        "totalPopulation": 57247
+      },
+      {
+        "dhbName": "Capital and Coast",
+        "firstDoses": 251431,
+        "firstDosesPercentage": 0.93,
+        "firstDosesTo90Percent": 0,
+        "secondDoses": 224666,
+        "secondDosesPercentage": 0.83,
+        "secondDosesTo90Percent": 19391,
+        "totalPopulation": 271174
+      },
+      {
+        "dhbName": "Hutt Valley",
+        "firstDoses": 115606,
+        "firstDosesPercentage": 0.89,
+        "firstDosesTo90Percent": 1609,
+        "secondDoses": 100608,
+        "secondDosesPercentage": 0.77,
+        "secondDosesTo90Percent": 16607,
+        "totalPopulation": 130239
+      },
+      {
+        "dhbName": "Wairarapa",
+        "firstDoses": 35836,
+        "firstDosesPercentage": 0.87,
+        "firstDosesTo90Percent": 1448,
+        "secondDoses": 30908,
+        "secondDosesPercentage": 0.75,
+        "secondDosesTo90Percent": 6376,
+        "totalPopulation": 41427
+      },
+      {
+        "dhbName": "Nelson Marlborough",
+        "firstDoses": 118950,
+        "firstDosesPercentage": 0.88,
+        "firstDosesTo90Percent": 3219,
+        "secondDoses": 105163,
+        "secondDosesPercentage": 0.77,
+        "secondDosesTo90Percent": 17006,
+        "totalPopulation": 135743
+      },
+      {
+        "dhbName": "West Coast",
+        "firstDoses": 23119,
+        "firstDosesPercentage": 0.83,
+        "firstDosesTo90Percent": 1996,
+        "secondDoses": 19403,
+        "secondDosesPercentage": 0.7,
+        "secondDosesTo90Percent": 5712,
+        "totalPopulation": 27906
+      },
+      {
+        "dhbName": "Canterbury",
+        "firstDoses": 445643,
+        "firstDosesPercentage": 0.92,
+        "firstDosesTo90Percent": 0,
+        "secondDoses": 373503,
+        "secondDosesPercentage": 0.77,
+        "secondDosesTo90Percent": 61098,
+        "totalPopulation": 482890
+      },
+      {
+        "dhbName": "South Canterbury",
+        "firstDoses": 46084,
+        "firstDosesPercentage": 0.88,
+        "firstDosesTo90Percent": 1242,
+        "secondDoses": 40424,
+        "secondDosesPercentage": 0.77,
+        "secondDosesTo90Percent": 6902,
+        "totalPopulation": 52584
+      },
+      {
+        "dhbName": "Southern",
+        "firstDoses": 261973,
+        "firstDosesPercentage": 0.91,
+        "firstDosesTo90Percent": 0,
+        "secondDoses": 229645,
+        "secondDosesPercentage": 0.8,
+        "secondDosesTo90Percent": 29568,
+        "totalPopulation": 288015
+      },
+      {
+        "dhbName": "Overseas / Unknown",
+        "firstDoses": 2047,
+        "firstDosesPercentage": 0.12,
+        "firstDosesTo90Percent": 13409,
+        "secondDoses": 1720,
+        "secondDosesPercentage": 0.1,
+        "secondDosesTo90Percent": 13736,
+        "totalPopulation": 17173
+      }
+    ],
+    "dataValidAsAtNzTimeIso": "2021-11-05T23:59:00.000+13:00"
+  }
 }

--- a/data/vaccineData/2021-11-05.json
+++ b/data/vaccineData/2021-11-05.json
@@ -1,5 +1,5 @@
 {
-  "metaData": {
+  "metadata": {
     "createdAtUtcTimeIso": "2021-11-07T05:46:24.789Z",
     "updatedAtUtcTimeIso": "2021-11-07T05:46:24.789Z"
   },

--- a/data/vaccineData/2021-11-06.json
+++ b/data/vaccineData/2021-11-06.json
@@ -1,215 +1,221 @@
 {
-  "vaccinationsPerDhb": [
-    {
-      "dhbName": "Northland",
-      "firstDoses": 130275,
-      "firstDosesPercentage": 0.81,
-      "firstDosesTo90Percent": 14913,
-      "secondDoses": 109565,
-      "secondDosesPercentage": 0.68,
-      "secondDosesTo90Percent": 35623,
-      "totalPopulation": 161320
-    },
-    {
-      "dhbName": "Waitemata",
-      "firstDoses": 483566,
-      "firstDosesPercentage": 0.92,
-      "firstDosesTo90Percent": 0,
-      "secondDoses": 438127,
-      "secondDosesPercentage": 0.83,
-      "secondDosesTo90Percent": 35351,
-      "totalPopulation": 526087
-    },
-    {
-      "dhbName": "Auckland",
-      "firstDoses": 400980,
-      "firstDosesPercentage": 0.95,
-      "firstDosesTo90Percent": 0,
-      "secondDoses": 368303,
-      "secondDosesPercentage": 0.87,
-      "secondDosesTo90Percent": 13259,
-      "totalPopulation": 423958
-    },
-    {
-      "dhbName": "Counties Manukau",
-      "firstDoses": 434304,
-      "firstDosesPercentage": 0.9,
-      "firstDosesTo90Percent": 192,
-      "secondDoses": 386148,
-      "secondDosesPercentage": 0.8,
-      "secondDosesTo90Percent": 48348,
-      "totalPopulation": 482773
-    },
-    {
-      "dhbName": "Waikato",
-      "firstDoses": 313818,
-      "firstDosesPercentage": 0.88,
-      "firstDosesTo90Percent": 7640,
-      "secondDoses": 270091,
-      "secondDosesPercentage": 0.76,
-      "secondDosesTo90Percent": 51367,
-      "totalPopulation": 357176
-    },
-    {
-      "dhbName": "Lakes",
-      "firstDoses": 77399,
-      "firstDosesPercentage": 0.82,
-      "firstDosesTo90Percent": 7578,
-      "secondDoses": 65224,
-      "secondDosesPercentage": 0.69,
-      "secondDosesTo90Percent": 19753,
-      "totalPopulation": 94419
-    },
-    {
-      "dhbName": "Bay of Plenty",
-      "firstDoses": 182736,
-      "firstDosesPercentage": 0.84,
-      "firstDosesTo90Percent": 12511,
-      "secondDoses": 154311,
-      "secondDosesPercentage": 0.71,
-      "secondDosesTo90Percent": 40936,
-      "totalPopulation": 216941
-    },
-    {
-      "dhbName": "Tairawhiti",
-      "firstDoses": 33639,
-      "firstDosesPercentage": 0.8,
-      "firstDosesTo90Percent": 4130,
-      "secondDoses": 27940,
-      "secondDosesPercentage": 0.67,
-      "secondDosesTo90Percent": 9828,
-      "totalPopulation": 41965
-    },
-    {
-      "dhbName": "Taranaki",
-      "firstDoses": 87398,
-      "firstDosesPercentage": 0.86,
-      "firstDosesTo90Percent": 4534,
-      "secondDoses": 71934,
-      "secondDosesPercentage": 0.7,
-      "secondDosesTo90Percent": 19998,
-      "totalPopulation": 102147
-    },
-    {
-      "dhbName": "Hawkes Bay",
-      "firstDoses": 124908,
-      "firstDosesPercentage": 0.86,
-      "firstDosesTo90Percent": 6106,
-      "secondDoses": 107557,
-      "secondDosesPercentage": 0.74,
-      "secondDosesTo90Percent": 23457,
-      "totalPopulation": 145571
-    },
-    {
-      "dhbName": "MidCentral",
-      "firstDoses": 133303,
-      "firstDosesPercentage": 0.88,
-      "firstDosesTo90Percent": 3769,
-      "secondDoses": 114842,
-      "secondDosesPercentage": 0.75,
-      "secondDosesTo90Percent": 22230,
-      "totalPopulation": 152302
-    },
-    {
-      "dhbName": "Whanganui",
-      "firstDoses": 46907,
-      "firstDosesPercentage": 0.82,
-      "firstDosesTo90Percent": 4615,
-      "secondDoses": 40638,
-      "secondDosesPercentage": 0.71,
-      "secondDosesTo90Percent": 10884,
-      "totalPopulation": 57247
-    },
-    {
-      "dhbName": "Capital and Coast",
-      "firstDoses": 251687,
-      "firstDosesPercentage": 0.93,
-      "firstDosesTo90Percent": 0,
-      "secondDoses": 226241,
-      "secondDosesPercentage": 0.83,
-      "secondDosesTo90Percent": 17816,
-      "totalPopulation": 271174
-    },
-    {
-      "dhbName": "Hutt Valley",
-      "firstDoses": 115829,
-      "firstDosesPercentage": 0.89,
-      "firstDosesTo90Percent": 1386,
-      "secondDoses": 101801,
-      "secondDosesPercentage": 0.78,
-      "secondDosesTo90Percent": 15414,
-      "totalPopulation": 130239
-    },
-    {
-      "dhbName": "Wairarapa",
-      "firstDoses": 35999,
-      "firstDosesPercentage": 0.87,
-      "firstDosesTo90Percent": 1285,
-      "secondDoses": 31186,
-      "secondDosesPercentage": 0.75,
-      "secondDosesTo90Percent": 6098,
-      "totalPopulation": 41427
-    },
-    {
-      "dhbName": "Nelson Marlborough",
-      "firstDoses": 119146,
-      "firstDosesPercentage": 0.88,
-      "firstDosesTo90Percent": 3023,
-      "secondDoses": 105710,
-      "secondDosesPercentage": 0.78,
-      "secondDosesTo90Percent": 16459,
-      "totalPopulation": 135743
-    },
-    {
-      "dhbName": "West Coast",
-      "firstDoses": 23222,
-      "firstDosesPercentage": 0.83,
-      "firstDosesTo90Percent": 1893,
-      "secondDoses": 19608,
-      "secondDosesPercentage": 0.7,
-      "secondDosesTo90Percent": 5507,
-      "totalPopulation": 27906
-    },
-    {
-      "dhbName": "Canterbury",
-      "firstDoses": 446480,
-      "firstDosesPercentage": 0.92,
-      "firstDosesTo90Percent": 0,
-      "secondDoses": 377521,
-      "secondDosesPercentage": 0.78,
-      "secondDosesTo90Percent": 57080,
-      "totalPopulation": 482890
-    },
-    {
-      "dhbName": "South Canterbury",
-      "firstDoses": 46161,
-      "firstDosesPercentage": 0.88,
-      "firstDosesTo90Percent": 1165,
-      "secondDoses": 40667,
-      "secondDosesPercentage": 0.77,
-      "secondDosesTo90Percent": 6659,
-      "totalPopulation": 52584
-    },
-    {
-      "dhbName": "Southern",
-      "firstDoses": 262357,
-      "firstDosesPercentage": 0.91,
-      "firstDosesTo90Percent": 0,
-      "secondDoses": 230687,
-      "secondDosesPercentage": 0.8,
-      "secondDosesTo90Percent": 28526,
-      "totalPopulation": 288015
-    },
-    {
-      "dhbName": "Overseas / Unknown",
-      "firstDoses": 2097,
-      "firstDosesPercentage": 0.12,
-      "firstDosesTo90Percent": 13359,
-      "secondDoses": 1732,
-      "secondDosesPercentage": 0.1,
-      "secondDosesTo90Percent": 13724,
-      "totalPopulation": 17173
-    }
-  ],
-  "dataValidAsAtNzTimeIso": "2021-11-06T23:59:00.000+13:00"
+  "metaData": {
+    "createdAtUtcTimeIso": "2021-11-07T05:46:24.789Z",
+    "updatedAtUtcTimeIso": "2021-11-07T05:46:24.789Z"
+  },
+  "data": {
+    "vaccinationsPerDhb": [
+      {
+        "dhbName": "Northland",
+        "firstDoses": 130275,
+        "firstDosesPercentage": 0.81,
+        "firstDosesTo90Percent": 14913,
+        "secondDoses": 109565,
+        "secondDosesPercentage": 0.68,
+        "secondDosesTo90Percent": 35623,
+        "totalPopulation": 161320
+      },
+      {
+        "dhbName": "Waitemata",
+        "firstDoses": 483566,
+        "firstDosesPercentage": 0.92,
+        "firstDosesTo90Percent": 0,
+        "secondDoses": 438127,
+        "secondDosesPercentage": 0.83,
+        "secondDosesTo90Percent": 35351,
+        "totalPopulation": 526087
+      },
+      {
+        "dhbName": "Auckland",
+        "firstDoses": 400980,
+        "firstDosesPercentage": 0.95,
+        "firstDosesTo90Percent": 0,
+        "secondDoses": 368303,
+        "secondDosesPercentage": 0.87,
+        "secondDosesTo90Percent": 13259,
+        "totalPopulation": 423958
+      },
+      {
+        "dhbName": "Counties Manukau",
+        "firstDoses": 434304,
+        "firstDosesPercentage": 0.9,
+        "firstDosesTo90Percent": 192,
+        "secondDoses": 386148,
+        "secondDosesPercentage": 0.8,
+        "secondDosesTo90Percent": 48348,
+        "totalPopulation": 482773
+      },
+      {
+        "dhbName": "Waikato",
+        "firstDoses": 313818,
+        "firstDosesPercentage": 0.88,
+        "firstDosesTo90Percent": 7640,
+        "secondDoses": 270091,
+        "secondDosesPercentage": 0.76,
+        "secondDosesTo90Percent": 51367,
+        "totalPopulation": 357176
+      },
+      {
+        "dhbName": "Lakes",
+        "firstDoses": 77399,
+        "firstDosesPercentage": 0.82,
+        "firstDosesTo90Percent": 7578,
+        "secondDoses": 65224,
+        "secondDosesPercentage": 0.69,
+        "secondDosesTo90Percent": 19753,
+        "totalPopulation": 94419
+      },
+      {
+        "dhbName": "Bay of Plenty",
+        "firstDoses": 182736,
+        "firstDosesPercentage": 0.84,
+        "firstDosesTo90Percent": 12511,
+        "secondDoses": 154311,
+        "secondDosesPercentage": 0.71,
+        "secondDosesTo90Percent": 40936,
+        "totalPopulation": 216941
+      },
+      {
+        "dhbName": "Tairawhiti",
+        "firstDoses": 33639,
+        "firstDosesPercentage": 0.8,
+        "firstDosesTo90Percent": 4130,
+        "secondDoses": 27940,
+        "secondDosesPercentage": 0.67,
+        "secondDosesTo90Percent": 9828,
+        "totalPopulation": 41965
+      },
+      {
+        "dhbName": "Taranaki",
+        "firstDoses": 87398,
+        "firstDosesPercentage": 0.86,
+        "firstDosesTo90Percent": 4534,
+        "secondDoses": 71934,
+        "secondDosesPercentage": 0.7,
+        "secondDosesTo90Percent": 19998,
+        "totalPopulation": 102147
+      },
+      {
+        "dhbName": "Hawkes Bay",
+        "firstDoses": 124908,
+        "firstDosesPercentage": 0.86,
+        "firstDosesTo90Percent": 6106,
+        "secondDoses": 107557,
+        "secondDosesPercentage": 0.74,
+        "secondDosesTo90Percent": 23457,
+        "totalPopulation": 145571
+      },
+      {
+        "dhbName": "MidCentral",
+        "firstDoses": 133303,
+        "firstDosesPercentage": 0.88,
+        "firstDosesTo90Percent": 3769,
+        "secondDoses": 114842,
+        "secondDosesPercentage": 0.75,
+        "secondDosesTo90Percent": 22230,
+        "totalPopulation": 152302
+      },
+      {
+        "dhbName": "Whanganui",
+        "firstDoses": 46907,
+        "firstDosesPercentage": 0.82,
+        "firstDosesTo90Percent": 4615,
+        "secondDoses": 40638,
+        "secondDosesPercentage": 0.71,
+        "secondDosesTo90Percent": 10884,
+        "totalPopulation": 57247
+      },
+      {
+        "dhbName": "Capital and Coast",
+        "firstDoses": 251687,
+        "firstDosesPercentage": 0.93,
+        "firstDosesTo90Percent": 0,
+        "secondDoses": 226241,
+        "secondDosesPercentage": 0.83,
+        "secondDosesTo90Percent": 17816,
+        "totalPopulation": 271174
+      },
+      {
+        "dhbName": "Hutt Valley",
+        "firstDoses": 115829,
+        "firstDosesPercentage": 0.89,
+        "firstDosesTo90Percent": 1386,
+        "secondDoses": 101801,
+        "secondDosesPercentage": 0.78,
+        "secondDosesTo90Percent": 15414,
+        "totalPopulation": 130239
+      },
+      {
+        "dhbName": "Wairarapa",
+        "firstDoses": 35999,
+        "firstDosesPercentage": 0.87,
+        "firstDosesTo90Percent": 1285,
+        "secondDoses": 31186,
+        "secondDosesPercentage": 0.75,
+        "secondDosesTo90Percent": 6098,
+        "totalPopulation": 41427
+      },
+      {
+        "dhbName": "Nelson Marlborough",
+        "firstDoses": 119146,
+        "firstDosesPercentage": 0.88,
+        "firstDosesTo90Percent": 3023,
+        "secondDoses": 105710,
+        "secondDosesPercentage": 0.78,
+        "secondDosesTo90Percent": 16459,
+        "totalPopulation": 135743
+      },
+      {
+        "dhbName": "West Coast",
+        "firstDoses": 23222,
+        "firstDosesPercentage": 0.83,
+        "firstDosesTo90Percent": 1893,
+        "secondDoses": 19608,
+        "secondDosesPercentage": 0.7,
+        "secondDosesTo90Percent": 5507,
+        "totalPopulation": 27906
+      },
+      {
+        "dhbName": "Canterbury",
+        "firstDoses": 446480,
+        "firstDosesPercentage": 0.92,
+        "firstDosesTo90Percent": 0,
+        "secondDoses": 377521,
+        "secondDosesPercentage": 0.78,
+        "secondDosesTo90Percent": 57080,
+        "totalPopulation": 482890
+      },
+      {
+        "dhbName": "South Canterbury",
+        "firstDoses": 46161,
+        "firstDosesPercentage": 0.88,
+        "firstDosesTo90Percent": 1165,
+        "secondDoses": 40667,
+        "secondDosesPercentage": 0.77,
+        "secondDosesTo90Percent": 6659,
+        "totalPopulation": 52584
+      },
+      {
+        "dhbName": "Southern",
+        "firstDoses": 262357,
+        "firstDosesPercentage": 0.91,
+        "firstDosesTo90Percent": 0,
+        "secondDoses": 230687,
+        "secondDosesPercentage": 0.8,
+        "secondDosesTo90Percent": 28526,
+        "totalPopulation": 288015
+      },
+      {
+        "dhbName": "Overseas / Unknown",
+        "firstDoses": 2097,
+        "firstDosesPercentage": 0.12,
+        "firstDosesTo90Percent": 13359,
+        "secondDoses": 1732,
+        "secondDosesPercentage": 0.1,
+        "secondDosesTo90Percent": 13724,
+        "totalPopulation": 17173
+      }
+    ],
+    "dataValidAsAtNzTimeIso": "2021-11-06T23:59:00.000+13:00"
+  }
 }

--- a/data/vaccineData/2021-11-06.json
+++ b/data/vaccineData/2021-11-06.json
@@ -1,5 +1,5 @@
 {
-  "metaData": {
+  "metadata": {
     "createdAtUtcTimeIso": "2021-11-07T05:46:24.789Z",
     "updatedAtUtcTimeIso": "2021-11-07T05:46:24.789Z"
   },

--- a/fetchy/fetchyboi.ts
+++ b/fetchy/fetchyboi.ts
@@ -29,8 +29,8 @@ const sendDataUpdatedNotification = async () => {
   );
 };
 
-const areObjectsDifferent = (a: object, b: object) =>
-  Object.keys(diff(a, b)).length !== 0;
+const areObjectsDifferent = (a: Object, b: Object) =>
+  Boolean(Object.keys(diff(a, b)).length);
 
 const main = async () => {
   try {
@@ -47,7 +47,7 @@ const main = async () => {
 
     if (
       existingData == null ||
-      areObjectsDifferent(existingData, vaccineData)
+      areObjectsDifferent(existingData.data, vaccineData)
     ) {
       // store raw html and data
       await storeRawVaccineSite(vaccineData.dataValidAsAtNzTimeIso, rawHtml);

--- a/fetchy/fetchyboi.ts
+++ b/fetchy/fetchyboi.ts
@@ -31,7 +31,7 @@ const sendDataUpdatedNotification = async () => {
   );
 };
 
-const areObjectsDifferent = (a: Object, b: Object) =>
+const areObjectsDifferent = (a: object, b: object) =>
   Boolean(Object.keys(diff(a, b)).length);
 
 const extractAndStoreVaccineData = async (rawHtml: string) => {
@@ -83,7 +83,7 @@ const fetchNewVaccineData = async () => {
 };
 
 const main = async () => {
-  if (process.env.REGEN_DATA === "true") {
+  if (process.env.REGENERATE_DATA === "true") {
     await regenVaccineData();
   } else {
     await fetchNewVaccineData();

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint": "next lint",
     "husky-install": "husky install",
     "fetch-boi": "cross-env NODE_OPTIONS='--unhandled-rejections=strict' ts-node fetchy/fetchyboi.ts",
-    "regen-data": "cross-env NODE_OPTIONS='--unhandled-rejections=strict' REGEN_DATA=true ts-node fetchy/fetchyboi.ts"
+    "regen-data": "cross-env NODE_OPTIONS='--unhandled-rejections=strict' REGENERATE_DATA=true ts-node fetchy/fetchyboi.ts"
   },
   "dependencies": {
     "@heroicons/react": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "start": "next start",
     "lint": "next lint",
     "husky-install": "husky install",
-    "fetch-boi": "cross-env NODE_OPTIONS='--unhandled-rejections=strict' ts-node fetchy/fetchyboi.ts"
+    "fetch-boi": "cross-env NODE_OPTIONS='--unhandled-rejections=strict' ts-node fetchy/fetchyboi.ts",
+    "regen-data": "cross-env NODE_OPTIONS='--unhandled-rejections=strict' REGEN_DATA=true ts-node fetchy/fetchyboi.ts"
   },
   "dependencies": {
     "@heroicons/react": "^1.0.5",

--- a/shared/types/DataStoreTypes.ts
+++ b/shared/types/DataStoreTypes.ts
@@ -1,11 +1,11 @@
 type UtcTimeIso = string;
 
-type DocumentMetaData = {
+type DocumentMetadata = {
   createdAtUtcTimeIso: UtcTimeIso;
   updatedAtUtcTimeIso: UtcTimeIso;
 };
 
 export type DataDocument<Type> = {
-  metaData: DocumentMetaData;
+  metadata: DocumentMetadata;
   data: Type;
 };

--- a/shared/types/DataStoreTypes.ts
+++ b/shared/types/DataStoreTypes.ts
@@ -1,0 +1,11 @@
+type UtcTimeIso = string;
+
+type DocumentMetaData = {
+  createdAtUtcTimeIso: UtcTimeIso;
+  updatedAtUtcTimeIso: UtcTimeIso;
+};
+
+export type DataDocument<Type> = {
+  metaData: DocumentMetaData;
+  data: Type;
+};

--- a/shared/types/VaccineDataTypes.ts
+++ b/shared/types/VaccineDataTypes.ts
@@ -43,13 +43,3 @@ type SouthIslandDhbKeys =
 type OverseasUnknown = "Overseas / Unknown";
 
 export type DhbName = NorthIslandDhbKeys | SouthIslandDhbKeys | OverseasUnknown;
-
-type FileMetaData = {
-  createdAtTimeIso: NzTimeIso;
-  updatedAtTimeIso: NzTimeIso;
-};
-
-export type VaccineDataFile = {
-  meta: FileMetaData;
-  data: VaccineData;
-};

--- a/shared/types/VaccineDataTypes.ts
+++ b/shared/types/VaccineDataTypes.ts
@@ -43,3 +43,13 @@ type SouthIslandDhbKeys =
 type OverseasUnknown = "Overseas / Unknown";
 
 export type DhbName = NorthIslandDhbKeys | SouthIslandDhbKeys | OverseasUnknown;
+
+type FileMetaData = {
+  createdAtTimeIso: NzTimeIso;
+  updatedAtTimeIso: NzTimeIso;
+};
+
+export type VaccineDataFile = {
+  meta: FileMetaData;
+  data: VaccineData;
+};

--- a/shared/vaccineDataStore.ts
+++ b/shared/vaccineDataStore.ts
@@ -1,4 +1,8 @@
-import { NzTimeIso, VaccineData } from "./types/VaccineDataTypes";
+import {
+  NzTimeIso,
+  VaccineData,
+  VaccineDataFile,
+} from "./types/VaccineDataTypes";
 import { promises as fs, existsSync as fileExists } from "fs";
 import { DateTime } from "luxon";
 import { CONSTANTS } from "./constants";
@@ -6,41 +10,72 @@ import { CONSTANTS } from "./constants";
 export const createOrUpdateVaccineDataForDate = async (
   time: NzTimeIso,
   vaccineData: VaccineData
-) =>
-  await fs.writeFile(
-    generateVaccineDataFilePath(time),
-    JSON.stringify(vaccineData, null, 2)
-  );
-
-export const getVaccineDataForDate = async (
-  time: NzTimeIso
-): Promise<VaccineData | null> => {
+) => {
   const filePath = generateVaccineDataFilePath(time);
-  if (fileExists(filePath)) {
-    const data = await fs.readFile(filePath, "utf8");
-    return JSON.parse(data);
+  const previousFileData = await getFileDataForPath(filePath);
+
+  const rightNow = DateTime.fromISO(DateTime.now().toISO(), {
+    zone: "Pacific/Auckland",
+  }).toISO();
+
+  if (previousFileData) {
+    const { createdAtTimeIso } = previousFileData.meta;
+    const meta = {
+      createdAtTimeIso,
+      updatedAtTimeIso: rightNow,
+    };
+
+    return writeFileDataForPath(filePath, { meta, data: vaccineData });
+  } else {
+    const meta = {
+      createdAtTimeIso: rightNow,
+      updatedAtTimeIso: rightNow,
+    };
+
+    return writeFileDataForPath(filePath, { meta, data: vaccineData });
   }
-  return null;
 };
 
 export const getAllVaccineData = async (
   // by default return all data
   maxItems: number = 999
-): Promise<VaccineData[]> => {
+): Promise<VaccineDataFile[]> => {
   const files = await fs.readdir(CONSTANTS.vaccineDataFolder);
   const filesToParse = files.sort().reverse().slice(0, maxItems);
 
-  const vaccineData = filesToParse.map(async (f) => {
-    const filePath = `${CONSTANTS.vaccineDataFolder}/${f}`;
-    const data = await fs.readFile(filePath, "utf8");
-    return JSON.parse(data);
-  });
+  const vaccineData = await Promise.all(
+    filesToParse.map((f) => {
+      const filePath = `${CONSTANTS.vaccineDataFolder}/${f}`;
+      return getFileDataForPath(filePath);
+    })
+  );
 
-  return Promise.all(vaccineData);
+  return vaccineData.filter((v): v is VaccineDataFile => v !== null);
+};
+
+export const getVaccineDataForDate = async (
+  time: NzTimeIso
+): Promise<VaccineDataFile | null> => {
+  const filePath = generateVaccineDataFilePath(time);
+
+  return getFileDataForPath(filePath);
+};
+
+const getFileDataForPath = async (
+  filePath: string
+): Promise<VaccineDataFile | null> => {
+  if (fileExists(filePath)) {
+    const fileData = await fs.readFile(filePath, "utf8");
+    return JSON.parse(fileData);
+  }
+  return null;
 };
 
 export const storeRawVaccineSite = async (time: NzTimeIso, rawHtml: string) =>
   await fs.writeFile(generateRawSiteFilePath(time), rawHtml);
+
+const writeFileDataForPath = (filePath: string, fileData: VaccineDataFile) =>
+  fs.writeFile(filePath, JSON.stringify(fileData, null, 2));
 
 const formatDate = (time: NzTimeIso) =>
   DateTime.fromISO(time).toFormat("yyyy-LL-dd");

--- a/shared/vaccineDataStore.ts
+++ b/shared/vaccineDataStore.ts
@@ -1,81 +1,65 @@
-import {
-  NzTimeIso,
-  VaccineData,
-  VaccineDataFile,
-} from "./types/VaccineDataTypes";
+import { NzTimeIso, VaccineData } from "./types/VaccineDataTypes";
 import { promises as fs, existsSync as fileExists } from "fs";
 import { DateTime } from "luxon";
 import { CONSTANTS } from "./constants";
+import { DataDocument } from "./types/DataStoreTypes";
 
 export const createOrUpdateVaccineDataForDate = async (
   time: NzTimeIso,
   vaccineData: VaccineData
 ) => {
   const filePath = generateVaccineDataFilePath(time);
-  const previousFileData = await getFileDataForPath(filePath);
+  const previousFileData = fileExists(filePath)
+    ? await readFileDataForPath(filePath)
+    : null;
 
-  const rightNow = DateTime.fromISO(DateTime.now().toISO(), {
-    zone: "Pacific/Auckland",
-  }).toISO();
+  const rightNow = DateTime.utc().toISO();
+  const metaData = {
+    createdAtUtcTimeIso: previousFileData
+      ? previousFileData.metaData.createdAtUtcTimeIso
+      : rightNow,
+    updatedAtUtcTimeIso: rightNow,
+  };
 
-  if (previousFileData) {
-    const { createdAtTimeIso } = previousFileData.meta;
-    const meta = {
-      createdAtTimeIso,
-      updatedAtTimeIso: rightNow,
-    };
-
-    return writeFileDataForPath(filePath, { meta, data: vaccineData });
-  } else {
-    const meta = {
-      createdAtTimeIso: rightNow,
-      updatedAtTimeIso: rightNow,
-    };
-
-    return writeFileDataForPath(filePath, { meta, data: vaccineData });
-  }
+  await writeFileDataForPath(filePath, { metaData, data: vaccineData });
 };
 
 export const getAllVaccineData = async (
   // by default return all data
   maxItems: number = 999
-): Promise<VaccineDataFile[]> => {
+): Promise<DataDocument<VaccineData>[]> => {
   const files = await fs.readdir(CONSTANTS.vaccineDataFolder);
   const filesToParse = files.sort().reverse().slice(0, maxItems);
 
-  const vaccineData = await Promise.all(
+  return await Promise.all(
     filesToParse.map((f) => {
       const filePath = `${CONSTANTS.vaccineDataFolder}/${f}`;
-      return getFileDataForPath(filePath);
+      return readFileDataForPath(filePath);
     })
   );
-
-  return vaccineData.filter((v): v is VaccineDataFile => v !== null);
 };
 
 export const getVaccineDataForDate = async (
   time: NzTimeIso
-): Promise<VaccineDataFile | null> => {
+): Promise<DataDocument<VaccineData> | null> => {
   const filePath = generateVaccineDataFilePath(time);
-
-  return getFileDataForPath(filePath);
-};
-
-const getFileDataForPath = async (
-  filePath: string
-): Promise<VaccineDataFile | null> => {
-  if (fileExists(filePath)) {
-    const fileData = await fs.readFile(filePath, "utf8");
-    return JSON.parse(fileData);
-  }
-  return null;
+  return fileExists(filePath) ? await readFileDataForPath(filePath) : null;
 };
 
 export const storeRawVaccineSite = async (time: NzTimeIso, rawHtml: string) =>
   await fs.writeFile(generateRawSiteFilePath(time), rawHtml);
 
-const writeFileDataForPath = (filePath: string, fileData: VaccineDataFile) =>
-  fs.writeFile(filePath, JSON.stringify(fileData, null, 2));
+const writeFileDataForPath = (
+  filePath: string,
+  fileData: DataDocument<VaccineData>
+) => fs.writeFile(filePath, JSON.stringify(fileData, null, 2));
+
+const readFileDataForPath = async (
+  filePath: string
+): Promise<DataDocument<VaccineData>> => {
+  const fileData = await fs.readFile(filePath, "utf8");
+  return JSON.parse(fileData);
+};
 
 const formatDate = (time: NzTimeIso) =>
   DateTime.fromISO(time).toFormat("yyyy-LL-dd");

--- a/shared/vaccineDataStore.ts
+++ b/shared/vaccineDataStore.ts
@@ -46,6 +46,27 @@ export const getVaccineDataForDate = async (
   return fileExists(filePath) ? await readFileDataForPath(filePath) : null;
 };
 
+export const deleteAllVaccineData = async () => {
+  const files = await fs.readdir(CONSTANTS.vaccineDataFolder);
+  await Promise.all(
+    files.map((f) => {
+      const filePath = `${CONSTANTS.vaccineDataFolder}/${f}`;
+      return fs.rm(filePath);
+    })
+  );
+};
+
+export const getAllRawVaccineSites = async () => {
+  const files = await fs.readdir(CONSTANTS.rawSiteFolder);
+
+  return await Promise.all(
+    files.map((f) => {
+      const filePath = `${CONSTANTS.rawSiteFolder}/${f}`;
+      return fs.readFile(filePath, "utf8");
+    })
+  );
+};
+
 export const storeRawVaccineSite = async (time: NzTimeIso, rawHtml: string) =>
   await fs.writeFile(generateRawSiteFilePath(time), rawHtml);
 

--- a/shared/vaccineDataStore.ts
+++ b/shared/vaccineDataStore.ts
@@ -14,14 +14,14 @@ export const createOrUpdateVaccineDataForDate = async (
     : null;
 
   const rightNow = DateTime.utc().toISO();
-  const metaData = {
+  const metadata = {
     createdAtUtcTimeIso: previousFileData
-      ? previousFileData.metaData.createdAtUtcTimeIso
+      ? previousFileData.metadata.createdAtUtcTimeIso
       : rightNow,
     updatedAtUtcTimeIso: rightNow,
   };
 
-  await writeFileDataForPath(filePath, { metaData, data: vaccineData });
+  await writeFileDataForPath(filePath, { metadata, data: vaccineData });
 };
 
 export const getAllVaccineData = async (


### PR DESCRIPTION
## Changes
It's best to review this PR by commits IMO. Also probably turn on hide whitespace for differences. 

1. Created a concept of `DataDocument` which can store a generic object into the DataStore. It adds to the generic object some metadata (created and updated date)
2. Updated VaccineDataStore to use the `DataDocument` 
3. Unfortunately due to change #2 it meant reading the current json files doesn't work since the datastructure had changed. Rather than manually updating the files, I made fetchy have the ability to regenerate all of the files. This will be useful as we decide to extract more stuff from the page as we can regenerate our data structure from the raw site again. 

## TODO
- ~~Due to the regen, it deletes the data files which don't have rawSites at the moment. Wait until https://github.com/theramis/aucvid/pull/133 is merged and then regen the files for this PR.~~ **DONE**