### PR TITLE
Use non admin client to get latest fetch run and remove deprecated endpoint

### DIFF
--- a/app/propsGenerators/indexPagePropsGenerator.ts
+++ b/app/propsGenerators/indexPagePropsGenerator.ts
@@ -1,6 +1,6 @@
 import { DateTime } from "luxon";
 import { getAllVaccineData } from "../../shared/vaccineDataStore";
-import { getLastestFetchyRun } from "../../shared/githubDataStore";
+import { getLatestFetchyRun } from "../../shared/githubDataStore";
 import {
   DhbVaccineDoseData,
   DhbName,
@@ -21,7 +21,7 @@ function calculateDosePercentage(
 
 export default async function fetchIndexPageProps(): Promise<IndexPageProps> {
   const [latestData, yesterdayData] = await getAllVaccineData(2);
-  const latestFetchyRun = await getLastestFetchyRun();
+  const latestFetchyRun = await getLatestFetchyRun();
   const { run_started_at: lastCheckedAtTimeUtc = null } = latestFetchyRun ?? {};
 
   return {

--- a/pages/api/fetchy-boi/latest-run.ts
+++ b/pages/api/fetchy-boi/latest-run.ts
@@ -1,10 +1,10 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { getLastestFetchyRun } from "../../../shared/githubDataStore";
+import { getLatestFetchyRun } from "../../../shared/githubDataStore";
 
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
-  res.status(200).json({ data: await getLastestFetchyRun() });
+  res.status(200).json({ data: await getLatestFetchyRun() });
 }

--- a/pages/api/trigger-fetchy-boi.ts
+++ b/pages/api/trigger-fetchy-boi.ts
@@ -1,4 +1,0 @@
-// This route is deprecated - prefer /fetchy-boi/trigger
-import handler from "./fetchy-boi/trigger";
-
-export default handler;

--- a/shared/githubDataStore.ts
+++ b/shared/githubDataStore.ts
@@ -3,9 +3,10 @@ import { Octokit } from "@octokit/core";
 const githubOwner = "theramis";
 const githubRepo = "aucvid";
 
-const octokit = new Octokit({ auth: process.env.GITHUB_PAT });
+const octokit = new Octokit();
+const adminOctokit = new Octokit({ auth: process.env.GITHUB_PAT });
 
-export const getLastestFetchyRun = async () => {
+export const getLatestFetchyRun = async () => {
   const { data } = await octokit.request(
     "GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}/runs",
     {
@@ -25,7 +26,7 @@ export const getLastestFetchyRun = async () => {
 };
 
 export const triggerFetchy = async () => {
-  const response = await octokit.request(
+  const response = await adminOctokit.request(
     "POST /repos/{owner}/{repo}/dispatches",
     {
       owner: githubOwner,


### PR DESCRIPTION
## Changes
- Fixed typo in method name  `lastest` -> `latest`
- Removed old deprecated endpoint. All of the cron jobs have been moved to use the new endpoint. 
![image](https://user-images.githubusercontent.com/5621207/140712024-b2ae526d-c7d8-4ec8-92e7-11e15390c551.png)
- Using a non admin client to get latest fetchy fun vs admin one to trigger github action. #security or something 