### PR TITLE
Add All DHBs option to Region dropdown

### DIFF
--- a/app/components/RegionDropdown/RegionDropdown.tsx
+++ b/app/components/RegionDropdown/RegionDropdown.tsx
@@ -1,8 +1,10 @@
 import { DhbRegionId } from "../../types/IndexPageProps";
 import styles from "./RegionDropdown.module.scss";
 
+export type RegionOptionId = DhbRegionId | "all";
+
 type Option = {
-  id: DhbRegionId;
+  id: RegionOptionId;
   label: string;
 };
 
@@ -10,11 +12,12 @@ const options: Option[] = [
   { id: "auckland", label: "Auckland DHBs" },
   { id: "northIsland", label: "North Island DHBs" },
   { id: "southIsland", label: "South Island DHBs" },
+  { id: "all", label: "All DHBs" },
 ];
 
 type RegionDropdownProps = {
-  selectedRegion: DhbRegionId;
-  onChange: (id: DhbRegionId) => void;
+  selectedRegion: RegionOptionId;
+  onChange: (id: RegionOptionId) => void;
 };
 
 export const RegionDropdown = ({
@@ -26,7 +29,7 @@ export const RegionDropdown = ({
       <select
         className={styles["dropdown"]}
         value={selectedRegion}
-        onChange={(event) => onChange(event.target.value as DhbRegionId)}
+        onChange={(event) => onChange(event.target.value as RegionOptionId)}
       >
         {options.map((option: Option) => {
           return (

--- a/app/components/RegionDropdown/index.ts
+++ b/app/components/RegionDropdown/index.ts
@@ -1,1 +1,2 @@
 export { RegionDropdown } from "./RegionDropdown";
+export type { RegionOptionId } from "./RegionDropdown";

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -15,7 +15,7 @@ import {
   RegionDropdown,
   RegionOptionId,
 } from "../app/components/RegionDropdown";
-import { DhbRegionId, IndexPageProps } from "../app/types/IndexPageProps";
+import { IndexPageProps } from "../app/types/IndexPageProps";
 import fetchIndexPageProps from "../app/propsGenerators/indexPagePropsGenerator";
 import { DhbsVaccineDoseDataList } from "../app/components/DhbsVaccineDoseDataList";
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -11,7 +11,10 @@ import {
   PageFooter,
   Divider,
 } from "../app/components/Page";
-import { RegionDropdown } from "../app/components/RegionDropdown";
+import {
+  RegionDropdown,
+  RegionOptionId,
+} from "../app/components/RegionDropdown";
 import { DhbRegionId, IndexPageProps } from "../app/types/IndexPageProps";
 import fetchIndexPageProps from "../app/propsGenerators/indexPagePropsGenerator";
 import { DhbsVaccineDoseDataList } from "../app/components/DhbsVaccineDoseDataList";
@@ -19,7 +22,7 @@ import { DhbsVaccineDoseDataList } from "../app/components/DhbsVaccineDoseDataLi
 const Index: React.FC<IndexPageProps> = (props: IndexPageProps) => {
   const { allDhbsVaccineDoseData } = props;
   const hasMounted = useHasMounted();
-  const [region, selectedRegion] = useState<DhbRegionId>("auckland");
+  const [region, selectedRegion] = useState<RegionOptionId>("auckland");
 
   return (
     <Page className="flex align-items-center">
@@ -43,9 +46,12 @@ const Index: React.FC<IndexPageProps> = (props: IndexPageProps) => {
           <PageContainer>
             <DhbsVaccineDoseDataList
               key={region}
-              dhbsVaccineDoseData={allDhbsVaccineDoseData.filter((dhb) =>
-                dhb.regionIds.includes(region)
-              )}
+              dhbsVaccineDoseData={allDhbsVaccineDoseData.filter((dhb) => {
+                if (region === "all") {
+                  return true;
+                }
+                return dhb.regionIds.includes(region);
+              })}
             />
           </PageContainer>
         </section>


### PR DESCRIPTION
### Changes

- Adds a new `All DHBs` option in the region selector to view all DHBs in a single list
- The "All DHBs" option does now expose the `Overseas/Unknown` group. Do we want to filter it out?