### PR TITLE
Make fetchy alert if can't parse the data correctly

### DIFF
--- a/fetchy/extractors/vaccinationDataPerDhbExtrator.ts
+++ b/fetchy/extractors/vaccinationDataPerDhbExtrator.ts
@@ -19,13 +19,12 @@ export const getVaccinationDataPerDhb = (
   let match;
   while ((match = perDhbRegex.exec(vaccinationTo90PerDhbTableHtml)) !== null) {
     const dhbDoseData = createPopulationDoseDataForDhbFromRegexMatch(match);
+    vaccinationDataPerDhb.push(dhbDoseData);
 
-    if (dhbDoseData.dhbName.includes("New Zealand")) {
+    if (dhbDoseData.dhbName.includes("Overseas / Unknown")) {
       // this means we have reached the bottom of the table and all DHBs have been parsed
       break;
     }
-
-    vaccinationDataPerDhb.push(dhbDoseData);
   }
   return vaccinationDataPerDhb;
 };

--- a/fetchy/utilities.ts
+++ b/fetchy/utilities.ts
@@ -1,2 +1,8 @@
-export const convertToNumber = (s: string): number =>
-  Number(s.replace(/[%,]/g, ""));
+export const convertToNumber = (s: string): number => {
+  const stripped = s.replace(/[%,]/g, "");
+  const result = Number(stripped || NaN);
+  if (Number.isNaN(result)) {
+    throw new Error(`Could not convert string ${s} to a number.`);
+  }
+  return result;
+};


### PR DESCRIPTION
So this afternoon when fetchy was constantly getting new data. It was trying to parse a number and failing. Then when it tried to compare a `NaN` to a `null` it finds a difference and repeats. 

This all happened because the MoH site added these two lines at the bottom of the table. 
![image](https://user-images.githubusercontent.com/5621207/141085889-51a977a8-f7d3-40ef-9ff6-d84b9d73f38b.png)


The "fix" in this PR will make it so that if it can't parse the content from the table into a number it will crash and alert us. 
This fixes us from making sure that any new rows or if they change anything in the table and we can't parse it, then it would alert us. 


1. This approach gives us some flexibility like if they add more Dhbs (highly unlikely) that it would keep working but it more prone to randomly introducing new data/breaking.

2. Another approach we can go down is to code in EXACTLY what we expect. If we get something other than that, then alert. 
e.g. make sure we get only the dhbs we have in code, if we get anything else we crash. etc etc. 


Thoughts? 

Do we want the more strict approach (i.e. number 2) or okay with 1 for now?