### PR TITLE
Adds 'useQueryParam' wrapper on useState

### DIFF
--- a/app/components/RegionDropdown/RegionDropdown.tsx
+++ b/app/components/RegionDropdown/RegionDropdown.tsx
@@ -20,8 +20,15 @@ type RegionDropdownProps = {
   onChange: (id: RegionOptionId) => void;
 };
 
-export const isTypeOfRegionOptionId = (id: unknown): id is RegionOptionId =>
-  options.map((o) => o.id as any).includes(id);
+export const assertOptionTypeOrDefaultTo =
+  (defaultOption: RegionOptionId = "auckland") =>
+  (id: unknown): RegionOptionId => {
+    if (options.map((o) => o.id as unknown).includes(id)) {
+      return id as RegionOptionId;
+    }
+
+    return defaultOption;
+  };
 
 export const RegionDropdown = ({
   selectedRegion,

--- a/app/components/RegionDropdown/RegionDropdown.tsx
+++ b/app/components/RegionDropdown/RegionDropdown.tsx
@@ -40,8 +40,6 @@ export const RegionDropdown = ({
         })}
       </select>
       <div className={styles["dropdown-caret"]}>
-        {/* <span className={styles["caret-left"]} />
-        <span className={styles["caret-right"]} /> */}
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
           <path d="M0 7.33l2.829-2.83 9.175 9.339 9.167-9.339 2.829 2.83-11.996 12.17z" />
         </svg>

--- a/app/components/RegionDropdown/RegionDropdown.tsx
+++ b/app/components/RegionDropdown/RegionDropdown.tsx
@@ -20,6 +20,9 @@ type RegionDropdownProps = {
   onChange: (id: RegionOptionId) => void;
 };
 
+export const isTypeOfRegionOptionId = (id: unknown): id is RegionOptionId =>
+  options.map((o) => o.id as any).includes(id);
+
 export const RegionDropdown = ({
   selectedRegion,
   onChange,

--- a/app/components/RegionDropdown/index.ts
+++ b/app/components/RegionDropdown/index.ts
@@ -1,2 +1,2 @@
-export { RegionDropdown } from "./RegionDropdown";
+export { RegionDropdown, isTypeOfRegionOptionId } from "./RegionDropdown";
 export type { RegionOptionId } from "./RegionDropdown";

--- a/app/components/RegionDropdown/index.ts
+++ b/app/components/RegionDropdown/index.ts
@@ -1,2 +1,2 @@
-export { RegionDropdown, isTypeOfRegionOptionId } from "./RegionDropdown";
+export { RegionDropdown, assertOptionTypeOrDefaultTo } from "./RegionDropdown";
 export type { RegionOptionId } from "./RegionDropdown";

--- a/app/hooks/useQueryParam.ts
+++ b/app/hooks/useQueryParam.ts
@@ -7,14 +7,14 @@ import {
 } from "react";
 import { useRouter } from "next/router";
 
-const useEventCallback = (fn: (...a: any[]) => any) => {
+const useEventCallback = <T extends (...args: any[]) => any>(fn: T): T => {
   const fnRef = useRef(fn);
 
   useLayoutEffect(() => {
     fnRef.current = fn;
   });
 
-  return useCallback((...args) => fnRef.current(...args), []);
+  return useCallback((...args: any[]) => fnRef.current(...args), []) as T;
 };
 
 export const useQueryParam = <ParamType extends string>(

--- a/app/hooks/useQueryParam.ts
+++ b/app/hooks/useQueryParam.ts
@@ -1,0 +1,46 @@
+import {
+  useState,
+  useEffect,
+  useRef,
+  useLayoutEffect,
+  useCallback,
+} from "react";
+import { useRouter } from "next/router";
+
+const useEventCallback = (fn: (...a: any[]) => any) => {
+  const fnRef = useRef(fn);
+
+  useLayoutEffect(() => {
+    fnRef.current = fn;
+  });
+
+  return useCallback((...args) => fnRef.current(...args), []);
+};
+
+export const useQueryParam = <ParamType extends string>(
+  key: string,
+  defaultValue: ParamType,
+  checkType: (s: unknown) => s is ParamType
+): [ParamType, React.Dispatch<React.SetStateAction<ParamType | undefined>>] => {
+  const router = useRouter();
+  const push = useEventCallback(router.push);
+
+  const [value, setValue] = useState<ParamType | undefined>(() => {
+    const initialQueryValue = router.query[key];
+    if (checkType(initialQueryValue)) {
+      return initialQueryValue as ParamType;
+    }
+    return undefined;
+  });
+
+  useEffect(() => {
+    // If value is undefined or the default value, clear the query param
+    if (value && value !== defaultValue) {
+      push({ query: { [key]: value } });
+    } else {
+      push({ query: undefined });
+    }
+  }, [push, key, value, defaultValue]);
+
+  return [value ?? defaultValue, setValue];
+};

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -14,7 +14,6 @@ import {
 } from "../app/components/Page";
 import {
   RegionDropdown,
-  isValidRegionId,
   RegionOptionId,
 } from "../app/components/RegionDropdown";
 import { IndexPageProps } from "../app/types/IndexPageProps";

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,11 +1,10 @@
-import { useState, useEffect } from "react";
 import { GetServerSideProps } from "next";
-import { useRouter } from "next/router";
 import { DateTime } from "luxon";
 
 import { ExternalLink } from "../app/components/Link";
 import { DarkModeToggle } from "../app/components/DarkModeToggle";
 import { useHasMounted } from "../app/hooks/useHasMounted";
+import { useQueryParam } from "../app/hooks/useQueryParam";
 import {
   Page,
   PageContainer,
@@ -15,39 +14,19 @@ import {
 import {
   RegionDropdown,
   RegionOptionId,
+  isTypeOfRegionOptionId,
 } from "../app/components/RegionDropdown";
 import { IndexPageProps } from "../app/types/IndexPageProps";
 import fetchIndexPageProps from "../app/propsGenerators/indexPagePropsGenerator";
 import { DhbsVaccineDoseDataList } from "../app/components/DhbsVaccineDoseDataList";
 
-const useQueryParam = <ParamType extends string>(
-  key: string,
-  defaultValue: ParamType
-): [ParamType, React.Dispatch<React.SetStateAction<ParamType>>] => {
-  const { query, push } = useRouter();
-
-  const [value, setValue] = useState<ParamType>(() => {
-    if (query[key] && typeof query[key] === "string") {
-      // TODO - check this is actually ParamType & decode value
-      return query[key] as ParamType;
-    }
-    return defaultValue;
-  });
-
-  useEffect(() => {
-    push({ query: { [key]: value } });
-  }, [push, key, value]);
-
-  return [value, setValue];
-};
-
 const Index: React.FC<IndexPageProps> = (props: IndexPageProps) => {
   const { allDhbsVaccineDoseData } = props;
   const hasMounted = useHasMounted();
-
   const [region, selectRegion] = useQueryParam<RegionOptionId>(
     "dhbs",
-    "auckland"
+    "auckland",
+    isTypeOfRegionOptionId
   );
 
   return (

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -14,7 +14,7 @@ import {
 import {
   RegionDropdown,
   RegionOptionId,
-  isTypeOfRegionOptionId,
+  assertOptionTypeOrDefaultTo,
 } from "../app/components/RegionDropdown";
 import { IndexPageProps } from "../app/types/IndexPageProps";
 import fetchIndexPageProps from "../app/propsGenerators/indexPagePropsGenerator";
@@ -25,8 +25,7 @@ const Index: React.FC<IndexPageProps> = (props: IndexPageProps) => {
   const hasMounted = useHasMounted();
   const [region, selectRegion] = useQueryParam<RegionOptionId>(
     "dhbs",
-    "auckland",
-    isTypeOfRegionOptionId
+    assertOptionTypeOrDefaultTo("auckland")
   );
 
   return (

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,5 +1,6 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { GetServerSideProps } from "next";
+import { useRouter } from "next/router";
 import { DateTime } from "luxon";
 
 import { ExternalLink } from "../app/components/Link";
@@ -13,16 +14,42 @@ import {
 } from "../app/components/Page";
 import {
   RegionDropdown,
+  isValidRegionId,
   RegionOptionId,
 } from "../app/components/RegionDropdown";
 import { IndexPageProps } from "../app/types/IndexPageProps";
 import fetchIndexPageProps from "../app/propsGenerators/indexPagePropsGenerator";
 import { DhbsVaccineDoseDataList } from "../app/components/DhbsVaccineDoseDataList";
 
+const useQueryParam = <ParamType extends string>(
+  key: string,
+  defaultValue: ParamType
+): [ParamType, React.Dispatch<React.SetStateAction<ParamType>>] => {
+  const { query, push } = useRouter();
+
+  const [value, setValue] = useState<ParamType>(() => {
+    if (query[key] && typeof query[key] === "string") {
+      // TODO - check this is actually ParamType & decode value
+      return query[key] as ParamType;
+    }
+    return defaultValue;
+  });
+
+  useEffect(() => {
+    push({ query: { [key]: value } });
+  }, [push, key, value]);
+
+  return [value, setValue];
+};
+
 const Index: React.FC<IndexPageProps> = (props: IndexPageProps) => {
   const { allDhbsVaccineDoseData } = props;
   const hasMounted = useHasMounted();
-  const [region, selectedRegion] = useState<RegionOptionId>("auckland");
+
+  const [region, selectRegion] = useQueryParam<RegionOptionId>(
+    "dhbs",
+    "auckland"
+  );
 
   return (
     <Page className="flex align-items-center">
@@ -38,7 +65,7 @@ const Index: React.FC<IndexPageProps> = (props: IndexPageProps) => {
             </div>
             <RegionDropdown
               selectedRegion={region}
-              onChange={(regionId) => selectedRegion(regionId)}
+              onChange={(id) => selectRegion(id)}
             />
           </PageContainer>
         </section>


### PR DESCRIPTION
This is a simple, fairly restrictive version of query param handling for the index page. The approach is to store the initial value for a given param key in React state, and sync the query param in a useEffect when the state updates. To keep the path name as clean as possible, if the param value isn't valid, or if it matches the default value, it will be stripped from the url.

_Note: I tried to use query params directly, instead of syncing with state in between, but it re-rendered the whole page, and was a bit janky._

Because query params can be literally any string (or as Next parses them `string | string[] | undefined`), we need a way to ensure the parsed value is `RegionOptionId`. I've created a function in `RegionDropdown` to check the type, and return a default value if the type doesn't match. 

Question: Is this type checking or default value overkill? The other option is to assert the type is `RegionOptionId` and basically accept it will be possible wrong at runtime?

This approach uses Nextjs `useRouter`, which is nice because it encodes & decodes query params by default, but at the same time, it's pretty punishing since:
- The query object includes pathname variables (ie for `/blog/{blogId}/` - blogId would be in query object)
- There's no simple way of merging query params
- The push function isn't correctly memoized 👀 

Because of these shortcomings, and the fact that this hook only handles a single param, I think we need to update the implementation - which can be done in a later PR. I think it will be worth using `URLSearchParams` and handling some of the parsing & merging ourselves 🙏 

### Improvements
- Update hook to be "useQueryParams" to deal with the whole object of params
- Investigate type-safe query param parsing - is there a library to do this for us?

### Previously discussed
- ~Would it be better as `useQueryParams` that did the whole object?~ - Yes
- ~This method means there's always a query param - would it be better if we could have 'naked' paths, with no query params?~ - Ideally 'naked' routes. This PR has been updated
- ~peep the naming - I think "dhbs" makes the most sense?~ - confirmed!