### PR TITLE
Add percentage increased for each dhb doses

### DIFF
--- a/app/components/DosesDescriptionList/DosesDescriptionList.module.scss
+++ b/app/components/DosesDescriptionList/DosesDescriptionList.module.scss
@@ -58,3 +58,17 @@
     height: $space-s;
   }
 }
+
+// TODO
+// I copy pasted this. IDK how to CSS. Someone please fix
+.percentage-value-change {
+  color: var(--text-primary);
+
+  font-size: 1.125rem; // 18px
+  line-height: 1.5rem; // 24px
+  font-weight: 500;
+  @media (min-width: $breakpoint-s) {
+    font-size: 1.25rem; // 20px
+    line-height: 1.75rem; // 28px
+  }
+}

--- a/app/components/DosesDescriptionList/DosesDescriptionList.module.scss
+++ b/app/components/DosesDescriptionList/DosesDescriptionList.module.scss
@@ -31,6 +31,15 @@
   color: var(--text-positive);
 }
 
+.percentage-value-change {
+  color: var(--text-secondary);
+
+  & svg {
+    width: 0.625rem;
+    height: 0.625rem;
+  }
+}
+
 .vaccine-count {
   color: var(--text-primary);
 
@@ -44,6 +53,7 @@
 }
 
 .check {
+  align-self: center;
   width: $space-m;
   height: $space-m;
   display: flex;
@@ -56,19 +66,5 @@
   & svg {
     width: $space-s;
     height: $space-s;
-  }
-}
-
-// TODO
-// I copy pasted this. IDK how to CSS. Someone please fix
-.percentage-value-change {
-  color: var(--text-primary);
-
-  font-size: 1.125rem; // 18px
-  line-height: 1.5rem; // 24px
-  font-weight: 500;
-  @media (min-width: $breakpoint-s) {
-    font-size: 1.25rem; // 20px
-    line-height: 1.75rem; // 28px
   }
 }

--- a/app/components/DosesDescriptionList/DosesDescriptionList.tsx
+++ b/app/components/DosesDescriptionList/DosesDescriptionList.tsx
@@ -10,7 +10,7 @@ type DosesDescriptionProps = {
   term: string;
   hasMetTarget: boolean;
   dosesPercent: number;
-  dosesChange: number;
+  dosesPercentChange: number | null;
   children?: React.ReactNode;
 };
 
@@ -28,11 +28,17 @@ const DosesDescription = ({
   term,
   hasMetTarget,
   dosesPercent,
+  dosesPercentChange,
   children = null,
-}: Omit<DosesDescriptionProps, "dosesChange">) => (
+}: DosesDescriptionProps) => (
   <div className="width-half">
     <dt className={cx(styles["dose-label"], "margin-bottom-2xs")}>{term}</dt>
     <dd className="flex flex-row justify-content-start align-items-center space-x-xs">
+      {hasMetTarget && (
+        <div className={cx(styles["check"], "flex-0")}>
+          <CheckIcon aria-label={`${term} target met`} />
+        </div>
+      )}
       <div
         className={cx(styles["percentage-value"], {
           [styles["percentage-value-complete"]]: hasMetTarget,
@@ -40,9 +46,9 @@ const DosesDescription = ({
       >
         <DisplayPercentage percentage={dosesPercent} />
       </div>
-      {hasMetTarget && (
-        <div className={cx(styles["check"], "flex-0")}>
-          <CheckIcon aria-label={`${term} target met`} />
+      {dosesPercentChange && truncateNumber(dosesPercentChange, 1) > 0 && (
+        <div className={cx(styles["percentage-value-change"])}>
+          ↑ {truncateNumber(dosesPercentChange, 1)}
         </div>
       )}
     </dd>
@@ -58,6 +64,7 @@ export const DosesDescriptionList = ({
       term="First doses"
       hasMetTarget={dhbData.hasMetFirstDoseTarget}
       dosesPercent={dhbData.firstDosesPercentage}
+      dosesPercentChange={dhbData.firstDosesPercentChange}
     >
       <dd className={styles["vaccine-count"]}>
         {numberFormatter.format(dhbData.firstDosesTo90Percent)} left
@@ -67,6 +74,7 @@ export const DosesDescriptionList = ({
       term="Second doses"
       hasMetTarget={dhbData.hasMetSecondDoseTarget}
       dosesPercent={dhbData.secondDosesPercentage}
+      dosesPercentChange={dhbData.secondDosesPercentChange}
     >
       <dd className={styles["vaccine-count"]}>
         {numberFormatter.format(dhbData.secondDosesTo90Percent)} left

--- a/app/components/DosesDescriptionList/DosesDescriptionList.tsx
+++ b/app/components/DosesDescriptionList/DosesDescriptionList.tsx
@@ -28,33 +28,57 @@ const DosesDescription = ({
   term,
   hasMetTarget,
   dosesPercent,
-  dosesPercentChange,
+  dosesPercentChange = null,
   children = null,
-}: DosesDescriptionProps) => (
-  <div className="width-half">
-    <dt className={cx(styles["dose-label"], "margin-bottom-2xs")}>{term}</dt>
-    <dd className="flex flex-row justify-content-start align-items-center space-x-xs">
-      {hasMetTarget && (
-        <div className={cx(styles["check"], "flex-0")}>
-          <CheckIcon aria-label={`${term} target met`} />
+}: DosesDescriptionProps) => {
+  const displayDosesPercentageChange =
+    dosesPercentChange && truncateNumber(dosesPercentChange, 1);
+
+  return (
+    <div className="width-half">
+      <dt className={cx(styles["dose-label"], "margin-bottom-2xs")}>{term}</dt>
+      <dd className="flex flex-row justify-content-start align-items-baseline space-x-xs">
+        {hasMetTarget && (
+          <div className={cx(styles["check"], "flex-0")}>
+            <CheckIcon aria-label={`${term} target met`} />
+          </div>
+        )}
+        <div
+          className={cx(styles["percentage-value"], {
+            [styles["percentage-value-complete"]]: hasMetTarget,
+          })}
+        >
+          <DisplayPercentage percentage={dosesPercent} />
         </div>
-      )}
-      <div
-        className={cx(styles["percentage-value"], {
-          [styles["percentage-value-complete"]]: hasMetTarget,
-        })}
-      >
-        <DisplayPercentage percentage={dosesPercent} />
-      </div>
-      {dosesPercentChange && truncateNumber(dosesPercentChange, 1) > 0 && (
-        <div className={cx(styles["percentage-value-change"])}>
-          ↑ {truncateNumber(dosesPercentChange, 1)}
-        </div>
-      )}
-    </dd>
-    {children}
-  </div>
-);
+        {displayDosesPercentageChange ? (
+          <div
+            className={cx(
+              styles["percentage-value-change"],
+              "flex flex-row align-items-baseline space-x-2xs paragraph"
+            )}
+          >
+            <div className="flex-0">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 16 16"
+                fill="none"
+              >
+                <path
+                  fillRule="evenodd"
+                  clipRule="evenodd"
+                  d="M9.23077 4.57143L14.1538 9.14286L16 7.42857L8 0L-5.96046e-07 7.42857L1.84615 9.14286L6.76923 4.57143L6.76923 16H9.23077L9.23077 4.57143Z"
+                  fill="currentColor"
+                />
+              </svg>
+            </div>
+            <div>{displayDosesPercentageChange}</div>
+          </div>
+        ) : null}
+      </dd>
+      {children}
+    </div>
+  );
+};
 
 export const DosesDescriptionList = ({
   dhbData,

--- a/app/propsGenerators/indexPagePropsGenerator.ts
+++ b/app/propsGenerators/indexPagePropsGenerator.ts
@@ -102,6 +102,20 @@ function generateAllDhbsVaccineDoseData(
       dhb.totalPopulation
     );
 
+    const yesterdaysFirstDosesPercentage = yesterdayDoseData
+      ? calculateDosePercentage(
+          yesterdayDoseData.firstDoses,
+          yesterdayDoseData.totalPopulation
+        )
+      : null;
+
+    const yesterdaysSecondDosesPercentage = yesterdayDoseData
+      ? calculateDosePercentage(
+          yesterdayDoseData.secondDoses,
+          yesterdayDoseData.totalPopulation
+        )
+      : null;
+
     return {
       ...dhb,
       regionIds: regions,
@@ -111,11 +125,11 @@ function generateAllDhbsVaccineDoseData(
         firstDosesPercentage >= CONSTANTS.firstDoseTargetPercentage,
       hasMetSecondDoseTarget:
         secondDosesPercentage >= CONSTANTS.secondDoseTargetPercentage,
-      firstDosesChange: yesterdayDoseData
-        ? yesterdayDoseData?.firstDosesTo90Percent - dhb.firstDosesTo90Percent
+      firstDosesPercentChange: yesterdaysFirstDosesPercentage
+        ? firstDosesPercentage - yesterdaysFirstDosesPercentage
         : null,
-      secondDosesChange: yesterdayDoseData
-        ? yesterdayDoseData?.secondDosesTo90Percent - dhb.secondDosesTo90Percent
+      secondDosesPercentChange: yesterdaysSecondDosesPercentage
+        ? secondDosesPercentage - yesterdaysSecondDosesPercentage
         : null,
     };
   });

--- a/app/types/IndexPageProps.ts
+++ b/app/types/IndexPageProps.ts
@@ -5,9 +5,9 @@ export type DhbRegionId = "auckland" | "northIsland" | "southIsland";
 export type DhbVaccineDoseDataForIndexPage = DhbVaccineDoseData & {
   regionIds: DhbRegionId[];
   firstDosesPercentage: number;
-  firstDosesChange: number | null;
+  firstDosesPercentChange: number | null;
   secondDosesPercentage: number;
-  secondDosesChange: number | null;
+  secondDosesPercentChange: number | null;
   hasMetFirstDoseTarget: boolean;
   hasMetSecondDoseTarget: boolean;
 };


### PR DESCRIPTION
## Changes 
- Added the percentage increase for each dhb
- Removed the prop for doses change from before (I'm assuming it was leftover from before)
- Made a call to not show any percentage increase if it's less than 0.1 (@finnclark you alg with that?)
- Moved the tick to the left of the number as per design

**Expectation**
![image](https://user-images.githubusercontent.com/5621207/142405863-3e8e4961-607b-4408-a059-c6c691e120a2.png)

**Reality**
![image](https://user-images.githubusercontent.com/5621207/142405982-e9477054-fc03-4d60-8b48-3605ae5214f9.png)

## TODO

Can someone please checkout this branch and fix the CSS 😅 
One day I'll learn it I promise. 