### PR TITLE
FIX - Prepend '?' to search string

### DIFF
--- a/app/components/NextQueryParamProvider.tsx
+++ b/app/components/NextQueryParamProvider.tsx
@@ -13,14 +13,14 @@ export const NextQueryParamProvider = ({
 }: NextQueryParamProviderProps) => {
   const router = useRouter();
 
-  const [pathname, search = ""] = router.asPath.split("?");
+  const [pathname, queryString = ""] = router.asPath.split("?");
 
   const location = useMemo<Location>(() => {
     if (typeof window === "undefined") {
       // On the server side we only need a subset of the available
       // properties of `Location`. The other ones are only necessary
       // for interactive features on the client.
-      return { search } as Location;
+      return { search: `?${queryString}` } as Location;
     }
 
     // For SSG, no query parameters are available on the server side,
@@ -35,7 +35,7 @@ export const NextQueryParamProvider = ({
     }
 
     return { search: "" } as Location;
-  }, [search, router.isReady]);
+  }, [queryString, router.isReady]);
 
   const history = useMemo(
     () => ({


### PR DESCRIPTION
The bug as seen last night, was that there was a mismatch between the query string read on the server, and the initial hydration / render on the client. This showed up as incorrect styling on a given dhb:

![image](https://user-images.githubusercontent.com/22784983/142472774-47b06ae6-3da8-4d6b-b5f0-24a8358638da.png)

The root cause was that `search` couldn't properly be parsed on the server - that's because it expects to _have_ the "?" prepending it. This was a mistake I made in copying the implementation across from NextQueryParamsProvider.

Simple solution is to prepend the search string with a "?"