### PR TITLE
Fix issue where placeholder option rendered in iOS

### DIFF
--- a/app/components/RegionDropdown/RegionDropdown.tsx
+++ b/app/components/RegionDropdown/RegionDropdown.tsx
@@ -24,6 +24,8 @@ export const RegionDropdown = ({
   selectedRegion,
   onChange,
 }: RegionDropdownProps) => {
+  const isValidRegion = options.find((option) => option.id === selectedRegion);
+
   return (
     <div className={styles["dropdown-container"]}>
       <select
@@ -31,7 +33,7 @@ export const RegionDropdown = ({
         value={selectedRegion}
         onChange={(event) => onChange(event.target.value as RegionOptionId)}
       >
-        <option hidden>Select DHBs</option>
+        {isValidRegion ? null : <option hidden>Select DHBs</option>}
         {options.map((option: Option) => {
           return (
             <option key={option.id} value={option.id}>


### PR DESCRIPTION
Renders the placeholder option only when the query param doesn't match. Keeping the `hidden` attr on the element as this still works as expected in other browsers i.e. doesn't render in the the dropdown list