### PR TITLE
Adds 'date' page, with param - so we can render a page for days in the past

### DIFF
--- a/pages/[date].tsx
+++ b/pages/[date].tsx
@@ -1,0 +1,132 @@
+import { GetServerSideProps } from "next";
+import { DateTime } from "luxon";
+import { useQueryParams, withDefault, StringParam } from "use-query-params";
+
+import { ExternalLink } from "../app/components/Link";
+import { DarkModeToggle } from "../app/components/DarkModeToggle";
+import { useHasMounted } from "../app/hooks/useHasMounted";
+import {
+  Page,
+  PageContainer,
+  PageFooter,
+  Divider,
+} from "../app/components/Page";
+import { RegionDropdown } from "../app/components/RegionDropdown";
+import { DhbRegionId } from "../app/types/IndexPageProps";
+import {
+  fetchDatePageProps,
+  DatePageProps,
+} from "../app/propsGenerators/indexPagePropsGenerator";
+import { DhbsVaccineDoseDataList } from "../app/components/DhbsVaccineDoseDataList";
+
+const Date: React.FC<DatePageProps> = (props: DatePageProps) => {
+  const { allDhbsVaccineDoseData } = props;
+
+  const hasMounted = useHasMounted();
+  const [query, setQuery] = useQueryParams({
+    dhbs: withDefault(StringParam, "auckland"),
+  });
+
+  return (
+    <Page className="flex align-items-center">
+      <div className="flex-1 width-full">
+        <section className="padding-top-4xl padding-bottom-l">
+          <PageContainer className="flex align-items-stretch">
+            <div className="padding-left-l l:padding-left-none margin-bottom-4xl s:margin-bottom-5xl">
+              <div className="width-full flex flex-row justify-content-between align-items-center">
+                <h2 className="heading-2">Vaccination rates</h2>
+                {hasMounted && <DarkModeToggle className="flex-0" />}
+              </div>
+              <h1 className="heading-1">Aotearoa</h1>
+            </div>
+            <RegionDropdown
+              selectedRegion={query.dhbs}
+              onChange={(id) => setQuery({ dhbs: id })}
+            />
+          </PageContainer>
+        </section>
+        <section>
+          <PageContainer>
+            <DhbsVaccineDoseDataList
+              key={query.dhbs}
+              dhbsVaccineDoseData={allDhbsVaccineDoseData.filter((dhb) => {
+                if (query.dhbs === "all") {
+                  return true;
+                }
+                return dhb.regionIds.includes(query.dhbs as DhbRegionId);
+              })}
+            />
+          </PageContainer>
+        </section>
+      </div>
+      <PageFooter>
+        <div className="flex align-items-center">
+          <p className="footnote margin-bottom-xs">
+            Sourced from{" "}
+            <ExternalLink href="https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data">
+              Ministry of Health NZ
+            </ExternalLink>
+            ,{" "}
+            {DateTime.fromISO(props.dataUpdatedAtTimeUtc).toFormat(
+              "MMM dd yyyy"
+            )}
+          </p>
+          <div className="flex flex-column justify-content-center align-items-center footnote">
+            <p>
+              Data valid to:{" "}
+              {DateTime.fromISO(props.dataValidAsAtTimeUtc).toFormat(
+                "dd MMM yyyy, hh:mm a"
+              )}
+            </p>
+          </div>
+        </div>
+        <Divider className="margin-l" />
+      </PageFooter>
+    </Page>
+  );
+};
+
+export default Date;
+
+const queryParamAsString = (p: string | string[] | undefined = ""): string => {
+  if (Array.isArray(p)) {
+    return p.join("");
+  }
+  return p;
+};
+
+const queryDateToNzIso = (date: string) => {
+  const [year, month, day] = queryParamAsString(date).split("-").map(Number);
+
+  return DateTime.fromObject(
+    { day, month, year },
+    { zone: "Pacific/Auckland" }
+  ).toISO();
+};
+
+export const getServerSideProps: GetServerSideProps<DatePageProps> = async ({
+  query,
+}) => {
+  const queryNzIso = queryDateToNzIso(queryParamAsString(query.date));
+
+  // if query is 'today' or in the future, redirect to the home page
+  if (
+    DateTime.fromISO(queryNzIso).toISO() >=
+    DateTime.now().startOf("day").toISO()
+  ) {
+    return {
+      redirect: {
+        destination: "/",
+        permanent: false,
+      },
+    };
+  }
+
+  const props = await fetchDatePageProps(queryNzIso);
+
+  if (props) {
+    return { props };
+  }
+
+  return { notFound: true };
+};

--- a/pages/[date].tsx
+++ b/pages/[date].tsx
@@ -88,7 +88,7 @@ const Date: React.FC<DatePageProps> = (props: DatePageProps) => {
 
 export default Date;
 
-const queryParamAsString = (p: string | string[] | undefined = ""): string => {
+const paramToString = (p: string | string[] | undefined = ""): string => {
   if (Array.isArray(p)) {
     return p.join("");
   }
@@ -96,18 +96,15 @@ const queryParamAsString = (p: string | string[] | undefined = ""): string => {
 };
 
 const queryDateToNzIso = (date: string) => {
-  const [year, month, day] = queryParamAsString(date).split("-").map(Number);
+  const [year, month, day] = date.split("-").map(Number);
 
-  return DateTime.fromObject(
-    { day, month, year },
-    { zone: "Pacific/Auckland" }
-  ).toISO();
+  return DateTime.fromObject({ day, month, year }).toISO();
 };
 
 export const getServerSideProps: GetServerSideProps<DatePageProps> = async ({
-  query,
+  params,
 }) => {
-  const queryNzIso = queryDateToNzIso(queryParamAsString(query.date));
+  const queryNzIso = queryDateToNzIso(paramToString(params?.date));
 
   // if query is 'today' or in the future, redirect to the home page
   if (

--- a/pages/[date].tsx
+++ b/pages/[date].tsx
@@ -68,13 +68,9 @@ const Date: React.FC<DatePageProps> = (props: DatePageProps) => {
         <div className="flex align-items-center">
           <p className="footnote margin-bottom-xs">
             Sourced from{" "}
-            <ExternalLink href="https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics/covid-19-vaccine-data">
+            <ExternalLink href="https://www.health.govt.nz/our-work/diseases-and-conditions/covid-19-novel-coronavirus/covid-19-data-and-statistics">
               Ministry of Health NZ
             </ExternalLink>
-            ,{" "}
-            {DateTime.fromISO(props.dataUpdatedAtTimeUtc).toFormat(
-              "dd MMM yyyy"
-            )}
           </p>
           <div className="flex flex-column justify-content-center align-items-center footnote">
             <p>

--- a/pages/[date].tsx
+++ b/pages/[date].tsx
@@ -34,7 +34,12 @@ const Date: React.FC<DatePageProps> = (props: DatePageProps) => {
           <PageContainer className="flex align-items-stretch">
             <div className="padding-left-l l:padding-left-none margin-bottom-4xl s:margin-bottom-5xl">
               <div className="width-full flex flex-row justify-content-between align-items-center">
-                <h2 className="heading-2">Vaccination rates</h2>
+                <h2 className="heading-2">
+                  Vaccination rates:{" "}
+                  {DateTime.fromISO(props.dataValidAsAtTimeUtc).toFormat(
+                    "MMM dd"
+                  )}
+                </h2>
                 {hasMounted && <DarkModeToggle className="flex-0" />}
               </div>
               <h1 className="heading-1">Aotearoa</h1>
@@ -68,12 +73,12 @@ const Date: React.FC<DatePageProps> = (props: DatePageProps) => {
             </ExternalLink>
             ,{" "}
             {DateTime.fromISO(props.dataUpdatedAtTimeUtc).toFormat(
-              "MMM dd yyyy"
+              "dd MMM yyyy"
             )}
           </p>
           <div className="flex flex-column justify-content-center align-items-center footnote">
             <p>
-              Data valid to:{" "}
+              Data as at:{" "}
               {DateTime.fromISO(props.dataValidAsAtTimeUtc).toFormat(
                 "dd MMM yyyy, hh:mm a"
               )}


### PR DESCRIPTION
## Motivation
Since we have the data, it's fairly easy to generate pages for days in the past. This will be useful for our users to be able look back at data over time, but also for us to debug day to day changes.

It works by a url param, `/{year}-{month}-{day}` so `https://www.outoflockdown.co/2021-11-20` will show data for the 20th of November. "today" or dates in the future will redirect to the homepage. 

## Challenges 

How do we ensure that the user can easily tell this isn't up to date information? I've added the relevant dates (updated per your suggestion @jishaal), but it may still be a little confusing. There's also no way (at this point) of navigating to these pages, but that could be done in a future PR.

## Outstanding questions

- Naming: I've just called this page 'date' that kind of works but is _very_ generic
- URL path: Should the date param be prefaced? Something like: https://www.outoflockdown.co/date/2021-11-20 ?
- This is a bit more for us to maintain 😅 - happy to drop this if we'd prefer 🙏 

![image](https://user-images.githubusercontent.com/22784983/143785670-f28ab54d-e8fc-45ab-9f38-4326051f487e.png)
